### PR TITLE
Bugfix: Support BL events during EDL read

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -170,7 +170,7 @@ class ClipHandler(object):
 
     def __init__(self, line, comment_data):
         self._edit_num = None
-        self.reel = None
+        self._reel = None
         self.channel_code = None
         self.edl_rate = 24
         self.transition_id = None
@@ -184,7 +184,7 @@ class ClipHandler(object):
         self.clip = self._make_clip(comment_data)
 
     def _make_clip(self, comment_data):
-        if self.reel == 'BL':
+        if self._reel == 'BL':
             # TODO make this an explicit path
             # this is the only special tape name code we care about
             # AX exists but means nothing in our context. We aren't using tapes

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -154,7 +154,7 @@ class EDLAdapterTest(unittest.TestCase):
             ),
             strip_trailing_decimal_zero(
                 otio.adapters.write_to_string(
-                    tl, 
+                    tl,
                     adapter_name="otio_json"
                 )
             )


### PR DESCRIPTION
An EDL `BL` (black) reel reference will correctly evaluate to otio filler.