### PR TITLE
Add trimmed_range_in_parent method to core.Item

### DIFF
--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -397,7 +397,7 @@ class Composition(item.Item, collections.MutableSequence):
         # ...except for the 'children' field, which needs to run through the
         # insert method so that _parent pointers are correctly set on children.
         self._children = []
-        self.extend(d.get('children',[]))
+        self.extend(d.get('children', []))
     # @}
 
     # @{ collections.MutableSequence implementation

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -383,6 +383,23 @@ class Composition(item.Item, collections.MutableSequence):
 
         return opentime.TimeRange(new_start_time, new_duration)
 
+    # @{ SerializableObject override.
+    def update(self, d):
+        """Like the dictionary .update() method.
+
+        Update the data dictionary of this SerializableObject with the .data
+        of d if d is a SerializableObject or if d is a dictionary, d itself.
+        """
+
+        # use the parent update function
+        super(Composition, self).update(d)
+
+        # ...except for the 'children' field, which needs to run through the
+        # insert method so that _parent pointers are correctly set on children.
+        self._children = []
+        self.extend(d.get('children',[]))
+    # @}
+
     # @{ collections.MutableSequence implementation
     def __getitem__(self, item):
         return self._children[item]

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -26,6 +26,7 @@
 
 from .. import (
     opentime,
+    exceptions,
 )
 
 from . import (
@@ -107,6 +108,15 @@ class Item(composable.Composable):
             return self.source_range
 
         return self.available_range()
+
+    def trimmed_range_in_parent(self):
+        """Find and return the timmed range of this item in the parent."""
+        if not self.parent():
+            raise exceptions.NotAChildError(
+                "No parent of {}, cannot compute range in parent.".format(self)
+            )
+
+        return self.parent().trimmed_range_of_child(self)
 
     def transformed_time(self, t, to_item):
         """Converts time t in the coordinate system of self to coordinate

--- a/opentimelineio/core/type_registry.py
+++ b/opentimelineio/core/type_registry.py
@@ -132,6 +132,6 @@ def instance_from_schema(schema_name, schema_version, data_dict):
             data_dict = upgrade_func(data_dict)
 
     obj = cls()
-    obj.data.update(data_dict)
+    obj.update(data_dict)
 
     return obj

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -69,7 +69,7 @@ class StackTest(unittest.TestCase):
 
     def test_serialize(self):
         st = otio.schema.Stack(
-             name="test",
+            name="test",
             children=[otio.schema.Clip(name="testClip")]
         )
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -68,11 +68,16 @@ class StackTest(unittest.TestCase):
         self.assertEqual(st.name, "test")
 
     def test_serialize(self):
-        st = otio.schema.Stack(name="test", children=[])
+        st = otio.schema.Stack(
+             name="test",
+            children=[otio.schema.Clip(name="testClip")]
+        )
 
         encoded = otio.adapters.otio_json.write_to_string(st)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         self.assertEqual(st, decoded)
+
+        self.assertIsNotNone(decoded[0]._parent)
 
     def test_str(self):
         st = otio.schema.Stack(name="foo", children=[])

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -262,6 +262,22 @@ class StackTest(unittest.TestCase):
             )
         )
 
+        # get the trimmed range in the parent
+        self.assertEqual(
+            st[0].trimmed_range_in_parent(),
+            st.trimmed_range_of_child(st[0], reference_space=st),
+        )
+
+        # same test but via iteration
+        for i, c in enumerate(st):
+            self.assertEqual(
+                st[i].trimmed_range_in_parent(),
+                st.trimmed_range_of_child(st[i], reference_space=st),
+            )
+
+        with self.assertRaises(otio.exceptions.NotAChildError):
+            otio.schema.Clip().trimmed_range_in_parent()
+
     def test_transformed_time(self):
         st = otio.schema.Stack(
             name="foo",
@@ -596,6 +612,22 @@ class SequenceTest(unittest.TestCase):
                 otio.opentime.RationalTime(45, 24),
             )
         )
+
+        # get the trimmed range in the parent
+        self.assertEqual(
+            sq[0].trimmed_range_in_parent(),
+            sq.trimmed_range_of_child(sq[0], reference_space=sq),
+        )
+
+        # same tesq but via iteration
+        for i, c in enumerate(sq):
+            self.assertEqual(
+                c.trimmed_range_in_parent(),
+                sq.trimmed_range_of_child_at_index(i)
+            )
+
+        with self.assertRaises(otio.exceptions.NotAChildError):
+            otio.schema.Clip().trimmed_range_in_parent()
 
     def test_range_nested(self):
         sq = otio.schema.Sequence(


### PR DESCRIPTION
This PR:

- Fixes a bug where deserialized OTIO objects were missing their correct `._parent` pointers.
- Adds the `trimmed_range_in_parent` convenience method.  This method wraps up the pattern: `some_item.parent().trimmed_range_of_child(some_item)`.