### PR TITLE
FFMPEG Burnins adapter

### DIFF
--- a/contrib/adapters/contrib_adapters.plugin_manifest.json
+++ b/contrib/adapters/contrib_adapters.plugin_manifest.json
@@ -21,6 +21,13 @@
             "execution_scope" : "in process",
             "filepath" : "maya_sequencer.py",
             "suffixes" : ["ma","mb"]
+        },
+        {
+            "OTIO_SCHEMA" : "Adapter.1",
+            "name" : "ffmpeg_burnins",
+            "execution_scope" : "in process",
+            "filepath" : "ffmpeg_burnins_adapter.py",
+            "suffixes" : []
         }
     ]
 }

--- a/contrib/adapters/ffmpeg_burnins.py
+++ b/contrib/adapters/ffmpeg_burnins.py
@@ -1,0 +1,403 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+"""
+This module provides an interface to allow users to easily
+build out an FFMPEG command with all the correct filters
+for applying text (with a background) to the rendered media.
+"""
+import os
+import sys
+import json
+from enum import Enum
+from subprocess import Popen, PIPE
+from PIL import ImageFont
+
+
+class Command(Enum):
+    """
+    Command preset strings for ffmpeg/ffprobe
+    """
+    FFMPEG = ('ffmpeg -loglevel panic -i %(input)s '
+              '%(filters)s %(args)s%(output)s')
+    FFPROBE = ('ffprobe -v quiet -print_format json -show_format '
+               '-show_streams %(source)s')
+    DRAWBOX = 'drawbox=%(x)d:%(y)d:%(w)d:%(h)d:%(color)s@%(opacity).1f:t=max'
+    DRAWTEXT = ("drawtext=text='%(text)s':x=%(x)s:y=%(y)s:fontcolor="
+                "%(color)s@%(opacity).1f:fontsize=%(size)d:fontfile=%(font)s")
+
+
+def _system_font():
+    """
+    attempts to determine a default system font
+
+    :rtype: str
+    """
+    if sys.platform.startswith('win') or sys.platform.startswith('cygwin'):
+        font_path = os.path.join(os.environ['WINDIR'], 'Fonts')
+        fonts = ('arial.ttf', 'calibri.ttf', 'times.ttf')
+    elif sys.platform.startswith('darwin'):
+        font_path = '/System/Library/Fonts'
+        fonts = ('ArialHB.ttc', 'Menlo.ttc')
+    else:
+        raise OSError("TODO: Linux font support missing.")
+
+    system_font = None
+    for font in fonts:
+        font = os.path.join(font_path, font)
+        if os.path.exists(font):
+            system_font = font
+            break
+    else:
+        raise OSError("Could not determine system font.")
+
+    return system_font
+
+
+class Default(Enum):
+    """
+    Default values. Users should modify these to fit their
+    own preferences, especially the font file."
+    """
+    FONT = _system_font()
+    FONT_SIZE = 16
+    FONT_COLOR = 'white'
+    BG_COLOR = 'black'
+    BG_PADDING = 5
+
+
+class Align(Enum):
+    """
+    Valid aligment parameters. Users should use this class
+    and not try to pass in their own custom values when
+    defining the alignment to use.
+    """
+    TOP_CENTERED = 0x0
+    BOTTOM_CENTERED = 0x1
+    TOP_LEFT = 0x2
+    BOTTOM_LEFT = 0x3
+    TOP_RIGHT = 0x4
+    BOTTOM_RIGHT = 0x5
+
+
+class Options(dict):
+    """
+    Base options class.
+    """
+    _params = {
+        'opacity': 1,
+        'x_offset': 0,
+        'y_offset': 0,
+        'font': Default.FONT.value,
+        'font_size': Default.FONT_SIZE.value,
+        'bg_color': Default.BG_COLOR.value,
+        'bg_padding': Default.BG_PADDING.value,
+        'font_color': Default.FONT_COLOR.value
+    }
+
+    def __init__(self, **kwargs):
+        super(Options, self).__init__()
+        params = self._params.copy()
+        params.update(kwargs)
+        super(Options, self).update(**params)
+
+    def __setitem__(self, key, value):
+        if key not in self._params:
+            raise KeyError("Not a valid option key '%s'" % key)
+        super(Options, self).update({key: value})
+
+
+class FrameNumberOptions(Options):
+    """
+    :key int frame_offset: offset the frame numbers
+    :key float opacity: opacity value (0-1)
+    :key str expression: expression that would be used instead of text
+    :key bool x_offset: X position offset
+                         (does not apply to centered alignments)
+    :key bool y_offset: Y position offset
+    :key str font: path to the font file
+    :key int font_size: size to render the font in
+    :key str bg_color: background color of the box
+    :key int bg_padding: padding between the font and box
+    :key str font_color: color to render
+    """
+
+    def __init__(self, **kwargs):
+        self._params.update({
+            'frame_offset': 0,
+            'expression': None
+        })
+        super(FrameNumberOptions, self).__init__(**kwargs)
+
+
+class TextOptions(Options):
+    """
+    :key float opacity: opacity value (0-1)
+    :key str expression: expression that would be used instead of text
+    :key bool x_offset: X position offset
+                        (does not apply to centered alignments)
+    :key bool y_offset: Y position offset
+    :key str font: path to the font file
+    :key int font_size: size to render the font in
+    :key str bg_color: background color of the box
+    :key int bg_padding: padding between the font and box
+    :key str font_color: color to render
+    """
+
+
+class Burnins(object):
+    """
+    Class that provides convenience API for building filter
+    flags for the FFMPEG command.
+    """
+
+    def __init__(self, source):
+        """
+        :param str source: source media file
+        """
+        self.source = source
+        self.filters = {
+            'drawbox': [],
+            'drawtext': []
+        }
+        self._streams = _streams(self.source)
+
+    def __repr__(self):
+        return '<Overlayout - %s>' % os.path.basename(self.source)
+
+    @property
+    def start_frame(self):
+        """
+        :rtype: int
+        """
+        start_time = float(self._video_stream['start_time'])
+        return round(start_time * self.frame_rate)
+
+    @property
+    def end_frame(self):
+        """
+        :rtype: int
+        """
+        end_time = float(self._video_stream['duration'])
+        return round(end_time * self.frame_rate)
+
+    @property
+    def frame_rate(self):
+        """
+        :rtype: int
+        """
+        data = self._video_stream
+        return int(data['r_frame_rate'].split('/')[0])
+
+    @property
+    def _video_stream(self):
+        video_stream = None
+        for each in self._streams:
+            if each.get('codec_type') == 'video':
+                video_stream = each
+                break
+        else:
+            raise RuntimeError("Failed to locate video stream "
+                               "from '%s'" % self.source)
+        return video_stream
+
+    @property
+    def resolution(self):
+        """
+        :rtype: (int, int)
+        """
+        data = self._video_stream
+        return data['width'], data['height']
+
+    @property
+    def filter_string(self):
+        """
+        Generates the filter string that would be applied
+        to the `-vf` argument
+
+        :rtype: str
+        """
+        return ','.join(self.filters['drawbox'] +
+                        self.filters['drawtext'])
+
+    def add_frame_numbers(self, align, options=None):
+        """
+        Convenience method to create the frame number expression.
+
+        :param enum align: alignment, must use provided enum flags
+        :param dict options: recommended to use FrameNumberOptions
+        """
+        options = options or FrameNumberOptions()
+        options['expression'] = r'%%{eif\:n+%d\:d}' % options['frame_offset']
+        text = str(int(self.end_frame + options['frame_offset']))
+        self._add_overlay(text, align, options)
+
+    def add_text(self, text, align, options=None):
+        """
+        Adding static text to a filter.
+
+        :param str text: text to apply to the drawtext
+        :param enum align: alignment, must use provided enum flags
+        :param dict options: recommended to use TextOptions
+        """
+        options = options or TextOptions()
+        self._add_overlay(text, align, options)
+
+    def _add_overlay(self, text, align, options):
+        """
+        Generic method for building the filter flags.
+
+        :param str text: text to apply to the drawtext
+        :param enum align: alignment, must use provided enum flags
+        :param dict options:
+        """
+        ifont = ImageFont.truetype(options['font'],
+                                   options['font_size'])
+        bg_size = ifont.getsize(text)
+        data = {
+            'w': bg_size[0]+options['bg_padding'],
+            'h': bg_size[1]+(options['bg_padding']/2),
+            'color': options['bg_color'],
+            'opacity': options['opacity']
+        }
+        resolution = self.resolution
+        data.update(_drawbox(align, resolution,
+                             bg_size,
+                             [options['x_offset'],
+                              options['y_offset']]))
+        self.filters['drawbox'].append(Command.DRAWBOX.value % data)
+
+        data = {
+            'text': options.get('expression') or text,
+            'color': options['font_color'],
+            'size': options['font_size'],
+            'font': options['font'],
+            'opacity': options['opacity']
+        }
+        data.update(_drawtext(align, resolution,
+                              bg_size,
+                              [options['x_offset'],
+                               options['y_offset']],
+                              options['bg_padding']))
+        self.filters['drawtext'].append(Command.DRAWTEXT.value % data)
+
+    def command(self, output=None, args=None, overwrite=False):
+        """
+        Generate the entire FFMPEG command.
+
+        :param str output: output file
+        :param str args: additional FFMPEG arguments
+        :param bool overwrite: overwrite the output if it exists
+        :returns: completed command
+        :rtype: str
+        """
+        output = output or ''
+        if overwrite:
+            output = '-y %s' % output
+        return (Command.FFMPEG.value % {
+            'input': self.source,
+            'output': output,
+            'args': '%s ' % args if args else '',
+            'filters': '-vf "%s"' % self.filter_string
+        }).strip()
+
+    def render(self, output, args=None, overwrite=False):
+        """
+        Render the media to a specified destination.
+
+        :param str output: output file
+        :param str args: additional FFMPEG arguments
+        :param bool overwrite: overwrite the output if it exists
+        """
+        if not overwrite and os.path.exists(output):
+            raise RuntimeError("Destination '%s' exists, please "
+                               "use overwrite" % output)
+        command = self.command(output=output,
+                               args=args,
+                               overwrite=overwrite)
+        proc = Popen(command, shell=True)
+        proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError("Failed to render '%s': %s'"
+                               % (output, command))
+        if not os.path.exists(output):
+            raise RuntimeError("Failed to generate '%s'" % output)
+
+
+def _streams(source):
+    """
+    :param str source: source media file
+    :rtype: [{}, ...]
+    """
+    command = Command.FFPROBE.value % {'source': source}
+    proc = Popen(command, shell=True, stdout=PIPE)
+    out = proc.communicate()[0]
+    if proc.returncode != 0:
+        raise RuntimeError("Failed to run: %s" % command)
+    return json.loads(out)['streams']
+
+
+def _drawbox(align, resolution, bg_size, offset):
+    """
+    :rtype: {'x': int, 'y': int}
+    """
+    x_pos = 0
+    if align in (Align.TOP_CENTERED, Align.BOTTOM_CENTERED):
+        x_pos = (resolution[0] - bg_size[0]) / 2
+    elif align in (Align.TOP_LEFT, Align.BOTTOM_LEFT):
+        x_pos = offset[0]
+    elif align in (Align.TOP_RIGHT, Align.BOTTOM_RIGHT):
+        x_pos = resolution[0] - (bg_size[0] + offset[0])
+    else:
+        raise RuntimeError("Unknown alignment '%s'" % str(align))
+
+    y_pos = 0
+    if align in (Align.BOTTOM_CENTERED,
+                 Align.BOTTOM_LEFT,
+                 Align.BOTTOM_RIGHT):
+        y_pos = resolution[1] - bg_size[1]
+        offset[1] *= -1
+    return {'x': x_pos, 'y': y_pos + offset[1]}
+
+
+def _drawtext(align, resolution, bg_size, offset, padding):
+    """
+    :rtype: {'x': int, 'y': int}
+    """
+    x_pos = '0'
+    if align in (Align.TOP_CENTERED, Align.BOTTOM_CENTERED):
+        x_pos = 'w/2-tw/2+%d' % (padding/2)
+    elif align in (Align.TOP_RIGHT, Align.BOTTOM_RIGHT):
+        x_pos = resolution[0] - (bg_size[0] + offset[0])
+        x_pos += (padding/2)
+    elif align in (Align.TOP_LEFT, Align.BOTTOM_LEFT):
+        x_pos = offset[0]
+        x_pos += (padding/2)
+
+    if align in (Align.TOP_CENTERED,
+                 Align.TOP_RIGHT,
+                 Align.TOP_LEFT):
+        y_pos = '%d' % (offset[1] + padding)
+    else:
+        y_pos = 'h-text_h-%d' % (offset[1] + padding)
+    return {'x': x_pos, 'y': y_pos}

