### PR TITLE
Add check to see if PIL is importable before running tests.

### DIFF
--- a/contrib/adapters/tests/test_burnins.py
+++ b/contrib/adapters/tests/test_burnins.py
@@ -138,6 +138,17 @@ TIMECODE = ('ffmpeg -loglevel panic -i TEST.MOV -vf "drawtext=timecode='
             'ttc\':box=1:boxborderw=5:boxcolor=black@1.0" TEST.MOV')
 
 
+try:
+    import PIL # flake8: noqa
+    skip_tests = False
+except (ImportError):
+    skip_tests = True
+
+@unittest.skipIf(
+    skip_tests,
+    "PIL Required for burnin unit tests. see:"
+    " http://www.pythonware.com/products/pil/"
+)
 class FFMPEGBurninsTest(unittest.TestCase):
     """Test Cases for FFMPEG Burnins"""
 

--- a/contrib/adapters/tests/test_burnins.py
+++ b/contrib/adapters/tests/test_burnins.py
@@ -140,14 +140,14 @@ TIMECODE = ('ffmpeg -loglevel panic -i TEST.MOV -vf "drawtext=timecode='
 
 try:
     import PIL # flake8: noqa
-    skip_tests = False
+    could_import_pillow = True
 except (ImportError):
-    skip_tests = True
+    could_import_pillow = False
 
 @unittest.skipIf(
-    skip_tests,
-    "PIL Required for burnin unit tests. see:"
-    " http://www.pythonware.com/products/pil/"
+    not could_import_pillow,
+    "Pillow Required for burnin unit tests. see:"
+    " https://python-pillow.org/"
 )
 class FFMPEGBurninsTest(unittest.TestCase):
     """Test Cases for FFMPEG Burnins"""

--- a/contrib/adapters/tests/test_burnins.py
+++ b/contrib/adapters/tests/test_burnins.py
@@ -140,6 +140,7 @@ TIMECODE = ('ffmpeg -loglevel panic -i TEST.MOV -vf "drawtext=timecode='
 
 try:
     import PIL # flake8: noqa
+    from PIL import imaging # flake8: noqa
     could_import_pillow = True
 except (ImportError):
     could_import_pillow = False


### PR DESCRIPTION
Noticed that tests fail instead of skip if PIL isn't installed, so added a check for it.  Now unit tests skip instead of fail if PIL isn't installed for the contrib/burnin adapter.