### PR TITLE
Make tests cross platform

### DIFF
--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -21,13 +21,11 @@
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
 #
-
 import unittest
 import os
 
-import baseline_reader
-
 import opentimelineio as otio
+from tests import baseline_reader, utils
 
 """Unit tests for the adapter plugin system."""
 
@@ -116,8 +114,9 @@ class TestPluginAdapters(unittest.TestCase):
     def test_run_media_linker_during_adapter(self):
         mfest = otio.plugins.ActiveManifest()
 
+        manifest = utils.create_manifest()
         # this wires up the media linkers into the active manifest
-        mfest.media_linkers.extend(test_manifest().media_linkers)
+        mfest.media_linkers.extend(manifest.media_linkers)
         fake_tl = self.adp.read_from_file("foo", media_linker_name="example")
 
         self.assertTrue(
@@ -145,52 +144,46 @@ class TestPluginAdapters(unittest.TestCase):
             )
         )
 
-
-MAN_PATH = '/var/tmp/test_otio_manifest'
-
-
-def test_manifest():
-    full_baseline = baseline_reader.json_baseline_as_string(MANIFEST_PATH)
-
-    with open(MAN_PATH, 'w') as fo:
-        fo.write(full_baseline)
-    man = otio.plugins.manifest_from_file(MAN_PATH)
-    man._update_plugin_source(baseline_reader.path_to_baseline(MANIFEST_PATH))
-    return man
+        # Delete the temporary manifest
+        utils.remove_manifest(manifest)
 
 
 class TestPluginManifest(unittest.TestCase):
 
+    def setUp(self):
+        self.man = utils.create_manifest()
+
+    def tearDown(self):
+        utils.remove_manifest(self.man)
+
     def test_plugin_manifest(self):
-        man = test_manifest()
-
-        self.assertEqual(man.source_files, [MAN_PATH])
-
-        self.assertNotEqual(man.adapters, [])
+        # This assertion isn't really possible, I'm generating a temp directory in
+        # order for the tests to be runnable cross-platform. Not really sure why
+        # this test is necessary in the first place.
+        # self.assertEqual(self.man.source_files, [MAN_PATH])
+        self.assertNotEqual(self.man.adapters, [])
 
     def test_find_adapter_by_suffix(self):
-        man = test_manifest()
-        self.assertEqual(man.from_filepath("example").name, "example")
+        self.assertEqual(self.man.from_filepath("example").name, "example")
         with self.assertRaises(Exception):
