### PR TITLE
Fix spelling of 'serializable'

### DIFF
--- a/bin/otioview.py
+++ b/bin/otioview.py
@@ -138,7 +138,7 @@ class Main(QtGui.QMainWindow):
             self.sequences_widget.setVisible(False)
         elif isinstance(
             file_contents,
-            otio.schema.SerializeableCollection
+            otio.schema.SerializableCollection
         ):
             for s in file_contents:
                 TimelineWidgetItem(s, s.name, self.sequences_widget)

--- a/doc/source/opentimelineio.core.rst
+++ b/doc/source/opentimelineio.core.rst
@@ -20,10 +20,10 @@ opentimelineio.core.item module
     :undoc-members:
     :show-inheritance:
 
-opentimelineio.core.serializeable_object module
+opentimelineio.core.serializable_object module
 -----------------------------------------------
 
-.. automodule:: opentimelineio.core.serializeable_object
+.. automodule:: opentimelineio.core.serializable_object
     :members:
     :undoc-members:
     :show-inheritance:

--- a/opentimelineio/adapters/adapter.py
+++ b/opentimelineio/adapters/adapter.py
@@ -54,7 +54,7 @@ class Adapter(plugins.PythonPlugin):
     For more information:
         https://github.com/PixarAnimationStudios/OpenTimelineIO/wiki/How-to-Write-an-OpenTimelineIO-Adapter # noqa
     """
-    _serializeable_label = "Adapter.1"
+    _serializable_label = "Adapter.1"
 
     def __init__(
         self,
@@ -74,7 +74,7 @@ class Adapter(plugins.PythonPlugin):
             suffixes = []
         self.suffixes = suffixes
 
-    suffixes = core.serializeable_field(
+    suffixes = core.serializable_field(
         "suffixes",
         type([]),
         doc="File suffixes associated with this adapter."

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -502,7 +502,7 @@ def _parse_timeline(sequence, element_map):
 
 
 def _parse_collection(sequences, element_map):
-    collection = otio.schema.SerializeableCollection(name='sequences')
+    collection = otio.schema.SerializableCollection(name='sequences')
     collection.extend([_parse_timeline(s, element_map) for s in sequences])
     return collection
 
@@ -925,7 +925,7 @@ def write_to_string(input_otio):
         children_e.append(
             _build_sequence(input_otio.tracks, timeline_range, br_map)
         )
-    elif isinstance(input_otio, otio.schema.SerializeableCollection):
+    elif isinstance(input_otio, otio.schema.SerializableCollection):
         children_e.extend(
             _build_collection(input_otio, br_map)
         )

--- a/opentimelineio/core/__init__.py
+++ b/opentimelineio/core/__init__.py
@@ -26,10 +26,10 @@
 
 # flake8: noqa
 
-from . import serializeable_object
-from .serializeable_object import (
-    SerializeableObject,
-    serializeable_field,
+from . import serializable_object
+from .serializable_object import (
+    SerializableObject,
+    serializable_field,
     deprecated_field,
 )
 from .composable import (

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -27,12 +27,12 @@
 An object that can be composed by sequences.
 """
 
-from . import serializeable_object
+from . import serializable_object
 from . import type_registry
 
 
 @type_registry.register_type
-class Composable(serializeable_object.SerializeableObject):
+class Composable(serializable_object.SerializableObject):
     """An object that can be composed by sequences.
 
     Base class of:
@@ -40,23 +40,23 @@ class Composable(serializeable_object.SerializeableObject):
         Transition
     """
 
