### PR TITLE
Make the leading asterisk optional in comments.

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -279,7 +279,7 @@ class ClipHandler(object):
 
 class CommentHandler(object):
     # this is the for that all comment 'id' tags take
-    _regex_template = '\*\s*{id}:'
+    _regex_template = '\*?\s*{id}:'
     # this should be a map of all known comments that we can read
     # 'FROM CLIP' is a required comment to link media
     comment_id_map = {


### PR DESCRIPTION
Another small fix for EDL parsing.  This makes sure that comments can be parsed for things like the shot name, even if they don't start with an asterisk.