--- a/contrib/adapters/ffmpeg_burnins_adapter.py
+++ b/contrib/adapters/ffmpeg_burnins_adapter.py
@@ -1,0 +1,84 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+"""FFMPEG Burnins Adapter"""
+import os
+import sys
+
+
+def build_burnins(input_otio):
+    """
+    Generates the burnin objects for each clip within the otio container
+
+    :param input_otio: OTIO container
+    :rtype: [ffmpeg_burnins.Burnins(), ...]
+    """
+    # for some reason updating PYTHONPATH isn't working...
+    if os.path.dirname(__file__) not in sys.path:
+        sys.path.append(os.path.dirname(__file__))
+
+    import ffmpeg_burnins
+    key = 'ffmpeg_burnins'
+
+    burnins = []
+    global_burnins = input_otio.metadata.get(key)
+    for clip in input_otio.each_clip():
+        burnin_data = clip.media_reference.metadata.get(key)
+        if not burnin_data:
+            burnin_data = global_burnins
+        if not burnin_data:
+            continue
+
+        media = clip.media_reference.target_url
+        if media.startswith('file://'):
+            media = media[7:]
+        burnins.append(ffmpeg_burnins.Burnins(media))
+        burnins[-1].otio_media = media
+        burnins[-1].otio_overwrite = burnin_data.get('overwrite')
+        burnins[-1].otio_args = burnin_data.get('args')
+
+        for burnin in burnin_data.get('burnins', []):
+            align = burnin.pop('align')
+            function = burnin.pop('function')
+            align = getattr(ffmpeg_burnins.Align, align)
+            if function == 'text':
+                text = burnin.pop('text')
+                options = ffmpeg_burnins.TextOptions()
+                options.update(burnin)
+                burnins[-1].add_text(text, align, options=options)
+            elif function == 'frame_number':
+                options = ffmpeg_burnins.FrameNumberOptions()
+                options.update(burnin)
+                burnins[-1].add_frame_numbers(align, options=options)
+            else:
+                raise RuntimeError("Unknown function '%s'" % function)
+
+    return burnins
+
+
+def write_to_file(input_otio, filepath):
+    """required OTIO function hook"""
+    for burnin in build_burnins(input_otio):
+        burnin.render(os.path.join(filepath, burnin.otio_media),
+                      args=burnin.otio_args,
+                      overwrite=burnin.otio_overwrite)