-    name = serializeable_object.serializeable_field(
+    name = serializable_object.serializable_field(
         "name",
         doc="Composable name."
     )
-    metadata = serializeable_object.serializeable_field(
+    metadata = serializable_object.serializable_field(
         "metadata",
         doc="Metadata dictionary for this Composable."
     )
 
-    _serializeable_label = "Composable.1"
+    _serializable_label = "Composable.1"
     _class_path = "core.Composable"
 
     def __init__(self, name=None, metadata=None):
         super(Composable, self).__init__()
         self._parent = None
 
-        # initialize the serializeable fields
+        # initialize the serializable fields
         self.name = name
 
         if metadata is None:

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -27,7 +27,7 @@
 import collections
 
 from . import (
-    serializeable_object,
+    serializable_object,
     type_registry,
     item,
     composable,
@@ -47,7 +47,7 @@ class Composition(item.Item, collections.MutableSequence):
     directly.
     """
 
-    _serializeable_label = "Composition.1"
+    _serializable_label = "Composition.1"
     _composition_kind = "Composition"
     _modname = "core"
     _composable_base_class = composable.Composable
@@ -73,7 +73,7 @@ class Composition(item.Item, collections.MutableSequence):
             # extra logic (assigning ._parent pointers).
             self.extend(children)
 
-    _children = serializeable_object.serializeable_field(
+    _children = serializable_object.serializable_field(
         "children",
         list,
         "Items contained by this composition."
@@ -111,7 +111,7 @@ class Composition(item.Item, collections.MutableSequence):
             )
         )
 
-    transform = serializeable_object.deprecated_field()
+    transform = serializable_object.deprecated_field()
 
     def each_child(
         self,

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -29,7 +29,7 @@ from .. import (
 )
 
 from . import (
-    serializeable_object,
+    serializable_object,
     composable,
 )
 
@@ -47,7 +47,7 @@ class Item(composable.Composable):
         - Gap
     """
 
-    _serializeable_label = "Item.1"
+    _serializable_label = "Item.1"
     _class_path = "core.Item"
 
     def __init__(
@@ -58,7 +58,7 @@ class Item(composable.Composable):
         markers=None,
         metadata=None,
     ):
-        serializeable_object.SerializeableObject.__init__(self)
+        serializable_object.SerializableObject.__init__(self)
 
         self.name = name
         self.source_range = source_range
@@ -77,8 +77,8 @@ class Item(composable.Composable):
 
         self._parent = None
 
-    name = serializeable_object.serializeable_field("name", doc="Item name.")
-    source_range = serializeable_object.serializeable_field(
+    name = serializable_object.serializable_field("name", doc="Item name.")
+    source_range = serializable_object.serializable_field(
         "source_range",
         opentime.TimeRange,
         doc="Range of source to trim to.  Can be None or a TimeRange."
@@ -170,15 +170,15 @@ class Item(composable.Composable):
             tr.duration
         )
 
-    markers = serializeable_object.serializeable_field(
+    markers = serializable_object.serializable_field(
         "markers",
         doc="List of markers on this item."
     )
-    effects = serializeable_object.serializeable_field(
+    effects = serializable_object.serializable_field(
         "effects",
         doc="List of effects on this item."
     )
-    metadata = serializeable_object.serializeable_field(
+    metadata = serializable_object.serializable_field(
         "metadata",
         doc="Metadata dictionary for this item."
     )

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-"""Serializer for SerializeableObjects to JSON
+"""Serializer for SerializableObjects to JSON
 
 Used for the otio_json adapter as well as for plugins and manifests.
 """
@@ -30,7 +30,7 @@ Used for the otio_json adapter as well as for plugins and manifests.
 import json
 
 from . import (
-    SerializeableObject,
+    SerializableObject,
     type_registry,
 )
 
@@ -43,9 +43,9 @@ from .. import (
 # @TODO: Handle file version drifting
 
 
-class _SerializeableObjectEncoder(json.JSONEncoder):
+class _SerializableObjectEncoder(json.JSONEncoder):
 
-    """ Encoder for the SerializeableObject OTIO Class and its descendents. """
+    """ Encoder for the SerializableObject OTIO Class and its descendents. """
 
     def default(self, obj):
         for typename, encfn in _ENCODER_MAP.items():
@@ -56,12 +56,12 @@ class _SerializeableObjectEncoder(json.JSONEncoder):
 
 
 def serialize_json_to_string(root, sort_keys=True, indent=4):
-    """Serialize a tree of SerializeableObject to JSON.
+    """Serialize a tree of SerializableObject to JSON.
 
     Returns a JSON string.
     """
 
-    return _SerializeableObjectEncoder(
+    return _SerializableObjectEncoder(
         sort_keys=sort_keys,
         indent=indent
     ).encode(root)
@@ -69,7 +69,7 @@ def serialize_json_to_string(root, sort_keys=True, indent=4):
 
 def serialize_json_to_file(root, to_file):
     """
-    Serialize a tree of SerializeableObject to JSON.
+    Serialize a tree of SerializableObject to JSON.
 
     Writes the result to the given file path.
     """
@@ -82,13 +82,13 @@ def serialize_json_to_file(root, to_file):
 # @{ Encoders
 
 
-def _encoded_serializeable_object(input_otio):
-    if not input_otio._serializeable_label:
-        raise exceptions.InvalidSerializeableLabelError(
-            input_otio._serializeable_label
+def _encoded_serializable_object(input_otio):
+    if not input_otio._serializable_label:
+        raise exceptions.InvalidSerializableLabelError(
+            input_otio._serializable_label
         )
     result = {
-        "OTIO_SCHEMA": input_otio._serializeable_label,
+        "OTIO_SCHEMA": input_otio._serializable_label,
     }
     result.update(input_otio.data)
     return result
@@ -125,7 +125,7 @@ _ENCODER_MAP = {
     opentime.RationalTime: _encoded_time,
     opentime.TimeRange: _encoded_time_range,
     opentime.TimeTransform: _encoded_transform,
-    SerializeableObject: _encoded_serializeable_object,
+    SerializableObject: _encoded_serializable_object,
 }
 
 # @{ Decoders
@@ -155,7 +155,7 @@ def _decoded_transform(input_otio):
 
 # Map of explicit decoder functions to schema labels (for opentime)
 # because opentime is implemented with no knowledge of OTIO, it doesn't use the
-# same pattern as SerializeableObject.
+# same pattern as SerializableObject.
 _DECODER_FUNCTION_MAP = {
     'RationalTime.1': _decoded_time,
     'TimeRange.1': _decoded_time_range,

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-"""Implements the otio.core.SerializeableObject"""
+"""Implements the otio.core.SerializableObject"""
 
 import copy
 
@@ -31,11 +31,11 @@ from . import (
 )
 
 
-class SerializeableObject(object):
+class SerializableObject(object):
     """Base object for things that can be [de]serialized to/from .otio files.
 
     To define a new child class of this, you inherit from it and also use the
-    register_type decorator.  Then you use the serializeable_field function
+    register_type decorator.  Then you use the serializable_field function
     above to create attributes that can be serialized/deserialized.
 
     You can use the upgrade_function_for decorator to upgrade older schemas
@@ -51,10 +51,10 @@ class SerializeableObject(object):
         import opentimelineio as otio
 
         @otio.core.register_type
-        class ExampleChild(otio.core.SerializeableObject):
-            _serializeable_label = "ExampleChild.7"
+        class ExampleChild(otio.core.SerializableObject):
+            _serializable_label = "ExampleChild.7"
 
-            child_data = otio.core.serializeable_field("child_data", int)
+            child_data = otio.core.serializable_field("child_data", int)
 
             # @TODO: delete once testing shows nothing is referencing this.
             old_child_data_name = otio.core.deprecated_field()
@@ -65,13 +65,13 @@ class SerializeableObject(object):
             return {"child_data" : data["old_child_data_name"]}
     """
 
-    # Every child must define a _serializeable_label attribute.
+    # Every child must define a _serializable_label attribute.
     # This attribute is a string in the form of: "SchemaName.VersionNumber"
     # Where VersionNumber is an integer.
     # You can use the classmethods .schema_name() and .schema_version() to
     # query these fields.
-    _serializeable_label = None
-    _class_path = "core.SerializeableObject"
+    _serializable_label = None
+    _class_path = "core.SerializableObject"
 
     def __init__(self):
         self.data = {}
@@ -99,11 +99,11 @@ class SerializeableObject(object):
     def update(self, d):
         """Like the dictionary .update() method.
 
-        Update the data dictionary of this SerializeableObject with the .data
-        of d if d is a SerializeableObject or if d is a dictionary, d itself.
+        Update the data dictionary of this SerializableObject with the .data
+        of d if d is a SerializableObject or if d is a dictionary, d itself.
         """
 
-        if isinstance(d, SerializeableObject):
+        if isinstance(d, SerializableObject):
             self.data.update(d.data)
         else:
             self.data.update(d)
@@ -111,13 +111,13 @@ class SerializeableObject(object):
     @classmethod
     def schema_name(cls):
         return type_registry.schema_name_from_label(
-            cls._serializeable_label
+            cls._serializable_label
         )
 
     @classmethod
     def schema_version(cls):
         return type_registry.schema_version_from_label(
-            cls._serializeable_label
+            cls._serializable_label
         )
 
     def __copy__(self):
@@ -139,18 +139,18 @@ class SerializeableObject(object):
         return self.__deepcopy__({})
 
 
-def serializeable_field(name, required_type=None, doc=None):
-    """Create a serializeable_field for child classes of SerializeableObject.
+def serializable_field(name, required_type=None, doc=None):
+    """Create a serializable_field for child classes of SerializableObject.
 
     Convienence function for adding attributes to child classes of
-    SerializeableObject in such a way that they will be serialized/deserialized
+    SerializableObject in such a way that they will be serialized/deserialized
     automatically.
 
     Use it like this:
-        class foo(SerializeableObject):
-            bar = serializeable_field("bar", required_type=int, doc="example")
+        class foo(SerializableObject):
+            bar = serializable_field("bar", required_type=int, doc="example")
 
-    This would indicate that class "foo" has a serializeable field "bar".  So:
+    This would indicate that class "foo" has a serializable field "bar".  So:
         f = foo()
         f.bar = "stuff"
 
@@ -189,7 +189,7 @@ def serializeable_field(name, required_type=None, doc=None):
 
 
 def deprecated_field():
-    """ For marking attributes on a SerializeableObject deprecated.  """
+    """ For marking attributes on a SerializableObject deprecated.  """
 
     def getter(self):
         raise DeprecationWarning

--- a/opentimelineio/core/type_registry.py
+++ b/opentimelineio/core/type_registry.py
@@ -65,7 +65,7 @@ def register_type(classobj, schemaname=None):
     """
 
     if schemaname is None:
-        schemaname = schema_name_from_label(classobj._serializeable_label)
+        schemaname = schema_name_from_label(classobj._serializable_label)
 
     _OTIO_TYPES[schemaname] = classobj
 
@@ -81,7 +81,7 @@ def upgrade_function_for(cls, version_to_upgrade_to):
             # ...
 
     This will get called to upgrade a schema of MyClass to version 5.  My class
-    must be a class deriving from otio.core.SerializeableObject.
+    must be a class deriving from otio.core.SerializableObject.
 
     The upgrade function should take a single argument - the dictionary to
     upgrade, and return a dictionary with the fields upgraded.

--- a/opentimelineio/exceptions.py
+++ b/opentimelineio/exceptions.py
@@ -49,7 +49,7 @@ class NotSupportedError(OTIOError):
     pass
 
 
-class InvalidSerializeableLabelError(OTIOError):
+class InvalidSerializableLabelError(OTIOError):
     pass
 
 

--- a/opentimelineio/media_linker.py
+++ b/opentimelineio/media_linker.py
@@ -129,7 +129,7 @@ def linked_media_reference(
 
 @core.register_type
 class MediaLinker(plugins.PythonPlugin):
-    _serializeable_label = "MediaLinker.1"
+    _serializable_label = "MediaLinker.1"
 
     def __init__(
         self,

--- a/opentimelineio/media_reference.py
+++ b/opentimelineio/media_reference.py
@@ -31,7 +31,7 @@ from . import (
 
 
 @core.register_type
-class MediaReference(core.SerializeableObject):
+class MediaReference(core.SerializableObject):
     """Base Media Reference Class.
 
     Currently handles string printing the child classes, which expose interface
@@ -40,7 +40,7 @@ class MediaReference(core.SerializeableObject):
     The requirement is that the schema is named so that external systems can
     fetch the required information correctly.
     """
-    _serializeable_label = "MediaReference.1"
+    _serializable_label = "MediaReference.1"
     _name = "MediaReference"
 
     def __init__(
@@ -49,7 +49,7 @@ class MediaReference(core.SerializeableObject):
         available_range=None,
         metadata=None
     ):
-        core.SerializeableObject.__init__(self)
+        core.SerializableObject.__init__(self)
 
         self.name = name
         self.available_range = available_range
@@ -58,16 +58,16 @@ class MediaReference(core.SerializeableObject):
             metadata = {}
         self.metadata = metadata
 
-    name = core.serializeable_field(
+    name = core.serializable_field(
         "name",
         doc="Name of this media reference."
     )
-    available_range = core.serializeable_field(
+    available_range = core.serializable_field(
         "available_range",
         opentime.TimeRange,
         doc="Available range of media in this media reference."
     )
-    metadata = core.serializeable_field(
+    metadata = core.serializable_field(
         "metadata",
         dict,
         doc="Metadata dictionary."
@@ -112,7 +112,7 @@ class MediaReference(core.SerializeableObject):
 class MissingReference(MediaReference):
     """Represents media for which a concrete reference is missing."""
 
-    _serializeable_label = "MissingReference.1"
+    _serializable_label = "MissingReference.1"
     _name = "MissingReference"
 
     @property
@@ -124,7 +124,7 @@ class MissingReference(MediaReference):
 class External(MediaReference):
     """Reference to media via a url, for example "file:///var/tmp/foo.mov" """
 
-    _serializeable_label = "ExternalReference.1"
+    _serializable_label = "ExternalReference.1"
     _name = "External"
 
     def __init__(
@@ -141,7 +141,7 @@ class External(MediaReference):
 
         self.target_url = target_url
 
-    target_url = core.serializeable_field(
+    target_url = core.serializable_field(
         "target_url",
         doc=(
             "URL at which this media lives.  For local references, use the "

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -42,7 +42,7 @@ def manifest_from_file(filepath):
 
 
 @core.register_type
-class Manifest(core.SerializeableObject):
+class Manifest(core.SerializableObject):
     """Defines an OTIO plugin Manifest.
 
     This is an internal OTIO implementation detail.  A manifest tracks a
@@ -51,20 +51,20 @@ class Manifest(core.SerializeableObject):
     For writing your own adapters, consult:
         https://github.com/PixarAnimationStudios/OpenTimelineIO/wiki/How-to-Write-an-OpenTimelineIO-Adapter
     """
-    _serializeable_label = "PluginManifest.1"
+    _serializable_label = "PluginManifest.1"
 
     def __init__(self):
-        core.SerializeableObject.__init__(self)
+        core.SerializableObject.__init__(self)
         self.adapters = []
         self.media_linkers = []
         self.source_files = []
 
-    adapters = core.serializeable_field(
+    adapters = core.serializable_field(
         "adapters",
         type([]),
         "Adapters this manifest describes."
     )
-    media_linkers = core.serializeable_field(
+    media_linkers = core.serializable_field(
         "media_linkers",
         type([]),
         "Media Linkers this manifest describes."

--- a/opentimelineio/plugins/python_plugin.py
+++ b/opentimelineio/plugins/python_plugin.py
@@ -33,12 +33,12 @@ from .. import (
 )
 
 
-class PythonPlugin(core.SerializeableObject):
+class PythonPlugin(core.SerializableObject):
     """A class of plugin that is encoded in a python module, exposed via a
     manifest.
     """
 
-    _serializeable_label = "PythonPlugin.1"
+    _serializable_label = "PythonPlugin.1"
 
     def __init__(
         self,
@@ -46,15 +46,15 @@ class PythonPlugin(core.SerializeableObject):
         execution_scope=None,
         filepath=None,
     ):
-        core.SerializeableObject.__init__(self)
+        core.SerializableObject.__init__(self)
         self.name = name
         self.execution_scope = execution_scope
         self.filepath = filepath
         self._json_path = None
         self._module = None
 
-    name = core.serializeable_field("name", str, "Adapter name.")
-    execution_scope = core.serializeable_field(
+    name = core.serializable_field("name", str, "Adapter name.")
+    execution_scope = core.serializable_field(
         "execution_scope",
         str,
         doc=(
@@ -63,7 +63,7 @@ class PythonPlugin(core.SerializeableObject):
             "['in process', 'out of process']."
         )
     )
-    filepath = core.serializeable_field(
+    filepath = core.serializable_field(
         "filepath",
         str,
         doc=(

--- a/opentimelineio/schema/__init__.py
+++ b/opentimelineio/schema/__init__.py
@@ -55,6 +55,6 @@ from .transition import (
     Transition,
     TransitionTypes,
 )
-from .serializeable_collection import (
-    SerializeableCollection
+from .serializable_collection import (
+    SerializableCollection
 )

--- a/opentimelineio/schema/clip.py
+++ b/opentimelineio/schema/clip.py
@@ -38,7 +38,7 @@ class Clip(core.Item):
     Contains a media reference and a trim on that media reference.
     """
 
-    _serializeable_label = "Clip.1"
+    _serializable_label = "Clip.1"
 
     def __init__(
         self,
@@ -61,9 +61,9 @@ class Clip(core.Item):
             media_reference = mr.MissingReference()
         self._media_reference = media_reference
 
-    name = core.serializeable_field("name", doc="Name of this clip.")
+    name = core.serializable_field("name", doc="Name of this clip.")
     transform = core.deprecated_field()
-    _media_reference = core.serializeable_field(
+    _media_reference = core.serializable_field(
         "media_reference",
         mr.MediaReference,
         "Media reference to the media this clip represents."

--- a/opentimelineio/schema/effect.py
+++ b/opentimelineio/schema/effect.py
@@ -30,8 +30,8 @@ from .. import (
 
 
 @core.register_type
-class Effect(core.SerializeableObject):
-    _serializeable_label = "Effect.1"
+class Effect(core.SerializableObject):
+    _serializable_label = "Effect.1"
 
     def __init__(
         self,
@@ -39,7 +39,7 @@ class Effect(core.SerializeableObject):
         effect_name=None,
         metadata=None
     ):
-        core.SerializeableObject.__init__(self)
+        core.SerializableObject.__init__(self)
         self.name = name
         self.effect_name = effect_name
 
@@ -48,15 +48,15 @@ class Effect(core.SerializeableObject):
         self.metadata = metadata
         self.metadata = metadata
 
-    name = core.serializeable_field(
+    name = core.serializable_field(
         "name",
         doc="Name of this effect object. Example: 'BlurByHalfEffect'."
     )
-    effect_name = core.serializeable_field(
+    effect_name = core.serializable_field(
         "effect_name",
         doc="Name of the kind of effect (example: 'Blur', 'Crop', 'Flip')."
     )
-    metadata = core.serializeable_field(
+    metadata = core.serializable_field(
         "metadata",
         dict,
         doc="Metadata dictionary."

--- a/opentimelineio/schema/gap.py
+++ b/opentimelineio/schema/gap.py
@@ -29,7 +29,7 @@ from .. import core
 
 @core.register_type
 class Gap(core.Item):
-    _serializeable_label = "Gap.1"
+    _serializable_label = "Gap.1"
     _class_path = "schema.Gap"
 
     @staticmethod

--- a/opentimelineio/schema/marker.py
+++ b/opentimelineio/schema/marker.py
@@ -47,11 +47,11 @@ class MarkerColor:
 
 
 @core.register_type
-class Marker(core.SerializeableObject):
+class Marker(core.SerializableObject):
 
     """ Holds metadata over time on a timeline """
 
-    _serializeable_label = "Marker.2"
+    _serializable_label = "Marker.2"
     _class_path = "marker.Marker"
 
     def __init__(
@@ -61,7 +61,7 @@ class Marker(core.SerializeableObject):
         color=MarkerColor.RED,
         metadata=None,
     ):
-        core.SerializeableObject.__init__(
+        core.SerializableObject.__init__(
             self,
         )
         self.name = name
@@ -72,15 +72,15 @@ class Marker(core.SerializeableObject):
             metadata = {}
         self.metadata = metadata
 
-    name = core.serializeable_field("name", str, "Name of this marker.")
+    name = core.serializable_field("name", str, "Name of this marker.")
 
-    marked_range = core.serializeable_field(
+    marked_range = core.serializable_field(
         "marked_range",
         opentime.TimeRange,
         "Range this marker applies to."
     )
 
-    color = core.serializeable_field(
+    color = core.serializable_field(
         "color",
         required_type=type(MarkerColor.RED),
         doc="Color string for this marker (for example: 'RED'), based on the "
@@ -90,7 +90,7 @@ class Marker(core.SerializeableObject):
     # old name
     range = core.deprecated_field()
 
-    metadata = core.serializeable_field(
+    metadata = core.serializable_field(
         "metadata",
         dict,
         "Metadata dictionary."

--- a/opentimelineio/schema/sequence.py
+++ b/opentimelineio/schema/sequence.py
@@ -49,7 +49,7 @@ class NeighborGapPolicy:
 
 @core.register_type
 class Sequence(core.Composition):
-    _serializeable_label = "Sequence.1"
+    _serializable_label = "Sequence.1"
     _composition_kind = "Sequence"
     _modname = "schema"
 
@@ -70,7 +70,7 @@ class Sequence(core.Composition):
         )
         self.kind = kind
 
-    kind = core.serializeable_field(
+    kind = core.serializable_field(
         "kind",
         doc="Composition kind (Stack, Sequence)"
     )

--- a/opentimelineio/schema/serializable_collection.py
+++ b/opentimelineio/schema/serializable_collection.py
@@ -116,6 +116,8 @@ class SerializableCollection(
         del self._children[item]
     # @}
 
-# the original name for "SerializableCollection" was "SerializeableCollection" -
-# this will turn this misspelling found in OTIO files into the correct instance automatically.
+
+# the original name for "SerializableCollection" was "SerializeableCollection"
+# this will turn this misspelling found in OTIO files into the correct instance
+# automatically.
 core.register_type(SerializableCollection, 'SerializeableCollection')

--- a/opentimelineio/schema/serializable_collection.py
+++ b/opentimelineio/schema/serializable_collection.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-"""A serializeable collection of SerializeableObjects."""
+"""A serializable collection of SerializableObjects."""
 
 import collections
 
@@ -32,19 +32,19 @@ from .. import (
 
 
 @core.register_type
-class SerializeableCollection(
-    core.SerializeableObject,
+class SerializableCollection(
+    core.SerializableObject,
     collections.MutableSequence
 ):
-    """A kind of composition which can hold any serializeable object.
+    """A kind of composition which can hold any serializable object.
 
     This composition approximates the concept of a `bin` - a collection of
-    SerializeableObjects that do not have any compositing meaning, but can
+    SerializableObjects that do not have any compositing meaning, but can
     serialize to/from OTIO correctly, with metadata and a named collection.
     """
 
-    _serializeable_label = "SerializeableCollection.1"
-    _class_path = "schema.SerializeableCollection"
+    _serializable_label = "SerializableCollection.1"
+    _class_path = "schema.SerializableCollection"
 
     def __init__(
         self,
@@ -52,7 +52,7 @@ class SerializeableCollection(
         children=None,
         metadata=None,
     ):
-        core.SerializeableObject.__init__(self)
+        core.SerializableObject.__init__(self)
 
         self.name = name
         self._children = []
@@ -60,25 +60,25 @@ class SerializeableCollection(
             self._children = children
         self.metadata = metadata
 
-    name = core.serializeable_field(
+    name = core.serializable_field(
         "name",
         str,
-        doc="SerializeableCollection name."
+        doc="SerializableCollection name."
     )
-    _children = core.serializeable_field(
+    _children = core.serializable_field(
         "children",
         list,
-        "SerializeableObject contained by this container."
+        "SerializableObject contained by this container."
     )
-    metadata = core.serializeable_field(
+    metadata = core.serializable_field(
         "metadata",
         dict,
-        doc="Metadata dictionary for this SerializeableCollection."
+        doc="Metadata dictionary for this SerializableCollection."
     )
 
     # @{ Stringification
     def __str__(self):
-        return "SerializeableCollection({}, {}, {})".format(
+        return "SerializableCollection({}, {}, {})".format(
             str(self.name),
             str(self._children),
             str(self.metadata)

--- a/opentimelineio/schema/serializable_collection.py
+++ b/opentimelineio/schema/serializable_collection.py
@@ -115,3 +115,7 @@ class SerializableCollection(
     def __delitem__(self, item):
         del self._children[item]
     # @}
+
+# the original name for "SerializableCollection" was "SerializeableCollection" -
+# this will turn this misspelling found in OTIO files into the correct instance automatically.
+core.register_type(SerializableCollection, 'SerializeableCollection')

--- a/opentimelineio/schema/stack.py
+++ b/opentimelineio/schema/stack.py
@@ -37,7 +37,7 @@ from . import (
 
 @core.register_type
 class Stack(core.Composition):
-    _serializeable_label = "Stack.1"
+    _serializable_label = "Stack.1"
     _composition_kind = "Stack"
     _modname = "schema"
 

--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -33,8 +33,8 @@ from . import stack, sequence
 
 
 @core.register_type
-class Timeline(core.SerializeableObject):
-    _serializeable_label = "Timeline.1"
+class Timeline(core.SerializableObject):
+    _serializable_label = "Timeline.1"
 
     def __init__(
         self,
@@ -43,7 +43,7 @@ class Timeline(core.SerializeableObject):
         global_start_time=None,
         metadata=None,
     ):
-        core.SerializeableObject.__init__(self)
+        core.SerializableObject.__init__(self)
         self.name = name
         if global_start_time is None:
             global_start_time = opentime.RationalTime(0, 24)
@@ -57,13 +57,13 @@ class Timeline(core.SerializeableObject):
             metadata = {}
         self.metadata = metadata
 
-    name = core.serializeable_field("name", doc="Name of this timeline.")
-    tracks = core.serializeable_field(
+    name = core.serializable_field("name", doc="Name of this timeline.")
+    tracks = core.serializable_field(
         "tracks",
         core.Composition,
         doc="Stack of sequences containing items."
     )
-    metadata = core.serializeable_field(
+    metadata = core.serializable_field(
         "metadata",
         dict,
         "Metadata dictionary."

--- a/opentimelineio/schema/transition.py
+++ b/opentimelineio/schema/transition.py
@@ -53,7 +53,7 @@ class TransitionTypes:
 class Transition(core.Composable):
     """Represents a transition between two items."""
 
-    _serializeable_label = "Transition.1"
+    _serializable_label = "Transition.1"
 
     def __init__(
         self,
@@ -81,22 +81,22 @@ class Transition(core.Composable):
         self.in_offset = in_offset
         self.out_offset = out_offset
 
-    transition_type = core.serializeable_field(
+    transition_type = core.serializable_field(
         "transition_type",
         required_type=type(TransitionTypes.SMPTE_Dissolve),
         doc="Kind of transition, as defined by the "
         "schema.transition.TransitionTypes enum."
     )
-    # parameters = core.serializeable_field(
+    # parameters = core.serializable_field(
     #     "parameters",
     #     doc="Parameters of the transition."
     # )
-    in_offset = core.serializeable_field(
+    in_offset = core.serializable_field(
         "in_offset",
         required_type=opentime.RationalTime,
         doc="Amount of the previous clip this transition overlaps, exclusive."
     )
-    out_offset = core.serializeable_field(
+    out_offset = core.serializable_field(
         "out_offset",
         required_type=opentime.RationalTime,
         doc="Amount of the next clip this transition overlaps, exclusive."

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -429,7 +429,7 @@ class StackScene(QtGui.QGraphicsScene):
 class StackView(QtGui.QGraphicsView):
 
     open_stack = QtCore.Signal(otio.schema.Stack)
-    selection_changed = QtCore.Signal(otio.core.SerializeableObject)
+    selection_changed = QtCore.Signal(otio.core.SerializableObject)
 
     def __init__(self, stack, *args, **kwargs):
         super(StackView, self).__init__(*args, **kwargs)
@@ -477,7 +477,7 @@ class StackView(QtGui.QGraphicsView):
 
 class Timeline(QtGui.QTabWidget):
 
-    selection_changed = QtCore.Signal(otio.core.SerializeableObject)
+    selection_changed = QtCore.Signal(otio.core.SerializableObject)
 
     def __init__(self, *args, **kwargs):
         super(Timeline, self).__init__(*args, **kwargs)

--- a/tests/baselines/empty_serializable_collection.json
+++ b/tests/baselines/empty_serializable_collection.json
@@ -1,5 +1,5 @@
 {
-    "OTIO_SCHEMA" : "SerializeableCollection.1",
+    "OTIO_SCHEMA" : "SerializableCollection.1",
     "metadata" : {
         "foo":"bar"
     },

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -70,7 +70,7 @@ class GapTester(unittest.TestCase):
 
     def test_convert_from_filler(self):
         gp = otio.schema.Gap()
-        gp._serializeable_label = "Filler.1"
+        gp._serializable_label = "Filler.1"
         encoded = otio.adapters.otio_json.write_to_string(gp)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         isinstance(decoded, otio.schema.Gap)

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -126,12 +126,12 @@ class TestJsonFormat(unittest.TestCase):
         trx = otio.schema.Transition()
         self.check_against_baseline(trx, "empty_transition")
 
-    def test_serializeable_collection(self):
-        tr = otio.schema.SerializeableCollection(
+    def test_serializable_collection(self):
+        tr = otio.schema.SerializableCollection(
             name="test",
             metadata={"foo": "bar"}
         )
-        self.check_against_baseline(tr, "empty_serializeable_collection")
+        self.check_against_baseline(tr, "empty_serializable_collection")
 
 
 if __name__ == '__main__':

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -27,14 +27,14 @@ import unittest
 import opentimelineio as otio
 
 
-class SerializeableCollectionTests(unittest.TestCase):
+class SerializableCollectionTests(unittest.TestCase):
     def setUp(self):
         self.children = [
             otio.schema.Clip(name="testClip"),
             otio.media_reference.MissingReference()
         ]
         self.md = {'foo': 'bar'}
-        self.sc = otio.schema.SerializeableCollection(
+        self.sc = otio.schema.SerializableCollection(
             name="test",
             children=self.children,
             metadata=self.md
@@ -58,7 +58,7 @@ class SerializeableCollectionTests(unittest.TestCase):
     def test_str(self):
         self.assertMultiLineEqual(
             str(self.sc),
-            "SerializeableCollection(" +
+            "SerializableCollection(" +
             str(self.sc.name) + ", " +
             str(self.sc._children) + ", " +
             str(self.sc.metadata) +
@@ -68,7 +68,7 @@ class SerializeableCollectionTests(unittest.TestCase):
     def test_repr(self):
         self.assertMultiLineEqual(
             repr(self.sc),
-            "otio.schema.SerializeableCollection(" +
+            "otio.schema.SerializableCollection(" +
             "name=" + repr(self.sc.name) + ", " +
             "children=" + repr(self.sc._children) + ", " +
             "metadata=" + repr(self.sc.metadata) +

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -47,37 +47,37 @@ class OpenTimeTypeSerializerTest(unittest.TestCase):
         self.assertEqual(tt, decoded)
 
 
-class SerializeableObjectTest(unittest.TestCase):
+class SerializableObjectTest(unittest.TestCase):
 
     def test_cons(self):
-        so = otio.core.SerializeableObject()
+        so = otio.core.SerializableObject()
         so.data['foo'] = 'bar'
         self.assertEqual(so.data['foo'], 'bar')
 
     def test_hash(self):
-        so = otio.core.SerializeableObject()
+        so = otio.core.SerializableObject()
         so.data['foo'] = 'bar'
-        so_2 = otio.core.SerializeableObject()
+        so_2 = otio.core.SerializableObject()
         so_2.data['foo'] = 'bar'
         self.assertEqual(hash(so), hash(so_2))
 
     def test_update(self):
-        so = otio.core.SerializeableObject()
+        so = otio.core.SerializableObject()
         so.update({"foo": "bar"})
         self.assertEqual(so.data["foo"], "bar")
-        so_2 = otio.core.SerializeableObject()
+        so_2 = otio.core.SerializableObject()
         so_2.data["foo"] = "not bar"
         so.update(so_2)
         self.assertEqual(so.data["foo"], "not bar")
 
     def test_serialize_to_error(self):
-        so = otio.core.SerializeableObject()
+        so = otio.core.SerializableObject()
         so.data['foo'] = 'bar'
-        with self.assertRaises(otio.exceptions.InvalidSerializeableLabelError):
+        with self.assertRaises(otio.exceptions.InvalidSerializableLabelError):
             otio.adapters.otio_json.write_to_string(so)
 
     def test_copy_lib(self):
-        so = otio.core.SerializeableObject()
+        so = otio.core.SerializableObject()
         so.data["metadata"] = {"foo": "bar"}
 
         import copy
@@ -102,8 +102,8 @@ class SerializeableObjectTest(unittest.TestCase):
 
     def test_copy_subclass(self):
         @otio.core.register_type
-        class Foo(otio.core.SerializeableObject):
-            _serializeable_label = "Foo.1"
+        class Foo(otio.core.SerializableObject):
+            _serializable_label = "Foo.1"
 
         foo = Foo()
         foo.data["metadata"] = {"foo": "bar"}
@@ -116,9 +116,9 @@ class SerializeableObjectTest(unittest.TestCase):
 
     def test_schema_versioning(self):
         @otio.core.register_type
-        class FakeThing(otio.core.SerializeableObject):
-            _serializeable_label = "Stuff.1"
-            foo_two = otio.core.serializeable_field("foo_2", doc="test")
+        class FakeThing(otio.core.SerializableObject):
+            _serializable_label = "Stuff.1"
+            foo_two = otio.core.serializable_field("foo_2", doc="test")
         ft = FakeThing()
 
         self.assertEqual(ft.schema_name(), "Stuff")
@@ -135,9 +135,9 @@ class SerializeableObjectTest(unittest.TestCase):
         self.assertEqual(ft.data['foo'], "bar")
 
         @otio.core.register_type
-        class FakeThing(otio.core.SerializeableObject):
-            _serializeable_label = "Stuff.4"
-            foo_two = otio.core.serializeable_field("foo_2")
+        class FakeThing(otio.core.SerializableObject):
+            _serializable_label = "Stuff.4"
+            foo_two = otio.core.serializable_field("foo_2")
 
         @otio.core.upgrade_function_for(FakeThing, 2)
         def upgrade_one_to_two(data_dict):


### PR DESCRIPTION
Before development and integration of OTIO gets too far along, I thought we might want to fix the spelling of this. Feel free to reject and keep it as it currently is, it was only a quick refactor. I ran all tests and everything is passing.