### PR TITLE
modernized unittest assertions

### DIFF
--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -19,10 +19,10 @@ class TestPluginAdapters(unittest.TestCase):
     def test_plugin_adapter(self):
         jsn = baseline_reader.json_baseline_as_string(ADAPTER_PATH)
         adp = otio.adapters.otio_json.read_from_string(jsn)
-        self.assertEquals(adp.name, "example")
-        self.assertEquals(adp.execution_scope, "in process")
-        self.assertEquals(adp.filepath, "example.py")
-        self.assertEquals(adp.suffixes, ["EXAMPLE"])
+        self.assertEqual(adp.name, "example")
+        self.assertEqual(adp.execution_scope, "in process")
+        self.assertEqual(adp.filepath, "example.py")
+        self.assertEqual(adp.suffixes, ["EXAMPLE"])
 
     def test_load_adapter_module(self):
         jsn = baseline_reader.json_baseline_as_string(ADAPTER_PATH)
@@ -34,9 +34,9 @@ class TestPluginAdapters(unittest.TestCase):
         target = os.path.join(baseline_reader.MODPATH,
                               "baseline", "example.py")
 
-        self.assertEquals(adp.module_abs_path(), target)
+        self.assertEqual(adp.module_abs_path(), target)
         self.assertTrue(hasattr(adp.module(), "read_from_file"))
-        self.assertEquals(adp.module().read_from_file("foo").name, "foo")
+        self.assertEqual(adp.module().read_from_file("foo").name, "foo")
 
 MAN_PATH = '/var/tmp/test_otio_manifest'
 
@@ -56,26 +56,28 @@ class TestPluginManifest(unittest.TestCase):
     def test_plugin_manifest(self):
         man = test_manifest()
 
-        self.assertEquals(man.source_files, [MAN_PATH])
+        self.assertEqual(man.source_files, [MAN_PATH])
 
-        self.assertNotEquals(man.adapters, [])
+        self.assertNotEqual(man.adapters, [])
 
     def test_find_adapter_by_suffix(self):
         man = test_manifest()
-        self.assertEquals(man.from_filepath("EXAMPLE").name, "example")
-        self.assertRaises(lambda: man.from_filepath("BLARG"))
+        self.assertEqual(man.from_filepath("EXAMPLE").name, "example")
+        with self.assertRaises(Exception):
+            man.from_filepath("BLARG")
         adp = man.from_filepath("EXAMPLE")
-        self.assertEquals(adp.module().read_from_file("path").name, "path")
-        self.assertEquals(man.adapter_module_from_suffix(
+        self.assertEqual(adp.module().read_from_file("path").name, "path")
+        self.assertEqual(man.adapter_module_from_suffix(
             "EXAMPLE").read_from_file("path").name, "path")
 
     def test_find_adapter_by_name(self):
         man = test_manifest()
-        self.assertEquals(man.from_name("example").name, "example")
-        self.assertRaises(lambda: man.from_name("BLARG"))
+        self.assertEqual(man.from_name("example").name, "example")
+        with self.assertRaises(Exception):
+            man.from_name("BLARG")
         adp = man.from_name("example")
-        self.assertEquals(adp.module().read_from_file("path").name, "path")
-        self.assertEquals(man.adapter_module_from_name(
+        self.assertEqual(adp.module().read_from_file("path").name, "path")
+        self.assertEqual(man.adapter_module_from_name(
             "example").read_from_file("path").name, "path")
 
 if __name__ == '__main__':

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -26,83 +26,83 @@ class BuiltInAdapterTest(unittest.TestCase):
         otiotmp = tempfile.mkstemp(suffix=".otio", text=True)[1]
         otio.adapters.write_to_file(timeline, otiotmp)
         decoded = otio.adapters.read_from_file(otiotmp)
-        self.assertEquals(timeline, decoded)
+        self.assertEqual(timeline, decoded)
 
     def test_edl_read(self):
         edl_path = SCREENING_EXAMPLE_PATH
         timeline = otio.adapters.read_from_file(edl_path)
-        self.failUnless(timeline is not None)
-        self.assertEquals(len(timeline.tracks), 1)
-        self.assertEquals(len(timeline.tracks[0]), 9)
-        self.assertEquals(
+        self.assertTrue(timeline is not None)
+        self.assertEqual(len(timeline.tracks), 1)
+        self.assertEqual(len(timeline.tracks[0]), 9)
+        self.assertEqual(
             timeline.tracks[0][0].name,
             "ZZ100_501 (LAY3)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][0].source_range.duration,
             otio.opentime.from_timecode("00:00:01:07")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][1].name,
             "ZZ100_502A (LAY3)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][1].source_range.duration,
             otio.opentime.from_timecode("00:00:02:02")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][2].name,
             "ZZ100_503A (LAY1)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][2].source_range.duration,
             otio.opentime.from_timecode("00:00:01:04")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][3].name,
             "ZZ100_504C (LAY1)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][3].source_range.duration,
             otio.opentime.from_timecode("00:00:04:19")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][4].name,
             "ZZ100_504B (LAY1)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][4].source_range.duration,
             otio.opentime.from_timecode("00:00:04:05")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][5].name,
             "ZZ100_507C (LAY2)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][5].source_range.duration,
             otio.opentime.from_timecode("00:00:06:17")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][6].name,
             "ZZ100_508 (LAY2)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][6].source_range.duration,
             otio.opentime.from_timecode("00:00:07:02")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][7].name,
             "ZZ100_510 (LAY1)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][7].source_range.duration,
             otio.opentime.from_timecode("00:00:05:16")
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][8].name,
             "ZZ100_510B (LAY1)"
         )
-        self.assertEquals(
+        self.assertEqual(
             timeline.tracks[0][8].source_range.duration,
             otio.opentime.from_timecode("00:00:10:17")
         )
@@ -147,14 +147,14 @@ class BuiltInAdapterTest(unittest.TestCase):
             otio.adapters.write_to_string(new_otio, adapter_name="otio_json"),
             otio.adapters.write_to_string(tl, adapter_name="otio_json")
         )
-        self.assertEquals(new_otio, tl)
+        self.assertEqual(new_otio, tl)
 
     def test_read_cmx(self):
         tl = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH, "cmx_3600")
 
         baseline_json = otio.adapters.otio_json.write_to_string(tl)
 