--- a/contrib/adapters/tests/test_ffmpeg_burnins.py
+++ b/contrib/adapters/tests/test_ffmpeg_burnins.py
@@ -1,0 +1,131 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+"""Unit tests for the rv session file adapter"""
+
+import unittest
+
+import opentimelineio as otio
+
+MODULE = otio.adapters.from_name('ffmpeg_burnins').module()
+SAMPLE_DATA = """{
+    "OTIO_SCHEMA": "Timeline.1", 
+    "metadata": {
+        "ffmpeg_burnins": {
+            "overwrite": true,
+            "burnins": [
+                {
+                    "text": "Top Center",
+                    "align": "TOP_CENTERED",
+                    "font": "/System/Library/Fonts/Menlo.ttc",
+                    "font_size": 48,
+                    "function": "text"
+                },
+                {
+                    "align": "TOP_LEFT",
+                    "x_offset": 75,
+                    "font": "/System/Library/Fonts/Menlo.ttc",
+                    "frame_offset": 101,
+                    "font_size": 48,
+                    "function": "frame_number"
+                }
+            ]
+        }
+    }, 
+    "name": "BUSH0005.MOV", 
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1", 
+        "children": [
+            {
+                "OTIO_SCHEMA": "Sequence.1", 
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.1", 
+                        "effects": [], 
+                        "markers": [], 
+                        "media_reference": {
+                            "OTIO_SCHEMA": "ExternalReference.1", 
+                            "available_range": {
+                                "OTIO_SCHEMA": "TimeRange.1", 
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1", 
+                                    "rate": 30.0, 
+                                    "value": 600.0
+                                }, 
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1", 
+                                    "rate": 30.0, 
+                                    "value": 0.0
+                                }
+                            }, 
+                            "metadata": {}, 
+                            "name": null, 
+                            "target_url": "file://BUSH0005.MOV"
+                        }, 
+                        "metadata": {}, 
+                        "name": "BUSH0005.MOV", 
+                        "source_range": null
+                    }
+                ], 
+                "effects": [], 
+                "kind": "Video", 
+                "markers": [], 
+                "metadata": {}, 
+                "name": "BUSH0005.MOV", 
+                "source_range": null
+            }
+        ], 
+        "effects": [], 
+        "markers": [], 
+        "metadata": {}, 
+        "name": "tracks", 
+        "source_range": null
+    }
+}"""
+COMMAND = ("ffmpeg -loglevel panic -i BUSH0005.MOV -vf "
+           "\"drawbox=815:0:295:57:black@1.0:t=max,"
+           "drawbox=75:0:92:48:black@1.0:t=max,drawtext="
+           "text='Top Center':x=w/2-tw/2+2:y=5:fontcolor"
+           "=white@1.0:fontsize=48:fontfile=/System/"
+           "Library/Fonts/Menlo.ttc,drawtext=text="
+           r"'%{eif\:n+101\:d}':x=77.5:y=5:fontcolor="
+           "white@1.0:fontsize=48:fontfile=/System/"
+           "Library/Fonts/Menlo.ttc\" BUSH0005.MOV")
+
+class FFMPEGBurninsTest(unittest.TestCase):
+    """Test Cases for FFMPEG Burnins"""
+
+    def test_burnins(self):
+        """
+        Simple test case that just tests the resulting
+        command string, no media output is being tested.
+        """
+        timeline = otio.adapters.read_from_string(SAMPLE_DATA, "otio_json")
+        burnins = MODULE.build_burnins(timeline)
+        self.assertEqual(len(burnins), 1)
+        command = burnins[-1].command(burnins[-1].otio_media)
+        self.assertEqual(command, COMMAND)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implementation of my personal module that has provided me with an easy to use API for generating the filter strings passed to `ffmpeg` for the purpose of generating burnins.

Example screen shot:
![screen shot 2017-08-31 at 11 33 08 pm](https://user-images.githubusercontent.com/1109289/29957890-c3702170-8ea4-11e7-9970-68edc2c8d383.png)

Note: I work in python 3 at home and make use of the Enum classes, not sure if this is an issue.
