### PR TITLE
Bugfix: Do not add extra frame when transition covers whole shot

### DIFF
--- a/contrib/adapters/extern_rv.py
+++ b/contrib/adapters/extern_rv.py
@@ -164,6 +164,8 @@ def _write_sequence(in_seq, to_session):
     for thing in items_to_serialize:
         if isinstance(thing, tuple):
             result = _write_transition(*thing, to_session=to_session)
+        elif thing.duration().value == 0:
+            continue
         else:
             result = write_otio(thing, to_session)
 


### PR DESCRIPTION
When a transition extended to completely cover either shot, the RV adaptor was still creating a node representing the shot before or after the transition.  This added an extra frame(s) to the RV session like so:

Incorrect:
![image](https://user-images.githubusercontent.com/1740063/27411039-384dcc14-56a0-11e7-98cd-d071e98daa92.png)

Correct:
![image](https://user-images.githubusercontent.com/1740063/27411025-2ad01718-56a0-11e7-9e31-7c59b98fc59d.png)

Example extraneous node:
```
sourceGroup000000_source : RVFileSource (1)
{
    cut {
        int in = 0
        int out = 0
    }
    group  {
        float fps = 24
    }
    media  {
        string movie = "blank,start=0.0,end=0.0,fps=24.0.movieproc"
    }
}
```