### PR TITLE
FCP adapter uses clip item rate instead of source rate

### DIFF
--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -255,8 +255,8 @@ class TrackWidget(QtGui.QGraphicsRectItem):
         self._populate()
 
     def _populate(self):
-        for item in self.track:
-            timeline_range = item.trimmed_range_in_parent()
+        for n, item in enumerate(self.track):
+            timeline_range = self.track.trimmed_range_of_child_at_index(n)
 
             rect = QtCore.QRectF(
                 0,
@@ -553,7 +553,7 @@ class Timeline(QtGui.QTabWidget):
         tab_index = next(
             (
                 i for i in range(self.count())
-                if stack is self.widget(i).scene().stack
+                if stack is self.widget(i).scene().composition
             ),
             None
         )

--- a/tests/sample_data/premiere_example.xml
+++ b/tests/sample_data/premiere_example.xml
@@ -50,15 +50,15 @@
 						<masterclipid>masterclip-1</masterclipid>
 						<name>sc01_sh010_anim.mov</name>
 						<enabled>TRUE</enabled>
-						<duration>100</duration>
+						<duration>50</duration>
 						<rate>
-							<timebase>30</timebase>
+							<timebase>15</timebase>
 							<ntsc>FALSE</ntsc>
 						</rate>
 						<start>536</start>
 						<end>636</end>
 						<in>0</in>
-						<out>100</out>
+						<out>50</out>
 						<pproTicksIn>0</pproTicksIn>
 						<pproTicksOut>846720000000</pproTicksOut>
 						<alphatype>none</alphatype>


### PR DESCRIPTION
addresses #174 
- uses clip item rate instead of source rate
- edited clipitem in premiere_example.xml that has different rate compared to its linked file
- fixed bug in timeline_widget, transitions don`t have trimmed_range_in_parent method
- fixed bug in timeline_widget, left over rename from stack to composition