### PR TITLE
Remove print statement from otiocat.

### DIFF
--- a/bin/otiocat.py
+++ b/bin/otiocat.py
@@ -36,7 +36,6 @@ def main():
     args = _parsed_args()
 
     for fpath in args.filepath:
-        print("fpath: {}".format(fpath))
         print(_cat_otio_file(fpath))
 
 


### PR DESCRIPTION
Very small commit removing a print statement from otiocat that prevents you from piping the output of otiocat.