### PR TITLE
Parenting bug fix + small cleanup

### DIFF
--- a/opentimelineio/adapters/adapter.py
+++ b/opentimelineio/adapters/adapter.py
@@ -70,9 +70,7 @@ class Adapter(plugins.PythonPlugin):
             filepath
         )
 
-        if suffixes is None:
-            suffixes = []
-        self.suffixes = suffixes
+        self.suffixes = suffixes or []
 
     suffixes = core.serializable_field(
         "suffixes",

--- a/opentimelineio/algorithms/track_algo.py
+++ b/opentimelineio/algorithms/track_algo.py
@@ -26,7 +26,7 @@
 
 import copy
 
-from ..import (
+from .. import (
     schema,
     exceptions,
 )

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -58,10 +58,7 @@ class Composable(serializable_object.SerializableObject):
 
         # initialize the serializable fields
         self.name = name
-
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
+        self.metadata = metadata or {}
 
     @staticmethod
     def visible():

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -93,10 +93,14 @@ class Composable(serializable_object.SerializableObject):
         return self._parent
 
     def _set_parent(self, new_parent):
+        if self._parent == new_parent:
+            return
+
         if self._parent is not None and (
             hasattr(self._parent, "remove") and
             self in self._parent
         ):
+            # remove from the old parent
             self._parent.remove(self)
 
         self._parent = new_parent

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -63,19 +63,9 @@ class Item(composable.Composable):
 
         self.name = name
         self.source_range = source_range
-
-        if effects is None:
-            effects = []
-        self.effects = effects
-
-        if markers is None:
-            markers = []
-        self.markers = markers
-
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
-
+        self.effects = effects or []
+        self.markers = markers or []
+        self.metadata = metadata or {}
         self._parent = None
 
     name = serializable_object.serializable_field("name", doc="Item name.")

--- a/opentimelineio/media_reference.py
+++ b/opentimelineio/media_reference.py
@@ -53,10 +53,7 @@ class MediaReference(core.SerializableObject):
 
         self.name = name
         self.available_range = available_range
-
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
+        self.metadata = metadata or {}
 
     name = core.serializable_field(
         "name",

--- a/opentimelineio/schema/effect.py
+++ b/opentimelineio/schema/effect.py
@@ -42,11 +42,7 @@ class Effect(core.SerializableObject):
         core.SerializableObject.__init__(self)
         self.name = name
         self.effect_name = effect_name
-
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
-        self.metadata = metadata
+        self.metadata = metadata or {}
 
     name = core.serializable_field(
         "name",

--- a/opentimelineio/schema/marker.py
+++ b/opentimelineio/schema/marker.py
@@ -67,10 +67,7 @@ class Marker(core.SerializableObject):
         self.name = name
         self.marked_range = marked_range
         self.color = color
-
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
+        self.metadata = metadata or {}
 
     name = core.serializable_field("name", str, "Name of this marker.")
 

--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -53,9 +53,7 @@ class Timeline(core.SerializableObject):
             tracks = []
         self.tracks = stack.Stack(name="tracks", children=tracks)
 
-        if metadata is None:
-            metadata = {}
-        self.metadata = metadata
+        self.metadata = metadata or {}
 
     name = core.serializable_field("name", doc="Name of this timeline.")
     tracks = core.serializable_field(

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -25,7 +25,7 @@ import unittest
 import os
 
 import opentimelineio as otio
-from tests import baseline_reader, utils
+import baseline_reader, utils
 
 """Unit tests for the adapter plugin system."""
 

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -25,7 +25,8 @@ import unittest
 import os
 
 import opentimelineio as otio
-import baseline_reader, utils
+import baseline_reader
+import utils
 
 """Unit tests for the adapter plugin system."""
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -481,15 +481,27 @@ class TrackTest(unittest.TestCase):
             ")"
         )
 
-    def test_range(self):
+    def test_instancing(self):
         length = otio.opentime.RationalTime(5, 1)
         tr = otio.opentime.TimeRange(otio.opentime.RationalTime(), length)
         it = otio.core.Item(source_range=tr)
         sq = otio.schema.Track(children=[it])
         self.assertEqual(sq.range_of_child_at_index(0), tr)
 
+        # TODO: Do we really want to support this case?
+        # It makes the whole _parent pointer thing really problematic...
         sq = otio.schema.Track(children=[it, it, it])
-        self.assertEqual(len(sq), 1)
+        self.assertEqual(len(sq), 3)
+
+        # del sq[1]
+        # self.assertEqual(len(sq), 2) -> you actually get 0
+
+    def test_range(self):
+        length = otio.opentime.RationalTime(5, 1)
+        tr = otio.opentime.TimeRange(otio.opentime.RationalTime(), length)
+        it = otio.core.Item(source_range=tr)
+        sq = otio.schema.Track(children=[it])
+        self.assertEqual(sq.range_of_child_at_index(0), tr)
 
         sq = otio.schema.Track(
             children=[it, it.copy(), it.copy(), it.copy()],

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -25,10 +25,10 @@
 import os
 import unittest
 
-from tests import baseline_reader
+import baseline_reader
 
 import opentimelineio as otio
-from tests import utils
+import utils
 
 LINKER_PATH = "media_linker_example"
 MANIFEST_PATH = "adapter_plugin_manifest.plugin_manifest"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,7 @@ import tempfile
 
 # import local modules
 import opentimelineio as otio
-from tests import baseline_reader
+import baseline_reader
 
 
 MANIFEST_PATH = "adapter_plugin_manifest.plugin_manifest"


### PR DESCRIPTION
Fixed a bug that caused problems if you tried to add an item to a Composition twice.
Minor cleanup of some imports that caused problems when running tests via PyCharm.
Minor cleanup of some property initialization.
This addresses #194 
