### PR TITLE
Add support for Nucoda EDLs

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -33,7 +33,6 @@
 # TODO: currently tracks with linked audio/video will lose their linkage when
 #       read into OTIO.
 
-import enum
 import os
 import re
 import math
@@ -73,12 +72,12 @@ channel_map = {
 
 
 # Currently, the 'style' argument determines
-# the comment string for the media reference.
+# the comment string for the media reference:
 #   'avid': '* FROM CLIP:' (default)
 #   'nucoda': '* FROM FILE:'
-class Style(enum.Enum):
-    avid = 0
-    nucoda = 1
+# When adding a new style, please be sure to add sufficient tests
+# to verify both the new and existing styles.
+VALID_EDL_STYLES = ['avid', 'nucoda']
 
 
 class EDLParser(object):
@@ -567,9 +566,7 @@ def write_to_string(input_otio, rate=None, style='avid'):
     # TODO: We should have convenience functions in Timeline for this?
     # also only works for a single video track at the moment
 
-    try:
-        edl_style = Style[style]
-    except KeyError:
+    if style not in VALID_EDL_STYLES:
         raise otio.exceptions.NotSupportedError(
             "The EDL style '{}' is not supported.".format(
                 style
@@ -660,9 +657,9 @@ def write_to_string(input_otio, rate=None, style='avid'):
             # Avid Media Composer outputs two spaces before the
             # clip name so we match that.
             lines.append("* FROM CLIP NAME:  {}".format(name))
-        if url and edl_style == Style.avid:
+        if url and style == 'avid':
             lines.append("* FROM CLIP: {}".format(url))
-        if url and edl_style == Style.nucoda:
+        if url and style == 'nucoda':
             lines.append("* FROM FILE: {}".format(url))
 
         cdl = clip.metadata.get('cdl')

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -33,6 +33,7 @@
 # TODO: currently tracks with linked audio/video will lose their linkage when
 #       read into OTIO.
 
+import enum
 import os
 import re
 import math
@@ -69,6 +70,15 @@ channel_map = {
     'A2/V': ['V', 'A2'],
     'AA/V': ['V', 'A1', 'A2']
 }
+
+
+# Currently, the 'style' argument determines
+# the comment string for the media reference.
+#   'avid': '* FROM CLIP:' (default)
+#   'nucoda': '* FROM FILE:'
+class Style(enum.Enum):
+    avid = 0
+    nucoda = 1
 
 
 class EDLParser(object):
@@ -407,11 +417,13 @@ class CommentHandler(object):
     regex_template = '\*\s*{id}:?\s+(?P<comment_body>.*)'
 
     # this should be a map of all known comments that we can read
-    # 'FROM CLIP' is a required comment to link media
+    # 'FROM CLIP' or 'FROM FILE' is a required comment to link media
+    # An exception is raised if both 'FROM CLIP' and 'FROM FILE' are found
     # needs to be ordered so that FROM CLIP NAME gets matched before FROM CLIP
     comment_id_map = collections.OrderedDict([
             ('FROM CLIP NAME', 'clip_name'),
             ('FROM CLIP', 'media_reference'),
+            ('FROM FILE', 'media_reference'),
             ('LOC', 'locator'),
             ('ASC_SOP', 'asc_sop'),
             ('ASC_SAT', 'asc_sat'),
@@ -551,9 +563,19 @@ def read_from_string(input_str, rate=24):
     return result
 
 
-def write_to_string(input_otio, rate=None):
+def write_to_string(input_otio, rate=None, style='avid'):
     # TODO: We should have convenience functions in Timeline for this?
     # also only works for a single video track at the moment
+
+    try:
+        edl_style = Style[style]
+    except KeyError:
+        raise otio.exceptions.NotSupportedError(
+            "The EDL style '{}' is not supported.".format(
+                style
+            )
+        )
+
     video_tracks = [t for t in input_otio.tracks
                     if t.kind == otio.schema.TrackKind.Video]
     audio_tracks = [t for t in input_otio.tracks
@@ -638,8 +660,10 @@ def write_to_string(input_otio, rate=None):
             # Avid Media Composer outputs two spaces before the
             # clip name so we match that.
             lines.append("* FROM CLIP NAME:  {}".format(name))
-        if url:
+        if url and edl_style == Style.avid:
             lines.append("* FROM CLIP: {}".format(url))
+        if url and edl_style == Style.nucoda:
+            lines.append("* FROM FILE: {}".format(url))
 
         cdl = clip.metadata.get('cdl')
         if cdl:

--- a/tests/sample_data/nucoda_example.edl
+++ b/tests/sample_data/nucoda_example.edl
@@ -1,0 +1,7 @@
+TITLE:   Nucoda_Example.01
+001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
+* FROM CLIP NAME:  take_1
+* FROM FILE: S:\path\to\ZZ100_501.take_1.0001.exr
+002  ZZ100_50 V     C        01:00:06:13 01:00:08:15 00:59:54:18 00:59:56:20
+* FROM CLIP NAME:  take_2
+* FROM FILE: S:\path\to\ZZ100_502A.take_2.0101.exr


### PR DESCRIPTION
Nucoda EDLs use a `* FROM FILE:` comment string to reference media in place of `* FROM CLIP:`.  This change introduces Nucoda EDL writing using an EDL `style` argument, and also supports Nucoda EDL reads.