### PR TITLE
Adapter argument map

### DIFF
--- a/opentimelineio/adapters/__init__.py
+++ b/opentimelineio/adapters/__init__.py
@@ -121,7 +121,7 @@ def read_from_file(
     adapter_name=None,
     media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
     media_linker_argument_map=None,
-    adapter_argument_map=None
+    **adapter_argument_map
 ):
     """Read filepath using adapter_name.
 
@@ -136,9 +136,9 @@ def read_from_file(
 
     return adapter.read_from_file(
         filepath=filepath,
-        adapter_argument_map=adapter_argument_map,
         media_linker_name=media_linker_name,
         media_linker_argument_map=media_linker_argument_map,
+        **adapter_argument_map
     )
 
 
@@ -147,7 +147,7 @@ def read_from_string(
     adapter_name,
     media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
     media_linker_argument_map=None,
-    adapter_argument_map=None
+    **adapter_argument_map
 ):
     """Read a timeline from input_str using adapter_name.
 
@@ -162,17 +162,17 @@ def read_from_string(
     adapter = plugins.ActiveManifest().from_name(adapter_name)
     return adapter.read_from_string(
         input_str=input_str,
-        adapter_argument_map=adapter_argument_map,
         media_linker_name=media_linker_name,
         media_linker_argument_map=media_linker_argument_map,
+        **adapter_argument_map
     )
 
 
 def write_to_file(
     input_otio,
     filepath,
-    adapter_name=None, 
-    adapter_argument_map=None
+    adapter_name=None,
+    **adapter_argument_map
 ):
     """Write input_otio to filepath using adapter_name.
 
@@ -188,14 +188,14 @@ def write_to_file(
     return adapter.write_to_file(
         input_otio=input_otio,
         filepath=filepath,
-        adapter_argument_map=adapter_argument_map
+        **adapter_argument_map
     )
 
 
 def write_to_string(
     input_otio,
     adapter_name,
-    adapter_argument_map=None
+    **adapter_argument_map
 ):
     """Return input_otio written to a string using adapter_name.
 
@@ -206,5 +206,5 @@ def write_to_string(
     adapter = plugins.ActiveManifest().from_name(adapter_name)
     return adapter.write_to_string(
         input_otio=input_otio,
-        adapter_argument_map=adapter_argument_map 
+        **adapter_argument_map
     )

--- a/opentimelineio/adapters/__init__.py
+++ b/opentimelineio/adapters/__init__.py
@@ -117,11 +117,12 @@ def from_name(name):
 
 
 def read_from_file(
-        filepath,
-        adapter_name=None,
-        media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
-        media_linker_argument_map=None
-        ):
+    filepath,
+    adapter_name=None,
+    media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
+    media_linker_argument_map=None,
+    adapter_argument_map=None
+):
     """Read filepath using adapter_name.
 
     If adapter_name is None, try and infer the adapter name from the filepath.
@@ -134,18 +135,20 @@ def read_from_file(
     adapter = _from_filepath_or_name(filepath, adapter_name)
 
     return adapter.read_from_file(
-            filepath,
-            media_linker_name,
-            media_linker_argument_map
+        filepath=filepath,
+        adapter_argument_map=adapter_argument_map,
+        media_linker_name=media_linker_name,
+        media_linker_argument_map=media_linker_argument_map,
     )
 
 
 def read_from_string(
-        input_str,
-        adapter_name,
-        media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
-        media_linker_argument_map=None
-        ):
+    input_str,
+    adapter_name,
+    media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
+    media_linker_argument_map=None,
+    adapter_argument_map=None
+):
     """Read a timeline from input_str using adapter_name.
 
     This is useful if you obtain a timeline from someplace other than the
@@ -158,13 +161,19 @@ def read_from_string(
 
     adapter = plugins.ActiveManifest().from_name(adapter_name)
     return adapter.read_from_string(
-            input_str,
-            media_linker_name,
-            media_linker_argument_map
+        input_str=input_str,
+        adapter_argument_map=adapter_argument_map,
+        media_linker_name=media_linker_name,
+        media_linker_argument_map=media_linker_argument_map,
     )
 
 
-def write_to_file(input_otio, filepath, adapter_name=None):
+def write_to_file(
+    input_otio,
+    filepath,
+    adapter_name=None, 
+    adapter_argument_map=None
+):
     """Write input_otio to filepath using adapter_name.
 
     If adapter_name is None, infer the adapter_name to use based on the
@@ -176,10 +185,18 @@ def write_to_file(input_otio, filepath, adapter_name=None):
 
     adapter = _from_filepath_or_name(filepath, adapter_name)
 
-    return adapter.write_to_file(input_otio, filepath)
+    return adapter.write_to_file(
+        input_otio=input_otio,
+        filepath=filepath,
+        adapter_argument_map=adapter_argument_map
+    )
 
 
-def write_to_string(input_otio, adapter_name):
+def write_to_string(
+    input_otio,
+    adapter_name,
+    adapter_argument_map=None
+):
     """Return input_otio written to a string using adapter_name.
 
     Example:
@@ -187,4 +204,7 @@ def write_to_string(input_otio, adapter_name):
     """
 
     adapter = plugins.ActiveManifest().from_name(adapter_name)
-    return adapter.write_to_string(input_otio)
+    return adapter.write_to_string(
+        input_otio=input_otio,
+        adapter_argument_map=adapter_argument_map 
+    )

--- a/opentimelineio/adapters/adapter.py
+++ b/opentimelineio/adapters/adapter.py
@@ -102,18 +102,15 @@ class Adapter(plugins.PythonPlugin):
     def read_from_file(
         self,
         filepath,
-        adapter_argument_map=None,
         media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
         media_linker_argument_map=None,
+        **adapter_argument_map
     ):
         """Execute the read_from_file function on this adapter.
 
         If read_from_string exists, but not read_from_file, execute that with
         a trivial file object wrapper.
         """
-
-        if adapter_argument_map is None:
-            adapter_argument_map = {}
 
         if media_linker_argument_map is None:
             media_linker_argument_map = {}
@@ -149,20 +146,18 @@ class Adapter(plugins.PythonPlugin):
 
         return result
 
-    def write_to_file(self, input_otio, filepath, adapter_argument_map=None):
+    def write_to_file(self, input_otio, filepath, **adapter_argument_map):
         """Execute the write_to_file function on this adapter.
 
         If write_to_string exists, but not write_to_file, execute that with
         a trivial file object wrapper.
         """
 
-        adapter_argument_map = adapter_argument_map or {}
-
         if (
             not self.has_feature("write_to_file") and
             self.has_feature("write_to_string")
         ):
-            result = self.write_to_string(input_otio, adapter_argument_map)
+            result = self.write_to_string(input_otio, **adapter_argument_map)
             with open(filepath, 'w') as fo:
                 fo.write(result)
             return filepath
@@ -179,11 +174,9 @@ class Adapter(plugins.PythonPlugin):
         input_str,
         media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
         media_linker_argument_map=None,
-        adapter_argument_map=None
+        **adapter_argument_map
     ):
         """Call the read_from_string function on this adapter."""
-
-        adapter_argument_map = adapter_argument_map or {}
 
         result = self._execute_function(
             "read_from_string",
@@ -202,12 +195,14 @@ class Adapter(plugins.PythonPlugin):
 
         return result
 
-    def write_to_string(self, input_otio, adapter_argument_map=None):
+    def write_to_string(self, input_otio, **adapter_argument_map):
         """Call the write_to_string function on this adapter."""
 
-        adapter_argument_map = adapter_argument_map or {}
-
-        return self._execute_function("write_to_string", input_otio=input_otio, **adapter_argument_map)
+        return self._execute_function(
+            "write_to_string",
+            input_otio=input_otio,
+            **adapter_argument_map
+        )
 
     def __str__(self):
         return (

--- a/opentimelineio/adapters/adapter.py
+++ b/opentimelineio/adapters/adapter.py
@@ -102,14 +102,18 @@ class Adapter(plugins.PythonPlugin):
     def read_from_file(
         self,
         filepath,
+        adapter_argument_map=None,
         media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
-        media_linker_argument_map=None
+        media_linker_argument_map=None,
     ):
         """Execute the read_from_file function on this adapter.
 
         If read_from_string exists, but not read_from_file, execute that with
         a trivial file object wrapper.
         """
+
+        if adapter_argument_map is None:
+            adapter_argument_map = {}
 
         if media_linker_argument_map is None:
             media_linker_argument_map = {}
@@ -124,12 +128,14 @@ class Adapter(plugins.PythonPlugin):
                 contents = fo.read()
             result = self._execute_function(
                 "read_from_string",
-                input_str=contents
+                input_str=contents,
+                **adapter_argument_map
             )
         else:
             result = self._execute_function(
                 "read_from_file",
-                filepath=filepath
+                filepath=filepath,
+                **adapter_argument_map
             )
 
         if media_linker_name and (
@@ -143,18 +149,20 @@ class Adapter(plugins.PythonPlugin):
 
         return result
 
-    def write_to_file(self, input_otio, filepath):
+    def write_to_file(self, input_otio, filepath, adapter_argument_map=None):
         """Execute the write_to_file function on this adapter.
 
         If write_to_string exists, but not write_to_file, execute that with
         a trivial file object wrapper.
         """
 
+        adapter_argument_map = adapter_argument_map or {}
+
         if (
             not self.has_feature("write_to_file") and
             self.has_feature("write_to_string")
         ):
-            result = self.write_to_string(input_otio)
+            result = self.write_to_string(input_otio, adapter_argument_map)
             with open(filepath, 'w') as fo:
                 fo.write(result)
             return filepath
@@ -162,20 +170,25 @@ class Adapter(plugins.PythonPlugin):
         return self._execute_function(
             "write_to_file",
             input_otio=input_otio,
-            filepath=filepath
+            filepath=filepath,
+            **adapter_argument_map
         )
 
     def read_from_string(
         self,
         input_str,
         media_linker_name=media_linker.MediaLinkingPolicy.ForceDefaultLinker,
-        media_linker_argument_map=None
+        media_linker_argument_map=None,
+        adapter_argument_map=None
     ):
         """Call the read_from_string function on this adapter."""
 
+        adapter_argument_map = adapter_argument_map or {}
+
         result = self._execute_function(
             "read_from_string",
-            input_str=input_str
+            input_str=input_str,
+            **adapter_argument_map
         )
 
         if media_linker_name and (
@@ -189,10 +202,12 @@ class Adapter(plugins.PythonPlugin):
 
         return result
 
-    def write_to_string(self, input_otio):
+    def write_to_string(self, input_otio, adapter_argument_map=None):
         """Call the write_to_string function on this adapter."""
 
-        return self._execute_function("write_to_string", input_otio=input_otio)
+        adapter_argument_map = adapter_argument_map or {}
+
+        return self._execute_function("write_to_string", input_otio=input_otio, **adapter_argument_map)
 
     def __str__(self):
         return (

--- a/tests/baselines/example.py
+++ b/tests/baselines/example.py
@@ -30,15 +30,15 @@ https://github.com/PixarAnimationStudios/OpenTimelineIO/wiki/How-to-Write-an-Ope
 import opentimelineio as otio
 
 
-def read_from_file(filepath):
-    fake_tl = otio.schema.Timeline(name=filepath)
+def read_from_file(filepath, suffix=""):
+    fake_tl = otio.schema.Timeline(name=filepath+str(suffix))
     fake_tl.tracks.append(otio.schema.Track())
     fake_tl.tracks[0].append(otio.schema.Clip(name=filepath + "_clip"))
     return fake_tl
 
 
-def read_from_string(input_str):
-    return read_from_file(input_str)
+def read_from_string(input_str, suffix=""):
+    return read_from_file(input_str, suffix)
 
 
 # in practice, these will be in separate plugins, but for simplicity in the

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -111,6 +111,9 @@ class TestPluginAdapters(unittest.TestCase):
         self.assertTrue(self.adp.has_feature("read_from_file"))
         self.assertFalse(self.adp.has_feature("write"))
 
+    def test_pass_arguments_to_adapter(self):
+        self.assertEqual(self.adp.read_from_file("foo", suffix=3).name, "foo3")
+
     def test_run_media_linker_during_adapter(self):
         mfest = otio.plugins.ActiveManifest()
 


### PR DESCRIPTION
In order for adapters to have custom extra arguments (for example a `rate` argument for the EDL adapter), the adapter plugin system will now pass keyword arguments along to the adapters.