### PR TITLE
Add nested sequence support to OTIOView

### DIFF
--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -256,8 +256,9 @@ class TrackWidget(QtGui.QGraphicsRectItem):
         self._populate()
 
     def _populate(self):
-        for i, item in enumerate(self.track):
-            timeline_range = self.track.range_of_child_at_index(i)
+        for item in self.track:
+            timeline_range = item.trimmed_range_in_parent()
+
             rect = QtCore.QRectF(
                 0,
                 0,
@@ -280,8 +281,10 @@ class TrackWidget(QtGui.QGraphicsRectItem):
                 continue
 
             new_item.setParentItem(self)
-            new_item.setX(otio.opentime.to_seconds(timeline_range.start_time) *
-                          TIME_MULTIPLIER)
+            new_item.setX(
+                otio.opentime.to_seconds(timeline_range.start_time) 
+                * TIME_MULTIPLIER
+            )
             new_item.counteract_zoom()
 
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -61,12 +61,11 @@ class _BaseItem(QtGui.QGraphicsRectItem):
     def itemChange(self, change, value):
         if change == QtGui.QGraphicsItem.ItemSelectedHasChanged:
             self.setPen(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected() 
                 else QtGui.QColor(0, 0, 0, 255)
             )
             self.setZValue(
-                self.zValue() + 1 if self.isSelected()
-                else self.zValue() - 1
+                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
             )
 
         return super(_BaseItem, self).itemChange(change, value)
@@ -193,7 +192,11 @@ class TransitionItem(_BaseItem):
     def __init__(self, item, timeline_range, rect, *args, **kwargs):
         rect.setHeight(TRANSITION_HEIGHT)
         super(TransitionItem, self).__init__(
-            item, timeline_range, rect, *args, **kwargs
+            item,
+            timeline_range,
+            rect,
+            *args,
+            **kwargs
         )
         self.setBrush(
             QtGui.QBrush(QtGui.QColor(237, 228, 148, 255))
@@ -225,9 +228,7 @@ class TransitionItem(_BaseItem):
 class ClipItem(_BaseItem):
     def __init__(self, *args, **kwargs):
         super(ClipItem, self).__init__(*args, **kwargs)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(168, 197, 255, 255))
-        )
+        self.setBrush(QtGui.QBrush(QtGui.QColor(168, 197, 255, 255)))
         self.source_name_label.setText(self.item.name)
 
 
@@ -250,9 +251,7 @@ class TrackWidget(QtGui.QGraphicsRectItem):
         super(TrackWidget, self).__init__(*args, **kwargs)
         self.track = track
 
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(43, 52, 59, 255))
-        )
+        self.setBrush(QtGui.QBrush(QtGui.QColor(43, 52, 59, 255)))
         self._populate()
 
     def _populate(self):
@@ -278,6 +277,7 @@ class TrackWidget(QtGui.QGraphicsRectItem):
             elif isinstance(item, otio.schema.Transition):
                 new_item = TransitionItem(item, timeline_range, rect)
             else:
+                print("Warning: could not add item {} to UI.".format(item))
                 continue
 
             new_item.setParentItem(self)
@@ -301,9 +301,7 @@ class Marker(QtGui.QGraphicsPolygonItem):
         super(Marker, self).__init__(poly, *args, **kwargs)
 
         self.setFlags(QtGui.QGraphicsItem.ItemIsSelectable)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(121, 212, 177, 255))
-        )
+        self.setBrush(QtGui.QBrush(QtGui.QColor(121, 212, 177, 255)))
 
     def paint(self, *args, **kwargs):
         new_args = [args[0], QtGui.QStyleOptionGraphicsItem()] + list(args[2:])
@@ -311,8 +309,10 @@ class Marker(QtGui.QGraphicsPolygonItem):
 
     def itemChange(self, change, value):
         if change == QtGui.QGraphicsItem.ItemSelectedHasChanged:
-            self.setPen(QtGui.QColor(0, 255, 0, 255) if self.isSelected()
-                        else QtGui.QColor(0, 0, 0, 255))
+            self.setPen(
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                else QtGui.QColor(0, 0, 0, 255)
+            )
         return super(Marker, self).itemChange(change, value)
 
     def counteract_zoom(self, zoom_level=1.0):
@@ -322,9 +322,7 @@ class Marker(QtGui.QGraphicsPolygonItem):
 class TimeSlider(QtGui.QGraphicsRectItem):
     def __init__(self, *args, **kwargs):
         super(TimeSlider, self).__init__(*args, **kwargs)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(64, 78, 87, 255))
-        )
+        self.setBrush(QtGui.QBrush(QtGui.QColor(64, 78, 87, 255)))
 
 
 class StackScene(QtGui.QGraphicsScene):
@@ -353,14 +351,19 @@ class StackScene(QtGui.QGraphicsScene):
                 t.kind == otio.schema.SequenceKind.Audio for t in self.stack 
             )
         else:
-            has_video_tracks = self.stack.kind == otio.schema.SequenceKind.Video 
-            has_audio_tracks = self.stack.kind == otio.schema.SequenceKind.Audio 
+            has_video_tracks = (
+                self.stack.kind == otio.schema.SequenceKind.Video 
+            )
+            has_audio_tracks = (
+                self.stack.kind == otio.schema.SequenceKind.Audio 
+            )
 
         height = (
             TIME_SLIDER_HEIGHT
-            + int(
-                has_video_tracks and has_audio_tracks
-            ) * MEDIA_TYPE_SEPARATOR_HEIGHT
+            + (
+                int(has_video_tracks and has_audio_tracks) 
+                * MEDIA_TYPE_SEPARATOR_HEIGHT
+            )
             + len(self.stack) * TRACK_HEIGHT
         )
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -248,9 +248,9 @@ class NestedItem(_BaseItem):
         self.scene().views()[0].open_stack.emit(self.item)
 
 
-class Track(QtGui.QGraphicsRectItem):
+class TrackWidget(QtGui.QGraphicsRectItem):
     def __init__(self, track, *args, **kwargs):
-        super(Track, self).__init__(*args, **kwargs)
+        super(TrackWidget, self).__init__(*args, **kwargs)
         self.track = track
 
         self.setBrush(
@@ -380,7 +380,7 @@ class StackScene(QtGui.QGraphicsScene):
     def _add_track(self, track, y_pos):
         scene_rect = self.sceneRect()
         rect = QtCore.QRectF(0, 0, scene_rect.width() * 10, TRACK_HEIGHT)
-        new_track = Track(track, rect)
+        new_track = TrackWidget(track, rect)
         self.addItem(new_track)
         new_track.setPos(scene_rect.x(), y_pos)
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -72,14 +72,11 @@ class _BaseItem(QtGui.QGraphicsRectItem):
         return super(_BaseItem, self).itemChange(change, value)
 
     def _add_markers(self):
-        trimmed_range = (
-            self.item.trimmed_range().start_time,
-            self.item.trimmed_range().end_time_exclusive()
-         )
+        trimmed_range = self.item.trimmed_range()
 
         for m in self.item.markers:
             marked_time = m.marked_range.start_time
-            if marked_time < trimmed_range[0] or marked_time > trimmed_range[1]:
+            if not trimmed_range.overlaps(marked_time):
                 continue
 
             # @TODO: set the marker color if its set from the OTIO object
@@ -88,7 +85,7 @@ class _BaseItem(QtGui.QGraphicsRectItem):
             marker.setX(
                 (
                     otio.opentime.to_seconds(m.marked_range.start_time)
-                    - otio.opentime.to_seconds(trimmed_range[0])
+                    - otio.opentime.to_seconds(trimmed_range.start_time)
                 ) * TIME_MULTIPLIER
             )
             marker.setParentItem(self)

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -61,7 +61,7 @@ class _BaseItem(QtGui.QGraphicsRectItem):
     def itemChange(self, change, value):
         if change == QtGui.QGraphicsItem.ItemSelectedHasChanged:
             self.setPen(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected() 
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
                 else QtGui.QColor(0, 0, 0, 255)
             )
             self.setZValue(
@@ -282,7 +282,7 @@ class TrackWidget(QtGui.QGraphicsRectItem):
 
             new_item.setParentItem(self)
             new_item.setX(
-                otio.opentime.to_seconds(timeline_range.start_time) 
+                otio.opentime.to_seconds(timeline_range.start_time)
                 * TIME_MULTIPLIER
             )
             new_item.counteract_zoom()
@@ -345,23 +345,23 @@ class StackScene(QtGui.QGraphicsScene):
 
         if isinstance(self.stack, otio.schema.Stack):
             has_video_tracks = any(
-                t.kind == otio.schema.SequenceKind.Video for t in self.stack 
+                t.kind == otio.schema.SequenceKind.Video for t in self.stack
             )
             has_audio_tracks = any(
-                t.kind == otio.schema.SequenceKind.Audio for t in self.stack 
+                t.kind == otio.schema.SequenceKind.Audio for t in self.stack
             )
         else:
             has_video_tracks = (
-                self.stack.kind == otio.schema.SequenceKind.Video 
+                self.stack.kind == otio.schema.SequenceKind.Video
             )
             has_audio_tracks = (
-                self.stack.kind == otio.schema.SequenceKind.Audio 
+                self.stack.kind == otio.schema.SequenceKind.Audio
             )
 
         height = (
             TIME_SLIDER_HEIGHT
             + (
-                int(has_video_tracks and has_audio_tracks) 
+                int(has_video_tracks and has_audio_tracks)
                 * MEDIA_TYPE_SEPARATOR_HEIGHT
             )
             + len(self.stack) * TRACK_HEIGHT
@@ -389,7 +389,7 @@ class StackScene(QtGui.QGraphicsScene):
 
     def _add_tracks(self):
         video_tracks_top = TIME_SLIDER_HEIGHT
-        audio_tracks_top = TIME_SLIDER_HEIGHT 
+        audio_tracks_top = TIME_SLIDER_HEIGHT
 
         video_tracks = []
         audio_tracks = []

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -72,14 +72,14 @@ class _BaseItem(QtGui.QGraphicsRectItem):
         return super(_BaseItem, self).itemChange(change, value)
 
     def _add_markers(self):
-        source_range = (
+        trimmed_range = (
             self.item.trimmed_range().start_time,
             self.item.trimmed_range().end_time_exclusive()
          )
 
         for m in self.item.markers:
             marked_time = m.marked_range.start_time
-            if marked_time < source_range[0] or marked_time > source_range[1]:
+            if marked_time < trimmed_range[0] or marked_time > trimmed_range[1]:
                 continue
 
             # @TODO: set the marker color if its set from the OTIO object
@@ -88,7 +88,7 @@ class _BaseItem(QtGui.QGraphicsRectItem):
             marker.setX(
                 (
                     otio.opentime.to_seconds(m.marked_range.start_time)
-                    - otio.opentime.to_seconds(source_range[0])
+                    - otio.opentime.to_seconds(trimmed_range[0])
                 ) * TIME_MULTIPLIER
             )
             marker.setParentItem(self)
@@ -103,17 +103,17 @@ class _BaseItem(QtGui.QGraphicsRectItem):
         )
 
     def _set_labels_rational_time(self):
-        source_range = self.item.trimmed_range()
+        trimmed_range = self.item.trimmed_range()
         self.source_in_label.setText(
             '{value}\n@{rate}'.format(
-                value=source_range.start_time.value,
-                rate=source_range.start_time.rate
+                value=trimmed_range.start_time.value,
+                rate=trimmed_range.start_time.rate
             )
         )
         self.source_out_label.setText(
             '{value}\n@{rate}'.format(
-                value=source_range.end_time_exclusive().value,
-                rate=source_range.end_time_exclusive().rate
+                value=trimmed_range.end_time_exclusive().value,
+                rate=trimmed_range.end_time_exclusive().rate
             )
         )
 
@@ -124,8 +124,8 @@ class _BaseItem(QtGui.QGraphicsRectItem):
                     self.timeline_range.start_time.rate
                 ),
                 source=otio.opentime.to_timecode(
-                    self.item.source_range.start_time,
-                    self.item.source_range.start_time.rate
+                    self.item.trimmed_range.start_time,
+                    self.item.trimmed_range.start_time.rate
                 )
             )
         )