-        self.assertEquals(tl.name, "Example_Screening.01")
+        self.assertEqual(tl.name, "Example_Screening.01")
 
         otio.adapters.otio_json.write_to_file(tl, "/var/tmp/test.otio")
         new = otio.adapters.otio_json.read_from_file(
@@ -164,7 +164,7 @@ class BuiltInAdapterTest(unittest.TestCase):
         new_json = otio.adapters.otio_json.write_to_string(new)
 
         self.assertMultiLineEqual(baseline_json, new_json)
-        self.assertEquals(tl, new)
+        self.assertEqual(tl, new)
 
     def test_edl_disk_vs_string(self):
         """ Writing to disk and writing to a string should
@@ -175,15 +175,16 @@ class BuiltInAdapterTest(unittest.TestCase):
         edltmp = tempfile.mkstemp(suffix=".edl", text=True)[1]
         otio.adapters.write_to_file(timeline, edltmp)
         in_memory = otio.adapters.write_to_string(timeline, 'cmx_3600')
-        on_disk = open(edltmp, 'r').read()
+        with open(edltmp, 'r') as f:
+            on_disk = f.read()
 
-        self.assertEquals(in_memory, on_disk)
+        self.assertEqual(in_memory, on_disk)
 
     def test_adapters_fetch(self):
         """ Test the dynamic string based adapter fetching """
         printer = otio.adapters.from_name('pretty_print_string')
-        self.assertEquals(printer.module(), pretty_print_string)
-        self.assertEquals(
+        self.assertEqual(printer.module(), pretty_print_string)
+        self.assertEqual(
             otio.adapters.from_name('cmx_3600').module(),
             cmx_3600
         )

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -26,18 +26,18 @@ class ClipTests(unittest.TestCase):
             # transition_in
             # transition_out
         )
-        self.assertEquals(cl.name, name)
-        self.assertEquals(cl.source_range, tr)
-        self.assertEquals(cl.media_reference, mr)
-        self.assertEquals(cl.source_range, tr)
+        self.assertEqual(cl.name, name)
+        self.assertEqual(cl.source_range, tr)
+        self.assertEqual(cl.media_reference, mr)
+        self.assertEqual(cl.source_range, tr)
 
         encoded = otio.adapters.otio_json.write_to_string(cl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(cl, decoded)
+        self.assertEqual(cl, decoded)
 
     def test_each_clip(self):
         cl = otio.schema.Clip(name="test_clip")
-        self.assertEquals(list(cl.each_clip()), [cl])
+        self.assertEqual(list(cl.each_clip()), [cl])
 
     def test_str(self):
         cl = otio.schema.Clip(name="test_clip")
@@ -91,15 +91,15 @@ class ClipTests(unittest.TestCase):
                 available_range=tr
             )
         )
-        self.assertEquals(cl.duration(), cl.computed_duration())
-        self.assertEquals(cl.duration(), tr.duration)
+        self.assertEqual(cl.duration(), cl.computed_duration())
+        self.assertEqual(cl.duration(), tr.duration)
         cl.source_range = otio.opentime.TimeRange(
             # 1 hour + 100 frames
             start_time=otio.opentime.RationalTime(86500, 24),
             duration=otio.opentime.RationalTime(50, 24)
         )
-        self.assertNotEquals(cl.duration(), tr.duration)
-        self.assertEquals(cl.duration(), cl.source_range.duration)
+        self.assertNotEqual(cl.duration(), tr.duration)
+        self.assertEqual(cl.duration(), cl.source_range.duration)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -10,35 +10,35 @@ class CompositionTests(unittest.TestCase):
     def test_cons(self):
         it = otio.core.Item()
         co = otio.core.Composition(name="test", children=[it])
-        self.assertEquals(co.name, "test")
-        self.assertEquals(co._children, [it])
-        self.assertEquals(co.composition_kind, "Composition")
+        self.assertEqual(co.name, "test")
+        self.assertEqual(co._children, [it])
+        self.assertEqual(co.composition_kind, "Composition")
 
     def test_iterable(self):
         it = otio.core.Item()
         co = otio.core.Composition(children=[it])
-        self.assertEquals(co[0], it)
-        self.assertEquals([i for i in co], [it])
-        self.assertEquals(len(co), 1)
+        self.assertEqual(co[0], it)
+        self.assertEqual([i for i in co], [it])
+        self.assertEqual(len(co), 1)
 
     def test_parent_manip(self):
         it = otio.core.Item()
         co = otio.core.Composition(children=[it])
-        self.assertEquals(it._parent, co)
+        self.assertEqual(it._parent, co)
 
 
 class StackTest(unittest.TestCase):
 
     def test_cons(self):
         st = otio.schema.Stack(name="test")
-        self.assertEquals(st.name, "test")
+        self.assertEqual(st.name, "test")
 
     def test_serialize(self):
         st = otio.schema.Stack(name="test", children=[])
 
         encoded = otio.adapters.otio_json.write_to_string(st)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(st, decoded)
+        self.assertEqual(st, decoded)
 
     def test_str(self):
         st = otio.schema.Stack(name="foo", children=[])
@@ -96,39 +96,39 @@ class StackTest(unittest.TestCase):
         ])
 
         # The Stack should be as long as the longest child
-        self.assertEquals(
+        self.assertEqual(
             st.duration(),
             otio.opentime.RationalTime(value=50, rate=24)
         )
 
         # Stacked items should all start at time zero
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(0).start_time,
             otio.opentime.RationalTime()
         )
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(1).start_time,
             otio.opentime.RationalTime()
         )
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(2).start_time,
             otio.opentime.RationalTime()
         )
 
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(0).duration,
             otio.opentime.RationalTime(value=50, rate=24)
         )
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(1).duration,
             otio.opentime.RationalTime(value=50, rate=24)
         )
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(2).duration,
             otio.opentime.RationalTime(value=50, rate=24)
         )
 
-        self.assertEquals(
+        self.assertEqual(
             st.range_of_child_at_index(2),
             st.range_of_child(st[2])
         )
@@ -187,7 +187,7 @@ class StackTest(unittest.TestCase):
 
         # range always returns the pre-trimmed range.  To get the post-trim
         # range, call .trimmed_range()
-        self.assertEquals(
+        self.assertEqual(
             # get the pre-trimmed range in the reference space of the parent
             st.range_of_child(st[0], reference_space=st),
             otio.opentime.TimeRange(
@@ -213,7 +213,7 @@ class StackTest(unittest.TestCase):
         )
 
         # # in the space of the child
-        # self.assertEquals(
+        # self.assertEqual(
         #     # get the pre-trimmed range in the reference space of the parent
         #     st.range_of_child(st[0], reference_space=st[0]),
         #     otio.opentime.TimeRange(
@@ -223,12 +223,12 @@ class StackTest(unittest.TestCase):
         # )
 
         # trimmed_ functions take into account the source_range
-        self.assertEquals(
+        self.assertEqual(
             st.trimmed_range_of_child_at_index(0),
             st.source_range
         )
 
-        self.assertEquals(
+        self.assertEqual(
             st.trimmed_range_of_child(st[0], reference_space=st),
             otio.opentime.TimeRange(
                 start_time=otio.opentime.RationalTime(5, 24),
@@ -365,7 +365,7 @@ class SequenceTest(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(sq)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(sq, decoded)
+        self.assertEqual(sq, decoded)
 
     def test_str(self):
         sq = otio.schema.Sequence(name="foo", children=[])
@@ -396,40 +396,38 @@ class SequenceTest(unittest.TestCase):
         tr = otio.opentime.TimeRange(otio.opentime.RationalTime(), length)
         it = otio.core.Item(source_range=tr)
         sq = otio.schema.Sequence(children=[it])
-        self.assertEquals(sq.range_of_child_at_index(0), tr)
+        self.assertEqual(sq.range_of_child_at_index(0), tr)
 
         sq = otio.schema.Sequence(children=[it, it, it])
-        self.assertEquals(len(sq), 1)
+        self.assertEqual(len(sq), 1)
 
         sq = otio.schema.Sequence(
             children=[it, it.copy(), it.copy(), it.copy()],
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(index=1),
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(5, 1),
                 otio.opentime.RationalTime(5, 1)
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(index=0),
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 1),
                 otio.opentime.RationalTime(5, 1)
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(index=-1),
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(15, 1),
                 otio.opentime.RationalTime(5, 1)
             )
         )
-        self.assertRaises(
-            IndexError,
-            lambda: sq.range_of_child_at_index(index=11)
-        )
-        self.assertEquals(sq.duration(), length + length + length + length)
+        with self.assertRaises(IndexError):
+            sq.range_of_child_at_index(index=11)
+        self.assertEqual(sq.duration(), length + length + length + length)
 
     def test_range_of_child(self):
         sq = otio.schema.Sequence(
@@ -478,7 +476,7 @@ class SequenceTest(unittest.TestCase):
         )
 
         # The Sequence should be as long as the children summed up
-        self.assertEquals(
+        self.assertEqual(
             sq.duration(),
             otio.opentime.RationalTime(value=150, rate=24)
         )
@@ -486,32 +484,32 @@ class SequenceTest(unittest.TestCase):
         # @TODO: should include time transforms
 
         # Sequenced items should all land end-to-end
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(0).start_time,
             otio.opentime.RationalTime()
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(1).start_time,
             otio.opentime.RationalTime(value=50, rate=24)
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(2).start_time,
             otio.opentime.RationalTime(value=100, rate=24)
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child(sq[2]),
             sq.range_of_child_at_index(2)
         )
 
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(0).duration,
             otio.opentime.RationalTime(value=50, rate=24)
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(1).duration,
             otio.opentime.RationalTime(value=50, rate=24)
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.range_of_child_at_index(2).duration,
             otio.opentime.RationalTime(value=50, rate=24)
         )
@@ -522,18 +520,18 @@ class SequenceTest(unittest.TestCase):
             duration=otio.opentime.RationalTime(140, 24),
         )
         sq.source_range = sq_sourcerange
-        self.assertEquals(
+        self.assertEqual(
             sq.trimmed_range_of_child_at_index(0),
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(5, 24),
                 otio.opentime.RationalTime(45, 24)
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.trimmed_range_of_child_at_index(1),
             sq.range_of_child_at_index(1)
         )
-        self.assertEquals(
+        self.assertEqual(
             sq.trimmed_range_of_child_at_index(2),
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(100, 24),
@@ -590,16 +588,14 @@ class SequenceTest(unittest.TestCase):
         #  Subtle point, but copy() of a list returns an empty list with a copy
         #  of all of its metadata, but not of its data.  To get that you need
         #  to deepcopy().
-        self.assertEquals(len(sq.copy()), 0)
+        self.assertEqual(len(sq.copy()), 0)
 
         sq_c = sq.deepcopy()
         other_sq = otio.schema.Sequence(name="outer", children=[sq_c])
 
         # import ipdb; ipdb.set_trace()
-        self.assertRaises(
-            otio.exceptions.NotAChildError,
-            lambda: other_sq.range_of_child(sq[1])
-        )
+        with self.assertRaises(otio.exceptions.NotAChildError):
+            other_sq.range_of_child(sq[1])
 
         other_sq = otio.schema.Sequence(
             name="outer",
@@ -616,7 +612,7 @@ class SequenceTest(unittest.TestCase):
             ),
             result_range_post.duration
         )
-        self.assertEquals(other_sq.range_of_child(sq[1]), result)
+        self.assertEqual(other_sq.range_of_child(sq[1]), result)
 
     def test_setitem(self):
         seq = otio.schema.Sequence()
@@ -624,10 +620,10 @@ class SequenceTest(unittest.TestCase):
         it_2 = otio.schema.Clip()
 
         seq.append(it)
-        self.assertEquals(len(seq), 1)
+        self.assertEqual(len(seq), 1)
 
         seq[0] = it_2
-        self.assertEquals(len(seq), 1)
+        self.assertEqual(len(seq), 1)
 
     def test_transformed_time(self):
         sq = otio.schema.Sequence(
@@ -804,8 +800,8 @@ class EdgeCases(unittest.TestCase):
 
     def test_empty_compositions(self):
         timeline = otio.schema.Timeline()
-        self.assertEquals(len(timeline.tracks), 0)
-        self.assertEquals(
+        self.assertEqual(len(timeline.tracks), 0)
+        self.assertEqual(
             timeline.tracks.duration(),
             otio.opentime.RationalTime(
                 0,
@@ -864,19 +860,19 @@ class NestingTest(unittest.TestCase):
 
         # the clip and track should auto-size to fit the media, since we
         # haven't trimmed anything
-        self.assertEquals(clip.duration(), onehundred)
-        self.assertEquals(track.duration(), onehundred)
-        self.assertEquals(stack.duration(), onehundred)
+        self.assertEqual(clip.duration(), onehundred)
+        self.assertEqual(track.duration(), onehundred)
+        self.assertEqual(stack.duration(), onehundred)
 
         # the ranges should match our expectations...
-        self.assertEquals(clip.trimmed_range(), media_range)
-        self.assertEquals(track.trimmed_range(), top_level_range)
-        self.assertEquals(stack.trimmed_range(), top_level_range)
+        self.assertEqual(clip.trimmed_range(), media_range)
+        self.assertEqual(track.trimmed_range(), top_level_range)
+        self.assertEqual(stack.trimmed_range(), top_level_range)
 
         # verify that the media is where we expect
-        self.assertEquals(stack.transformed_time(zero, clip), first_frame)
-        self.assertEquals(stack.transformed_time(fifty, clip), middle)
-        self.assertEquals(stack.transformed_time(ninetynine, clip), last)
+        self.assertEqual(stack.transformed_time(zero, clip), first_frame)
+        self.assertEqual(stack.transformed_time(fifty, clip), middle)
+        self.assertEqual(stack.transformed_time(ninetynine, clip), last)
 
         # now nest it many layers deeper
         wrappers = []
@@ -892,47 +888,47 @@ class NestingTest(unittest.TestCase):
 
         # the clip and track should auto-size to fit the media, since we
         # haven't trimmed anything
-        self.assertEquals(clip.duration(), onehundred)
-        self.assertEquals(track.duration(), onehundred)
-        self.assertEquals(stack.duration(), onehundred)
+        self.assertEqual(clip.duration(), onehundred)
+        self.assertEqual(track.duration(), onehundred)
+        self.assertEqual(stack.duration(), onehundred)
 
         # the ranges should match our expectations...
-        self.assertEquals(clip.trimmed_range(), media_range)
-        self.assertEquals(track.trimmed_range(), top_level_range)
-        self.assertEquals(stack.trimmed_range(), top_level_range)
+        self.assertEqual(clip.trimmed_range(), media_range)
+        self.assertEqual(track.trimmed_range(), top_level_range)
+        self.assertEqual(stack.trimmed_range(), top_level_range)
 
         # verify that the media is where we expect
-        self.assertEquals(stack.transformed_time(zero, clip), first_frame)
-        self.assertEquals(stack.transformed_time(fifty, clip), middle)
-        self.assertEquals(stack.transformed_time(ninetynine, clip), last)
+        self.assertEqual(stack.transformed_time(zero, clip), first_frame)
+        self.assertEqual(stack.transformed_time(fifty, clip), middle)
+        self.assertEqual(stack.transformed_time(ninetynine, clip), last)
 
         # now trim them all by one frame at each end
-        self.assertEquals(ninetynine, ninetynine)
-        self.assertEquals(ninetynine + one, onehundred)
+        self.assertEqual(ninetynine, ninetynine)
+        self.assertEqual(ninetynine + one, onehundred)
         trim = otio.opentime.TimeRange(
             start_time=one, duration=(
                 ninetynine - one))
-        self.assertEquals(trim.duration, otio.opentime.RationalTime(98, 24))
+        self.assertEqual(trim.duration, otio.opentime.RationalTime(98, 24))
         for wrapper in wrappers:
             wrapper.source_range = trim
 
         # print otio.adapters.otio_json.write_to_string(timeline)
 
         # the clip should be the same
-        self.assertEquals(clip.duration(), onehundred)
+        self.assertEqual(clip.duration(), onehundred)
 
         # the parents should have shrunk by only 2 frames
-        self.assertEquals(track.duration(), otio.opentime.RationalTime(98, 24))
-        self.assertEquals(stack.duration(), otio.opentime.RationalTime(98, 24))
+        self.assertEqual(track.duration(), otio.opentime.RationalTime(98, 24))
+        self.assertEqual(stack.duration(), otio.opentime.RationalTime(98, 24))
 
         # but the media should have shifted over by 1 one frame for each level
         # of nesting
         ten = otio.opentime.RationalTime(num_wrappers, 24)
-        self.assertEquals(
+        self.assertEqual(
             stack.transformed_time(
                 zero, clip), first_frame + ten)
-        self.assertEquals(stack.transformed_time(fifty, clip), middle + ten)
-        self.assertEquals(stack.transformed_time(ninetynine, clip), last + ten)
+        self.assertEqual(stack.transformed_time(fifty, clip), middle + ten)
+        self.assertEqual(stack.transformed_time(ninetynine, clip), last + ten)
 
     def test_trimming(self):
         sq = otio.schema.Sequence(
@@ -1073,7 +1069,7 @@ class NestingTest(unittest.TestCase):
             playhead = otio.opentime.RationalTime(frame, 24)
             item = sq.top_clip_at_time(playhead)
             mediaframe = sq.transformed_time(playhead, item)
-            self.assertEquals(
+            self.assertEqual(
                 (
                     item.name,
                     otio.opentime.to_frames(mediaframe, 24)

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -13,10 +13,10 @@ class EffectTest(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(ef)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(ef, decoded)
-        self.assertEquals(decoded.name, "blur it")
-        self.assertEquals(decoded.effect_name, "blur")
-        self.assertEquals(decoded.metadata['foo'], 'bar')
+        self.assertEqual(ef, decoded)
+        self.assertEqual(decoded.name, "blur it")
+        self.assertEqual(decoded.effect_name, "blur")
+        self.assertEqual(decoded.metadata['foo'], 'bar')
 
     def test_eq(self):
         ef = otio.schema.Effect(
@@ -29,7 +29,7 @@ class EffectTest(unittest.TestCase):
             effect_name="blur",
             metadata={"foo": "bar"}
         )
-        self.assertEquals(ef, ef2)
+        self.assertEqual(ef, ef2)
 
     def test_str(self):
         ef = otio.schema.Effect(

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -40,7 +40,7 @@ class FillerTester(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(fl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(fl, decoded)
+        self.assertEqual(fl, decoded)
 
 
 class ItemTests(unittest.TestCase):
@@ -51,12 +51,12 @@ class ItemTests(unittest.TestCase):
             otio.opentime.RationalTime(10, 1)
         )
         it = otio.core.Item(name="foo", source_range=tr)
-        self.assertEquals(it.source_range, tr)
-        self.assertEquals(it.name, "foo")
+        self.assertEqual(it.source_range, tr)
+        self.assertEqual(it.name, "foo")
 
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(it, decoded)
+        self.assertEqual(it, decoded)
 
     def test_is_parent_of(self):
         it = otio.core.Item()
@@ -72,16 +72,17 @@ class ItemTests(unittest.TestCase):
 
         # set it from none
         it_2._set_parent(it)
-        self.assertEquals(it, it_2._parent)
+        self.assertEqual(it, it_2._parent)
 
         # change it
         it_3 = otio.core.Item()
         it_2._set_parent(it_3)
-        self.assertEquals(it_3, it_2._parent)
+        self.assertEqual(it_3, it_2._parent)
 
     def test_duration(self):
         it = otio.core.Item()
-        self.assertRaises(NotImplementedError, lambda: it.computed_duration())
+        with self.assertRaises(NotImplementedError):
+            it.computed_duration()
 
         tr = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0, 1),
@@ -89,32 +90,36 @@ class ItemTests(unittest.TestCase):
         )
         it = otio.core.Item(source_range=tr)
 
-        self.assertEquals(it.duration(), tr.duration)
+        self.assertEqual(it.duration(), tr.duration)
 
     def test_duration_and_source_range(self):
         it = otio.core.Item()
-        self.assertRaises(NotImplementedError, lambda: it.computed_duration())
-        self.assertRaises(NotImplementedError, lambda: it.duration())
-        self.assertEquals(None, it.source_range)
+        with self.assertRaises(NotImplementedError):
+            it.computed_duration()
+        with self.assertRaises(NotImplementedError):
+            it.duration()
+        self.assertEqual(None, it.source_range)
 
         tr = otio.opentime.TimeRange(
             otio.opentime.RationalTime(1, 1),
             otio.opentime.RationalTime(10, 1)
         )
         it2 = otio.core.Item(source_range=tr)
-        self.assertRaises(NotImplementedError, lambda: it2.computed_duration())
-        self.assertEquals(tr, it2.source_range)
-        self.assertEquals(tr.duration, it2.duration())
+        with self.assertRaises(NotImplementedError):
+            it2.computed_duration()
+        self.assertEqual(tr, it2.source_range)
+        self.assertEqual(tr.duration, it2.duration())
 
     def test_trimmed_range(self):
         it = otio.core.Item()
-        self.assertRaises(NotImplementedError, lambda: it.trimmed_range())
+        with self.assertRaises(NotImplementedError):
+            it.trimmed_range()
         tr = otio.opentime.TimeRange(
             otio.opentime.RationalTime(1, 1),
             otio.opentime.RationalTime(10, 1)
         )
         it2 = otio.core.Item(source_range=tr)
-        self.assertEquals(it2.trimmed_range(), tr)
+        self.assertEqual(it2.trimmed_range(), tr)
 
     def test_serialize(self):
         tr = otio.opentime.TimeRange(
@@ -124,7 +129,7 @@ class ItemTests(unittest.TestCase):
         it = otio.core.Item(source_range=tr)
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(it, decoded)
+        self.assertEqual(it, decoded)
 
     def test_stringify(self):
         tr = otio.opentime.TimeRange(
@@ -171,8 +176,8 @@ class ItemTests(unittest.TestCase):
         it.metadata["foo"] = "bar"
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(it, decoded)
-        self.assertEquals(decoded.metadata["foo"], it.metadata["foo"])
+        self.assertEqual(it, decoded)
+        self.assertEqual(decoded.metadata["foo"], it.metadata["foo"])
 
     def test_add_effect(self):
         tr = otio.opentime.TimeRange(
@@ -188,8 +193,8 @@ class ItemTests(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(it, decoded)
-        self.assertEquals(it.effects, decoded.effects)
+        self.assertEqual(it, decoded)
+        self.assertEqual(it.effects, decoded.effects)
 
     def test_add_marker(self):
         tr = otio.opentime.TimeRange(
@@ -206,8 +211,8 @@ class ItemTests(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(it, decoded)
-        self.assertEquals(it.markers, decoded.markers)
+        self.assertEqual(it, decoded)
+        self.assertEqual(it.markers, decoded.markers)
 
     def test_copy(self):
         tr = otio.opentime.TimeRange(
@@ -232,19 +237,19 @@ class ItemTests(unittest.TestCase):
         )
 
         it_copy = it.copy()
-        self.assertEquals(it, it_copy)
+        self.assertEqual(it, it_copy)
         it.metadata["foo"] = "bar2"
         # shallow copy, should change both dictionaries
-        self.assertEquals(it_copy.metadata["foo"], "bar2")
+        self.assertEqual(it_copy.metadata["foo"], "bar2")
 
         # name should be different
         it.name = "foo"
-        self.assertNotEquals(it_copy.name, it.name)
+        self.assertNotEqual(it_copy.name, it.name)
 
         # deep copy should have different dictionaries
         it_dcopy = it.deepcopy()
         it_dcopy.metadata["foo"] = "not bar"
-        self.assertNotEquals(it.metadata, it_dcopy.metadata)
+        self.assertNotEqual(it.metadata, it_dcopy.metadata)
 
     def test_copy_library(self):
         tr = otio.opentime.TimeRange(
@@ -271,19 +276,19 @@ class ItemTests(unittest.TestCase):
         # shallow test
         import copy
         it_copy = copy.copy(it)
-        self.assertEquals(it, it_copy)
+        self.assertEqual(it, it_copy)
         it.metadata["foo"] = "bar2"
         # shallow copy, should change both dictionaries
-        self.assertEquals(it_copy.metadata["foo"], "bar2")
+        self.assertEqual(it_copy.metadata["foo"], "bar2")
 
         # name should be different
         it.name = "foo"
-        self.assertNotEquals(it_copy.name, it.name)
+        self.assertNotEqual(it_copy.name, it.name)
 
         # deep copy should have different dictionaries
         it_dcopy = copy.deepcopy(it)
         it_dcopy.metadata["foo"] = "not bar"
-        self.assertNotEquals(it.metadata, it_dcopy.metadata)
+        self.assertNotEqual(it.metadata, it_dcopy.metadata)
 
 
 if __name__ == '__main__':

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -29,7 +29,7 @@ class TestJsonFormat(unittest.TestCase):
         )
         if isinstance(baseline_data, dict):
             raise TypeError("did not deserialize correctly")
-        self.assertEquals(obj, baseline_data)
+        self.assertEqual(obj, baseline_data)
 
     def test_rationaltime(self):
         rt = otio.opentime.RationalTime()

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -17,21 +17,21 @@ class MarkerTest(unittest.TestCase):
             range=tr,
             metadata={'foo': 'bar'}
         )
-        self.assertEquals(m.name, 'marker_1')
-        self.assertEquals(m.metadata['foo'], 'bar')
-        self.assertEquals(m.range, tr)
-        self.assertNotEquals(hash(m), hash(otio.schema.Marker()))
+        self.assertEqual(m.name, 'marker_1')
+        self.assertEqual(m.metadata['foo'], 'bar')
+        self.assertEqual(m.range, tr)
+        self.assertNotEqual(hash(m), hash(otio.schema.Marker()))
 
         encoded = otio.adapters.otio_json.write_to_string(m)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(m, decoded)
+        self.assertEqual(m, decoded)
 
     def test_equality(self):
         m = otio.schema.Marker()
         bo = otio.core.Item()
 
-        self.assertNotEquals(m, bo)
-        self.assertNotEquals(bo, m)
+        self.assertNotEqual(m, bo)
+        self.assertNotEqual(bo, m)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -21,7 +21,7 @@ class MediaReferenceTests(unittest.TestCase):
             metadata={'show': 'OTIOTheMovie'}
         )
 
-        self.assertEquals(mr.available_range, tr)
+        self.assertEqual(mr.available_range, tr)
 
         mr = otio.media_reference.MissingReference()
         self.assertIsNone(mr.available_range)
@@ -36,7 +36,7 @@ class MediaReferenceTests(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(missing)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(missing, decoded)
+        self.assertEqual(missing, decoded)
 
     def test_filepath(self):
         filepath = otio.media_reference.External("/var/tmp/foo.mov")
@@ -54,16 +54,16 @@ class MediaReferenceTests(unittest.TestCase):
         # round trip serialize
         encoded = otio.adapters.otio_json.write_to_string(filepath)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(filepath, decoded)
+        self.assertEqual(filepath, decoded)
 
     def test_equality(self):
         filepath = otio.media_reference.External(target_url="/var/tmp/foo.mov")
         filepath2 = otio.media_reference.External(
             target_url="/var/tmp/foo.mov")
-        self.assertEquals(filepath, filepath2)
+        self.assertEqual(filepath, filepath2)
 
         bl = otio.media_reference.MissingReference()
-        self.assertNotEquals(filepath, bl)
+        self.assertNotEqual(filepath, bl)
 
         filepath = otio.media_reference.External(target_url="/var/tmp/foo.mov")
         filepath2 = otio.media_reference.External(
@@ -72,7 +72,7 @@ class MediaReferenceTests(unittest.TestCase):
         self.assertEqual(filepath == filepath2, False)
 
         bl = otio.media_reference.MissingReference()
-        self.assertNotEquals(filepath, bl)
+        self.assertNotEqual(filepath, bl)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -16,18 +16,18 @@ class TestTime(unittest.TestCase):
         t_val = 30.2
         t = otio.opentime.RationalTime(t_val)
         self.assertIsNotNone(t)
-        self.assertEquals(t.value, t_val)
+        self.assertEqual(t.value, t_val)
 
         t = otio.opentime.RationalTime()
-        self.assertEquals(t.value, 0)
-        self.assertEquals(t.rate, 1.0)
+        self.assertEqual(t.value, 0)
+        self.assertEqual(t.rate, 1.0)
 
     def test_equality(self):
         t1 = otio.opentime.RationalTime(30.2)
-        self.assertEquals(t1, t1)
+        self.assertEqual(t1, t1)
         t2 = otio.opentime.RationalTime(30.2)
         self.assertTrue(t1 is not t2)
-        self.assertEquals(t1, t2)
+        self.assertEqual(t1, t2)
 
     def test_comparison(self):
         t1 = otio.opentime.RationalTime(15.2)
@@ -42,48 +42,49 @@ class TestTime(unittest.TestCase):
 
         # from a number
         t = otio.opentime.RationalTime(10, 24)
-        self.assertRaises(TypeError, lambda: t.rescaled_to("foo"))
-        self.assertEquals(t.rate, 24)
+        with self.assertRaises(TypeError):
+            t.rescaled_to("foo")
+        self.assertEqual(t.rate, 24)
         t = t.rescaled_to(48)
-        self.assertEquals(t.rate, 48)
+        self.assertEqual(t.rate, 48)
 
         # from another RationalTime
         t = otio.opentime.RationalTime(10, 24)
         t2 = otio.opentime.RationalTime(20, 48)
         t = t.rescaled_to(t2)
-        self.assertEquals(t.rate, t2.rate)
+        self.assertEqual(t.rate, t2.rate)
 
     def test_time_timecode_convert(self):
         timecode = "00:06:56:17"
         t = otio.opentime.from_timecode(timecode)
-        self.assertEquals(timecode, otio.opentime.to_timecode(t))
+        self.assertEqual(timecode, otio.opentime.to_timecode(t))
 
     def test_timecode_24(self):
         timecode = "00:00:01:00"
         t = otio.opentime.RationalTime(value=24, rate=24)
-        self.assertEquals(t, otio.opentime.from_timecode(timecode))
+        self.assertEqual(t, otio.opentime.from_timecode(timecode))
 
         timecode = "00:01:00:00"
         t = otio.opentime.RationalTime(value=24 * 60, rate=24)
-        self.assertEquals(t, otio.opentime.from_timecode(timecode))
+        self.assertEqual(t, otio.opentime.from_timecode(timecode))
 
         timecode = "01:00:00:00"
         t = otio.opentime.RationalTime(value=24 * 60 * 60, rate=24)
-        self.assertEquals(t, otio.opentime.from_timecode(timecode))
+        self.assertEqual(t, otio.opentime.from_timecode(timecode))
 
         timecode = "24:00:00:00"
         t = otio.opentime.RationalTime(value=24 * 60 * 60 * 24, rate=24)
-        self.assertEquals(t, otio.opentime.from_timecode(timecode))
+        self.assertEqual(t, otio.opentime.from_timecode(timecode))
 
         timecode = "23:59:59:23"
         t = otio.opentime.RationalTime(value=24 * 60 * 60 * 24 - 1, rate=24)
-        self.assertEquals(t, otio.opentime.from_timecode(timecode))
+        self.assertEqual(t, otio.opentime.from_timecode(timecode))
 
     def test_time_timecode_zero(self):
         t = otio.opentime.RationalTime()
         timecode = "00:00:00:00"
-        self.assertEquals(timecode, otio.opentime.to_timecode(t))
-        self.assertEquals(t, otio.opentime.from_timecode(timecode))
+        self.assertEqual(timecode, otio.opentime.to_timecode(t))
+        self.assertEqual(t, otio.opentime.from_timecode(timecode))
 
     def test_long_running_timecode_24(self):
         previous_time = otio.opentime.RationalTime()
@@ -100,11 +101,11 @@ class TestTime(unittest.TestCase):
             t = otio.opentime.from_frames(frame, 24)
             timecode = otio.opentime.to_timecode(t)
 
-            self.assertEquals(len(timecode), len(previous_timecode))
+            self.assertEqual(len(timecode), len(previous_timecode))
             self.assertTrue(timecode > previous_timecode)
             self.assertTrue(t > previous_time)
 
-            self.assertEquals(
+            self.assertEqual(
                 previous_time +
                 otio.opentime.RationalTime(
                     value=step,
@@ -112,21 +113,21 @@ class TestTime(unittest.TestCase):
                 t)
 
             t2 = otio.opentime.from_timecode(timecode)
-            self.assertEquals(t, t2)
+            self.assertEqual(t, t2)
 
             components = timecode.split(":")
-            self.assertEquals(int(components[-1]), t.value % 24)
+            self.assertEqual(int(components[-1]), t.value % 24)
 
             previous_time = t
             previous_timecode = timecode
 
         if step == 1:
-            self.assertEquals(timecode, "23:59:59:23")
+            self.assertEqual(timecode, "23:59:59:23")
 
     def test_time_to_string(self):
         t = otio.opentime.RationalTime(1, 2)
-        self.assertEquals(str(t), "RationalTime(1, 2)")
-        self.assertEquals(
+        self.assertEqual(str(t), "RationalTime(1, 2)")
+        self.assertEqual(
             repr(t),
             "otio.opentime.RationalTime(value=1, rate=2)"
         )
@@ -135,21 +136,21 @@ class TestTime(unittest.TestCase):
         for fps in (24, 30, 48, 60):
             t1 = otio.opentime.from_frames(101, fps)
             t2 = otio.opentime.RationalTime(101, fps)
-            self.assertEquals(t1, t2)
+            self.assertEqual(t1, t2)
 
     def test_frames_with_nonint_fps(self):
         for fps in (23.98, 29.97, 59.94):
             t1 = otio.opentime.from_frames(101, fps)
-            self.assertEquals(t1.rate, 600)
+            self.assertEqual(t1.rate, 600)
             self.assertAlmostEqual(t1.value / t1.rate, 101 / fps)
 
     def test_seconds(self):
         s1 = 1834
         t1 = otio.opentime.from_seconds(s1)
-        self.assertEquals(t1.value, 1834)
-        self.assertEquals(t1.rate, 1)
+        self.assertEqual(t1.value, 1834)
+        self.assertEqual(t1.rate, 1)
         t1_as_seconds = otio.opentime.to_seconds(t1)
-        self.assertEquals(t1_as_seconds, s1)
+        self.assertEqual(t1_as_seconds, s1)
         self.assertAlmostEqual(float(t1.value) / t1.rate, s1)
 
         s2 = 248474.345
@@ -172,40 +173,41 @@ class TestTime(unittest.TestCase):
         start_time = otio.opentime.from_frames(100, 24)
         end = otio.opentime.from_frames(200, 24)
         duration = otio.opentime.duration_from_start_end_time(start_time, end)
-        self.assertEquals(duration, otio.opentime.from_frames(100, 24))
+        self.assertEqual(duration, otio.opentime.from_frames(100, 24))
 
         start_time = otio.opentime.from_frames(0, 1)
         end = otio.opentime.from_frames(200, 24)
         duration = otio.opentime.duration_from_start_end_time(start_time, end)
-        self.assertEquals(duration, otio.opentime.from_frames(200, 24))
+        self.assertEqual(duration, otio.opentime.from_frames(200, 24))
 
     def test_math(self):
         a = otio.opentime.from_frames(100, 24)
         gap = otio.opentime.from_frames(50, 24)
         b = otio.opentime.from_frames(150, 24)
-        self.assertEquals(b - a, gap)
-        self.assertEquals(a + gap, b)
-        self.assertEquals(b - gap, a)
+        self.assertEqual(b - a, gap)
+        self.assertEqual(a + gap, b)
+        self.assertEqual(b - gap, a)
 
-        self.assertRaises(TypeError, lambda: b + "foo")
+        with self.assertRaises(TypeError):
+            b + "foo"
 
     def test_math_with_different_scales(self):
         a = otio.opentime.from_frames(100, 24)
         gap = otio.opentime.from_frames(100, 48)
         b = otio.opentime.from_frames(75, 12)
-        self.assertEquals(b - a, gap.rescaled_to(24))
-        self.assertEquals(a + gap, b.rescaled_to(48))
-        self.assertEquals(b - gap, a.rescaled_to(48))
+        self.assertEqual(b - a, gap.rescaled_to(24))
+        self.assertEqual(a + gap, b.rescaled_to(48))
+        self.assertEqual(b - gap, a.rescaled_to(48))
 
     def test_hash(self):
         rt = otio.opentime.RationalTime(1, 12)
         rt2 = otio.opentime.RationalTime(1, 12)
 
-        self.assertEquals(hash(rt), hash(rt2))
+        self.assertEqual(hash(rt), hash(rt2))
 
         rt2 = otio.opentime.RationalTime(5, 12)
 
-        self.assertNotEquals(hash(rt), hash(rt2))
+        self.assertNotEqual(hash(rt), hash(rt2))
 
     def test_duration_from_start_end_time(self):
         tend = otio.opentime.RationalTime(12, 25)
@@ -215,7 +217,7 @@ class TestTime(unittest.TestCase):
             end_time=tend
         )
 
-        self.assertEquals(tend, tdur)
+        self.assertEqual(tend, tdur)
 
 
 class TestTimeTransform(unittest.TestCase):
@@ -223,20 +225,20 @@ class TestTimeTransform(unittest.TestCase):
     def test_identity_transform(self):
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform()
-        self.assertEquals(tstart, txform.applied_to(tstart))
+        self.assertEqual(tstart, txform.applied_to(tstart))
 
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform(rate=50)
-        self.assertEquals(24, txform.applied_to(tstart).value)
+        self.assertEqual(24, txform.applied_to(tstart).value)
 
     def test_offset(self):
         tstart = otio.opentime.RationalTime(12, 25)
         toffset = otio.opentime.RationalTime(10, 25)
         txform = otio.opentime.TimeTransform(offset=toffset)
-        self.assertEquals(tstart + toffset, txform.applied_to(tstart))
+        self.assertEqual(tstart + toffset, txform.applied_to(tstart))
 
         tr = otio.opentime.TimeRange(tstart, tstart)
-        self.assertEquals(
+        self.assertEqual(
             txform.applied_to(tr),
             otio.opentime.TimeRange(tstart + toffset, tstart)
         )
@@ -244,14 +246,14 @@ class TestTimeTransform(unittest.TestCase):
     def test_scale(self):
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform(scale=2)
-        self.assertEquals(
+        self.assertEqual(
             otio.opentime.RationalTime(24, 25),
             txform.applied_to(tstart)
         )
 
         tr = otio.opentime.TimeRange(tstart, tstart)
         tstart_scaled = otio.opentime.RationalTime(24, 25)
-        self.assertEquals(
+        self.assertEqual(
             txform.applied_to(tr),
             otio.opentime.TimeRange(tstart_scaled, tstart_scaled)
         )
@@ -259,12 +261,12 @@ class TestTimeTransform(unittest.TestCase):
     def test_rate(self):
         txform1 = otio.opentime.TimeTransform()
         txform2 = otio.opentime.TimeTransform(rate=50)
-        self.assertEquals(txform2.rate, txform1.applied_to(txform2).rate)
+        self.assertEqual(txform2.rate, txform1.applied_to(txform2).rate)
 
     def test_string(self):
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform(offset=tstart, scale=2)
-        self.assertEquals(
+        self.assertEqual(
             repr(txform),
             "otio.opentime.TimeTransform("
             "offset=otio.opentime.RationalTime("
@@ -276,7 +278,7 @@ class TestTimeTransform(unittest.TestCase):
             ")"
         )
 
-        self.assertEquals(
+        self.assertEqual(
             str(txform),
             "TimeTransform(RationalTime(12, 25), 2, None)"
         )
@@ -287,13 +289,13 @@ class TestTimeTransform(unittest.TestCase):
         tstart = otio.opentime.RationalTime(12, 25)
         txform2 = otio.opentime.TimeTransform(offset=tstart, scale=2)
 
-        self.assertEquals(hash(txform), hash(txform2))
+        self.assertEqual(hash(txform), hash(txform2))
 
         txform2 = otio.opentime.TimeTransform(offset=tstart, scale=3)
-        self.assertNotEquals(hash(txform), hash(txform2))
+        self.assertNotEqual(hash(txform), hash(txform2))
 
         txform2 = otio.opentime.TimeTransform(offset=tstart, scale=2, rate=10)
-        self.assertNotEquals(hash(txform), hash(txform2))
+        self.assertNotEqual(hash(txform), hash(txform2))
 
 
 class TestTimeRange(unittest.TestCase):
@@ -301,42 +303,45 @@ class TestTimeRange(unittest.TestCase):
     def test_create(self):
         tr = otio.opentime.TimeRange()
         blank = otio.opentime.RationalTime()
-        self.assertEquals(tr.start_time, blank)
-        self.assertEquals(tr.duration, blank)
+        self.assertEqual(tr.start_time, blank)
+        self.assertEqual(tr.duration, blank)
 
     def test_duration_validation(self):
         tr = otio.opentime.TimeRange()
-        self.assertRaises(TypeError, lambda: setattr(tr, "duration", "foo"))
+        with self.assertRaises(TypeError):
+            setattr(tr, "duration", "foo")
 
         bad_t = otio.opentime.RationalTime(-1, 1)
-        self.assertRaises(TypeError, lambda: setattr(tr, "duration", bad_t))
+        with self.assertRaises(TypeError):
+            setattr(tr, "duration", bad_t)
 
     def DISABLED_test_extended_by(self):
         tr = otio.opentime.TimeRange()
-        self.assertRaises(TypeError, lambda: tr.extended_by("foo"))
+        with self.assertRaises(TypeError):
+            tr.extended_by("foo")
         rt = otio.opentime.RationalTime(10, 25)
         tr = tr.extended_by(rt)
         self.assert_(tr.duration)
-        self.assertEquals(tr.start_time, otio.opentime.RationalTime(0, 25))
-        self.assertEquals(tr.duration, rt)
+        self.assertEqual(tr.start_time, otio.opentime.RationalTime(0, 25))
+        self.assertEqual(tr.duration, rt)
         rt = otio.opentime.RationalTime(-1, 25)
         tr = tr.extended_by(rt)
-        self.assertEquals(tr.start_time, otio.opentime.RationalTime(-1, 25))
-        self.assertEquals(tr.duration, otio.opentime.RationalTime(11, 25))
+        self.assertEqual(tr.start_time, otio.opentime.RationalTime(-1, 25))
+        self.assertEqual(tr.duration, otio.opentime.RationalTime(11, 25))
 
     def test_end_time(self):
         rt_start = otio.opentime.RationalTime(1, 24)
         rt_dur = otio.opentime.RationalTime(5, 24)
         tr = otio.opentime.TimeRange(rt_start, rt_dur)
-        self.assertEquals(tr.duration, rt_dur)
-        self.assertEquals(tr.end_time(), rt_start + rt_dur)
+        self.assertEqual(tr.duration, rt_dur)
+        self.assertEqual(tr.end_time(), rt_start + rt_dur)
 
     def test_repr(self):
         tr = otio.opentime.TimeRange(
             otio.opentime.RationalTime(-1, 24),
             otio.opentime.RationalTime(6, 24)
         )
-        self.assertEquals(
+        self.assertEqual(
             repr(tr),
             "otio.opentime.TimeRange("
             "start_time=otio.opentime.RationalTime(value=-1, rate=24), "
@@ -357,29 +362,30 @@ class TestTimeRange(unittest.TestCase):
             otio.opentime.RationalTime(7, 24),
         )
 
-        self.assertEquals(tr.clamped(test_point_min), test_point_min)
-        self.assertEquals(tr.clamped(test_point_max), test_point_max)
+        self.assertEqual(tr.clamped(test_point_min), test_point_min)
+        self.assertEqual(tr.clamped(test_point_max), test_point_max)
 
-        self.assertEquals(tr.clamped(other_tr), other_tr)
+        self.assertEqual(tr.clamped(other_tr), other_tr)
 
         start_bound = otio.opentime.BoundStrategy.Clamp
         end_bound = otio.opentime.BoundStrategy.Clamp
 
-        self.assertEquals(
+        self.assertEqual(
             tr.clamped(test_point_min, start_bound, end_bound),
             tr.start_time
         )
-        self.assertEquals(
+        self.assertEqual(
             tr.clamped(test_point_max, start_bound, end_bound),
             tr.end_time()
         )
 
-        self.assertEquals(
+        self.assertEqual(
             tr.clamped(other_tr, start_bound, end_bound),
             other_tr
         )
 
-        self.assertRaises(TypeError, lambda: tr.clamped("foo"))
+        with self.assertRaises(TypeError):
+            tr.clamped("foo")
 
     def test_hash(self):
         tstart = otio.opentime.RationalTime(12, 25)
@@ -390,21 +396,23 @@ class TestTimeRange(unittest.TestCase):
         tdur = otio.opentime.RationalTime(3, 25)
         tr2 = otio.opentime.TimeRange(tstart, tdur)
 
-        self.assertEquals(hash(tr), hash(tr2))
+        self.assertEqual(hash(tr), hash(tr2))
 
     def test_overlaps_garbage(self):
         tstart = otio.opentime.RationalTime(12, 25)
         tdur = otio.opentime.RationalTime(3, 25)
         tr = otio.opentime.TimeRange(tstart, tdur)
 
-        self.assertRaises(TypeError, lambda: tr.overlaps("foo"))
+        with self.assertRaises(TypeError):
+            tr.overlaps("foo")
 
     def test_contains(self):
         tstart = otio.opentime.RationalTime(12, 25)
         tdur = otio.opentime.RationalTime(3, 25)
         tr = otio.opentime.TimeRange(tstart, tdur)
 
-        self.assertRaises(TypeError, lambda: tr.contains("foo"))
+        with self.assertRaises(TypeError):
+            tr.contains("foo")
         self.assertTrue(tr.contains(tstart))
         self.assertFalse(tr.contains(tstart + tdur))
         self.assertFalse(tr.contains(tstart - tdur))
@@ -485,12 +493,12 @@ class TestTimeRange(unittest.TestCase):
             end_time=tend
         )
 
-        self.assertEquals(tr.start_time, tstart)
-        self.assertEquals(tr.duration, tend)
+        self.assertEqual(tr.start_time, tstart)
+        self.assertEqual(tr.duration, tend)
 
-        self.assertEquals(tr.end_time(), tend)
+        self.assertEqual(tr.end_time(), tend)
 
-        self.assertEquals(
+        self.assertEqual(
             tr,
             otio.opentime.range_from_start_end_time(
                 tr.start_time, tr.end_time())

--- a/tests/test_serializeable_object.py
+++ b/tests/test_serializeable_object.py
@@ -11,18 +11,18 @@ class OpenTimeTypeSerializerTest(unittest.TestCase):
         rt = otio.opentime.RationalTime(15, 24)
         encoded = otio.adapters.otio_json.write_to_string(rt)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(rt, decoded)
+        self.assertEqual(rt, decoded)
 
         rt_dur = otio.opentime.RationalTime(10, 20)
         tr = otio.opentime.TimeRange(rt, rt_dur)
         encoded = otio.adapters.otio_json.write_to_string(tr)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(tr, decoded)
+        self.assertEqual(tr, decoded)
 
         tt = otio.opentime.TimeTransform(rt, scale=1.5)
         encoded = otio.adapters.otio_json.write_to_string(tt)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(tt, decoded)
+        self.assertEqual(tt, decoded)
 
 
 class SerializeableObjectTest(unittest.TestCase):
@@ -30,31 +30,29 @@ class SerializeableObjectTest(unittest.TestCase):
     def test_cons(self):
         so = otio.core.SerializeableObject()
         so.data['foo'] = 'bar'
-        self.assertEquals(so.data['foo'], 'bar')
+        self.assertEqual(so.data['foo'], 'bar')
 
     def test_hash(self):
         so = otio.core.SerializeableObject()
         so.data['foo'] = 'bar'
         so_2 = otio.core.SerializeableObject()
         so_2.data['foo'] = 'bar'
-        self.assertEquals(hash(so), hash(so_2))
+        self.assertEqual(hash(so), hash(so_2))
 
     def test_update(self):
         so = otio.core.SerializeableObject()
         so.update({"foo": "bar"})
-        self.assertEquals(so.data["foo"], "bar")
+        self.assertEqual(so.data["foo"], "bar")
         so_2 = otio.core.SerializeableObject()
         so_2.data["foo"] = "not bar"
         so.update(so_2)
-        self.assertEquals(so.data["foo"], "not bar")
+        self.assertEqual(so.data["foo"], "not bar")
 
     def test_serialize_to_error(self):
         so = otio.core.SerializeableObject()
         so.data['foo'] = 'bar'
-        self.assertRaises(
-            otio.exceptions.InvalidSerializeableLabelError,
-            lambda: otio.adapters.otio_json.write_to_string(so)
-        )
+        with self.assertRaises(otio.exceptions.InvalidSerializeableLabelError):
+            otio.adapters.otio_json.write_to_string(so)
 
     def test_copy_lib(self):
         so = otio.core.SerializeableObject()
@@ -65,19 +63,20 @@ class SerializeableObjectTest(unittest.TestCase):
         # shallow copy
         so_cp = copy.copy(so)
         so_cp.data["metadata"]["foo"] = "not bar"
-        self.assertEquals(so, so_cp)
+        self.assertEqual(so, so_cp)
 
         so.foo = "bar"
         so_cp = copy.copy(so)
         # copy only copies members of the data dictionary, *not* other attrs.
-        self.assertRaises(AttributeError, lambda: so_cp.foo)
+        with self.assertRaises(AttributeError):
+            so_cp.foo
 
         # deep copy
         so_cp = copy.deepcopy(so)
-        self.assertEquals(so, so_cp)
+        self.assertEqual(so, so_cp)
 
         so_cp.data["foo"] = "bar"
-        self.assertNotEquals(so, so_cp)
+        self.assertNotEqual(so, so_cp)
 
     def test_copy_subclass(self):
         @otio.core.register_type
@@ -91,7 +90,7 @@ class SerializeableObjectTest(unittest.TestCase):
 
         foo_copy = copy.copy(foo)
 
-        self.assertEquals(Foo, type(foo_copy))
+        self.assertEqual(Foo, type(foo_copy))
 
     def test_schema_versioning(self):
         @otio.core.register_type
@@ -100,20 +99,18 @@ class SerializeableObjectTest(unittest.TestCase):
             foo_two = otio.core.serializeable_field("foo_2", doc="test")
         ft = FakeThing()
 
-        self.assertEquals(ft.schema_name(), "Stuff")
-        self.assertEquals(ft.schema_version(), 1)
+        self.assertEqual(ft.schema_name(), "Stuff")
+        self.assertEqual(ft.schema_version(), 1)
 
-        self.assertRaises(
-            otio.exceptions.UnsupportedSchemaError,
-            lambda: otio.core.instance_from_schema(
+        with self.assertRaises(otio.exceptions.UnsupportedSchemaError):
+            otio.core.instance_from_schema(
                 "Stuff",
                 "2",
                 {"foo": "bar"}
             )
-        )
 
         ft = otio.core.instance_from_schema("Stuff", "1", {"foo": "bar"})
-        self.assertEquals(ft.data['foo'], "bar")
+        self.assertEqual(ft.data['foo'], "bar")
 
         @otio.core.register_type
         class FakeThing(otio.core.SerializeableObject):
@@ -129,13 +126,13 @@ class SerializeableObjectTest(unittest.TestCase):
             return {"foo_3": data_dict["foo_2"]}
 
         ft = otio.core.instance_from_schema("Stuff", "1", {"foo": "bar"})
-        self.assertEquals(ft.data['foo_3'], "bar")
+        self.assertEqual(ft.data['foo_3'], "bar")
 
         ft = otio.core.instance_from_schema("Stuff", "3", {"foo_2": "bar"})
-        self.assertEquals(ft.data['foo_3'], "bar")
+        self.assertEqual(ft.data['foo_3'], "bar")
 
         ft = otio.core.instance_from_schema("Stuff", "4", {"foo_3": "bar"})
-        self.assertEquals(ft.data['foo_3'], "bar")
+        self.assertEqual(ft.data['foo_3'], "bar")
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -10,19 +10,19 @@ class TimelineTests(unittest.TestCase):
     def test_init(self):
         rt = otio.opentime.RationalTime(12, 24)
         tl = otio.schema.Timeline("test_timeline", global_start_time=rt)
-        self.assertEquals(tl.name, "test_timeline")
-        self.assertEquals(tl.global_start_time, rt)
+        self.assertEqual(tl.name, "test_timeline")
+        self.assertEqual(tl.global_start_time, rt)
 
     def test_metadata(self):
         rt = otio.opentime.RationalTime(12, 24)
         tl = otio.schema.Timeline("test_timeline", global_start_time=rt)
         tl.metadata['foo'] = "bar"
-        self.assertEquals(tl.metadata['foo'], 'bar')
+        self.assertEqual(tl.metadata['foo'], 'bar')
 
         encoded = otio.adapters.otio_json.write_to_string(tl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(tl, decoded)
-        self.assertEquals(tl.metadata, decoded.metadata)
+        self.assertEqual(tl, decoded)
+        self.assertEqual(tl.metadata, decoded.metadata)
 
     def test_range(self):
         track = otio.schema.Sequence(name="test_track")
@@ -54,9 +54,9 @@ class TimelineTests(unittest.TestCase):
         tl.tracks[0].append(cl)
         tl.tracks[0].extend([cl2, cl3])
 
-        self.assertEquals(tl.duration(), rt + rt + rt)
+        self.assertEqual(tl.duration(), rt + rt + rt)
 
-        self.assertEquals(
+        self.assertEqual(
             tl.range_of_child(cl),
             tl.tracks[0].range_of_child_at_index(0)
         )
@@ -99,12 +99,12 @@ class TimelineTests(unittest.TestCase):
         )
         tl.tracks[0].append(cl)
         tl.tracks[0].extend([cl2, cl3])
-        self.assertEquals([cl, cl2, cl3], list(tl.each_clip()))
+        self.assertEqual([cl, cl2, cl3], list(tl.each_clip()))
 
         rt_start = otio.opentime.RationalTime(0, 24)
         rt_end = otio.opentime.RationalTime(1, 24)
         search_range = otio.opentime.TimeRange(rt_start, rt_end)
-        self.assertEquals([cl], list(tl.each_clip(search_range)))
+        self.assertEqual([cl], list(tl.each_clip(search_range)))
 
     def test_str(self):
         self.maxDiff = None
@@ -137,10 +137,10 @@ class TimelineTests(unittest.TestCase):
         tl = otio.schema.timeline_from_clips([clip])
         encoded = otio.adapters.otio_json.write_to_string(tl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEquals(tl, decoded)
+        self.assertEqual(tl, decoded)
 
         string2 = otio.adapters.otio_json.write_to_string(decoded)
-        self.assertEquals(encoded, string2)
+        self.assertEqual(encoded, string2)
 
     def test_serialization_of_subclasses(self):
         clip1 = otio.schema.Clip()
@@ -156,23 +156,23 @@ class TimelineTests(unittest.TestCase):
         self.assertIsNotNone(serialized)
         tl2 = otio_module.read_from_string(serialized)
         self.assertIsNotNone(tl2)
-        self.assertEquals(type(tl1), type(tl2))
-        self.assertEquals(tl1.name, tl2.name)
-        self.assertEquals(len(tl1.tracks), 1)
-        self.assertEquals(len(tl2.tracks), 1)
+        self.assertEqual(type(tl1), type(tl2))
+        self.assertEqual(tl1.name, tl2.name)
+        self.assertEqual(len(tl1.tracks), 1)
+        self.assertEqual(len(tl2.tracks), 1)
         track1 = tl1.tracks[0]
         track2 = tl2.tracks[0]
-        self.assertEquals(type(track1), type(track2))
-        self.assertEquals(len(track1), 1)
-        self.assertEquals(len(track2), 1)
+        self.assertEqual(type(track1), type(track2))
+        self.assertEqual(len(track1), 1)
+        self.assertEqual(len(track2), 1)
         clip2 = tl2.tracks[0][0]
-        self.assertEquals(clip1.name, clip2.name)
-        self.assertEquals(type(clip1), type(clip2))
-        self.assertEquals(
+        self.assertEqual(clip1.name, clip2.name)
+        self.assertEqual(type(clip1), type(clip2))
+        self.assertEqual(
             type(clip1.media_reference),
             type(clip2.media_reference)
         )
-        self.assertEquals(
+        self.assertEqual(
             clip1.media_reference.target_url,
             clip2.media_reference.target_url
         )


### PR DESCRIPTION
Some of the assertions used in the unitests are marked as [deprecated](https://docs.python.org/2/library/unittest.html#deprecated-aliases). The specific assertion fixes were:
`assertEquals` -> `assertEqual`
`assertNotEquals` -> `assertNotEqual`
`assertUnless` -> `assertTrue`
`assertRaises used` with no exception type specified

As a bonus, I also changed all usages of `assertRaises` to use the context manager form rather than passing lambdas and fixed an instance where a file handle was left open.