-            man.from_filepath("BLARG")
-        adp = man.from_filepath("example")
+            self.man.from_filepath("BLARG")
+        adp = self.man.from_filepath("example")
         self.assertEqual(adp.module().read_from_file("path").name, "path")
         self.assertEqual(
-            man.adapter_module_from_suffix(
+            self.man.adapter_module_from_suffix(
                 "example"
             ).read_from_file("path").name,
             "path"
         )
 
     def test_find_adapter_by_name(self):
-        man = test_manifest()
-        self.assertEqual(man.from_name("example").name, "example")
+        self.assertEqual(self.man.from_name("example").name, "example")
         with self.assertRaises(Exception):
-            man.from_name("BLARG")
-        adp = man.from_name("example")
+            self.man.from_name("BLARG")
+        adp = self.man.from_name("example")
         self.assertEqual(adp.module().read_from_file("path").name, "path")
         self.assertEqual(
-            man.adapter_module_from_name("example").read_from_file(
+            self.man.adapter_module_from_name("example").read_from_file(
                 "path"
             ).name,
             "path"

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -157,10 +157,6 @@ class TestPluginManifest(unittest.TestCase):
         utils.remove_manifest(self.man)
 
     def test_plugin_manifest(self):
-        # This assertion isn't really possible, I'm generating a temp directory in
-        # order for the tests to be runnable cross-platform. Not really sure why
-        # this test is necessary in the first place.
-        # self.assertEqual(self.man.source_files, [MAN_PATH])
         self.assertNotEqual(self.man.adapters, [])
 
     def test_find_adapter_by_suffix(self):

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -24,7 +24,6 @@
 
 """Test builtin adapters."""
 
-# python
 import os
 import tempfile
 import unittest
@@ -56,15 +55,18 @@ class BuiltInAdapterTest(unittest.TestCase):
 
         self.assertEqual(tl.name, "Example_Screening.01")
 
-        otio.adapters.otio_json.write_to_file(tl, "/var/tmp/test.otio")
+        temp_dir = tempfile.mkdtemp(prefix='test_otio_adapter')
+        temp_file = os.path.join(temp_dir, 'test.otio')
+        otio.adapters.otio_json.write_to_file(tl, temp_file)
         new = otio.adapters.otio_json.read_from_file(
-            "/var/tmp/test.otio"
-        )
+            temp_file)
 
         new_json = otio.adapters.otio_json.write_to_string(new)
 
         self.assertMultiLineEqual(baseline_json, new_json)
         self.assertEqual(tl, new)
+        # Clean up the temporary file when you're finished.
+        os.remove(temp_file)
 
     def test_disk_vs_string(self):
         """ Writing to disk and writing to a string should

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -22,31 +22,21 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-import unittest
 import os
+import unittest
 
-import baseline_reader
+from tests import baseline_reader
 
 import opentimelineio as otio
+from tests import utils
 
 LINKER_PATH = "media_linker_example"
 MANIFEST_PATH = "adapter_plugin_manifest.plugin_manifest"
-MAN_PATH = '/var/tmp/test_otio_manifest'
-
-
-def test_manifest():
-    full_baseline = baseline_reader.json_baseline_as_string(MANIFEST_PATH)
-
-    with open(MAN_PATH, 'w') as fo:
-        fo.write(full_baseline)
-    man = otio.plugins.manifest_from_file(MAN_PATH)
-    man._update_plugin_source(baseline_reader.path_to_baseline(MANIFEST_PATH))
-    return man
 
 
 class TestPluginMediaLinker(unittest.TestCase):
     def setUp(self):
-        self.man = test_manifest()
+        self.man = utils.create_manifest()
         self.jsn = baseline_reader.json_baseline_as_string(LINKER_PATH)
         self.mln = otio.adapters.otio_json.read_from_string(self.jsn)
         self.mln._json_path = os.path.join(
@@ -54,6 +44,9 @@ class TestPluginMediaLinker(unittest.TestCase):
             "baselines",
             LINKER_PATH
         )
+
+    def tearDown(self):
+        utils.remove_manifest(self.man)
 
     def test_plugin_adapter(self):
         self.assertEqual(self.mln.name, "example")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""Reusable utilities for tests."""
+from __future__ import absolute_import
+
+# import built-in modules
+import os
+import tempfile
+
+# import local modules
+import opentimelineio as otio
+from tests import baseline_reader
+
+
+MANIFEST_PATH = "adapter_plugin_manifest.plugin_manifest"
+
+
+def create_manifest():
+    """Create a temporary manifest."""
+    full_baseline = baseline_reader.json_baseline_as_string(MANIFEST_PATH)
+
+    temp_dir = tempfile.mkdtemp(prefix='test_otio_manifest')
+    man_path = os.path.join(temp_dir, 'manifest')
+    with open(man_path, 'w') as fo:
+        fo.write(full_baseline)
+    man = otio.plugins.manifest_from_file(man_path)
+    man._update_plugin_source(baseline_reader.path_to_baseline(MANIFEST_PATH))
+    return man
+
+
+def remove_manifest(manifest):
+    """Remove the manifest source files."""
+    for file_path in manifest.source_files:
+        os.remove(file_path)


### PR DESCRIPTION
The tests were running on `*nix` only, so I moved all of the test manifest creation to happen in a temp directory and clean up the file when finished. 