@@ -136,8 +136,8 @@ class _BaseItem(QtGui.QGraphicsRectItem):
                     self.timeline_range.end_time_exclusive().rate
                 ),
                 source=otio.opentime.to_timecode(
-                    self.item.source_range.end_time_exclusive(),
-                    self.item.source_range.end_time_exclusive().rate
+                    self.item.trimmed_range.end_time_exclusive(),
+                    self.item.trimmed_range.end_time_exclusive().rate
                 )
             )
         )

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -73,8 +73,8 @@ class _BaseItem(QtGui.QGraphicsRectItem):
 
     def _add_markers(self):
         source_range = (
-            self.item.source_range.start_time,
-            self.item.source_range.end_time_exclusive()
+            self.item.trimmed_range().start_time,
+            self.item.trimmed_range().end_time_exclusive()
          )
 
         for m in self.item.markers:
@@ -103,7 +103,7 @@ class _BaseItem(QtGui.QGraphicsRectItem):
         )
 
     def _set_labels_rational_time(self):
-        source_range = self.item.source_range
+        source_range = self.item.trimmed_range()
         self.source_in_label.setText(
             '{value}\n@{rate}'.format(
                 value=source_range.start_time.value,

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -273,6 +273,8 @@ class Track(QtGui.QGraphicsRectItem):
                 new_item = ClipItem(item, timeline_range, rect)
             elif isinstance(item, otio.schema.Stack):
                 new_item = NestedItem(item, timeline_range, rect)
+            elif isinstance(item, otio.schema.Sequence):
+                new_item = NestedItem(item, timeline_range, rect)
             elif isinstance(item, otio.schema.Gap):
                 new_item = GapItem(item, timeline_range, rect)
             elif isinstance(item, otio.schema.Transition):


### PR DESCRIPTION
- Add support for nested sequences to `opentimelineview` library (prior version supported nested Stacks but not nested Sequences).
- this is done by adding support for `otio.schema.Sequence` to the `StackView`
- Fix small bugs associated with using `source_range` directly instead of going through the `trimmed_range` wrapper
- Renames `Track` widget class to `TrackWidget` to disambiguate it