### PR TITLE
Refactor media reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build*
 dist*
 *.egg-info
 .coverage
+.DS_store

--- a/contrib/adapters/ale.py
+++ b/contrib/adapters/ale.py
@@ -92,7 +92,7 @@ def _parse_data_line(line, columns, fps):
 
         if metadata.get("Source File"):
             source = metadata.pop("Source File")
-            clip.media_reference = otio.media_reference.External(
+            clip.media_reference = otio.schema.ExternalReference(
                 target_url=source
             )
 

--- a/contrib/adapters/extern_maya_sequencer.py
+++ b/contrib/adapters/extern_maya_sequencer.py
@@ -162,7 +162,7 @@ def _read_shot(shot):
     start = int(cmds.shot(shot, q=True, startTime=True))
     end = int(cmds.shot(shot, q=True, endTime=True)) + 1
 
-    video_reference = otio.media_reference.External(
+    video_reference = otio.schema.ExternalReference(
         target_url=_video_url_for_shot(shot),
         available_range=otio.opentime.TimeRange(
             otio.opentime.RationalTime(value=start, rate=rate),

--- a/contrib/adapters/extern_rv.py
+++ b/contrib/adapters/extern_rv.py
@@ -246,7 +246,7 @@ def _write_item(it, to_session):
         it.media_reference and
         isinstance(
             it.media_reference,
-            otio.media_reference.External
+            otio.schema.ExternalReference
         )
     ):
         src.setMedia([str(it.media_reference.target_url)])

--- a/contrib/adapters/hls_playlist.py
+++ b/contrib/adapters/hls_playlist.py
@@ -44,7 +44,7 @@ In general, you can author otio as follows:
     t.tracks.append(track)
 
     # Make a prototype media ref with the fragment's initialization metadata
-    fragmented_media_ref = otio.media_reference.External(
+    fragmented_media_ref = otio.schema.ExternalReference(
         target_url='video1.mp4',
         metadata={
             "streaming": {
@@ -880,7 +880,7 @@ class MediaPlaylistParser(object):
 
     def _parse_entries(self, playlist_entries, playlist_version):
         """Interpret the entries through the lens of the schema"""
-        current_media_ref = otio.media_reference.External(
+        current_media_ref = otio.schema.ExternalReference(
             metadata={
                 FORMAT_METADATA_KEY: {},
                 STREAMING_METADATA_KEY: {}
@@ -911,7 +911,7 @@ class MediaPlaylistParser(object):
                 current_track += 1
 
                 # Set up the next segment definition
-                current_media_ref = otio.media_reference.External(
+                current_media_ref = otio.schema.ExternalReference(
                     metadata={
                         FORMAT_METADATA_KEY: {},
                         STREAMING_METADATA_KEY: {}

--- a/contrib/adapters/tests/test_hls_playlist_adapter.py
+++ b/contrib/adapters/tests/test_hls_playlist_adapter.py
@@ -130,7 +130,7 @@ class HLSPMedialaylistAdapterTest(unittest.TestCase):
         t.tracks.append(track)
 
         # Make a prototype media ref with the segment's initialization metadata
-        segmented_media_ref = otio.media_reference.External(
+        segmented_media_ref = otio.schema.ExternalReference(
             target_url='video1.mp4',
             metadata={
                 "streaming": {
@@ -662,7 +662,7 @@ class HLSPMasterPlaylistAdapterTest(unittest.TestCase):
         t.tracks.append(track)
 
         # Make a prototype media ref with the segment's initialization metadata
-        segmented_media_ref = otio.media_reference.External(
+        segmented_media_ref = otio.schema.ExternalReference(
             target_url='video1.mp4',
             metadata={
                 'streaming': {

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -125,7 +125,7 @@ def _conform_timeline(timeline, folder):
             continue
 
         # if we found one, then relink to the new path
-        clip.media_reference = otio.media_reference.External(
+        clip.media_reference = otio.schema.ExternalReference(
             target_url="file://" + new_path,
             available_range=None    # we don't know the available range
         )

--- a/examples/shot_detect.py
+++ b/examples/shot_detect.py
@@ -127,7 +127,7 @@ def _timeline_with_single_clip(name, full_path, dryrun=False):
     fps = _ffprobe_fps(name, full_path, dryrun)
     available_range = _media_start_end_of(full_path, fps)
 
-    media_reference = otio.media_reference.External(
+    media_reference = otio.schema.ExternalReference(
         target_url="file://" + full_path,
         available_range=available_range
     )
@@ -186,7 +186,7 @@ def _timeline_with_breaks(name, full_path, dryrun=False):
 
         available_range = _media_start_end_of(full_path, fps)
 
-        clip.media_reference = otio.media_reference.External(
+        clip.media_reference = otio.schema.ExternalReference(
             target_url="file://" + full_path,
             available_range=available_range
         )

--- a/opentimelineio/__init__.py
+++ b/opentimelineio/__init__.py
@@ -36,10 +36,8 @@ from . import (
     opentime,
     exceptions,
     core,
-    media_reference,
     schema,
     plugins,
     adapters,
-    media_linker,
     algorithms,
 )

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -319,12 +319,12 @@ class ClipHandler(object):
             clip.name = str(self.clip_num)
 
             if 'media_reference' in comment_data:
-                clip.media_reference = otio.media_reference.External()
+                clip.media_reference = otio.schema.ExternalReference()
                 clip.media_reference.target_url = comment_data[
                     'media_reference'
                 ]
             else:
-                clip.media_reference = otio.media_reference.MissingReference()
+                clip.media_reference = otio.schema.MissingReference()
 
             # this could currently break without a 'FROM CLIP' comment.
             # Without that there is no 'media_reference' Do we have a default

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -66,16 +66,16 @@ def _resolved_backreference(elem, tag, element_map):
 
 
 def _populate_backreference_map(item, br_map):
-    if isinstance(item, otio.media_reference.MediaReference):
+    if isinstance(item, otio.core.MediaReference):
         tag = 'file'
     elif isinstance(item, otio.schema.Track):
         tag = 'sequence'
     else:
         tag = None
 
-    if isinstance(item, otio.media_reference.External):
+    if isinstance(item, otio.schema.ExternalReference):
         item_hash = hash(str(item.target_url))
-    elif isinstance(item, otio.media_reference.MissingReference):
+    elif isinstance(item, otio.schema.MissingReference):
         item_hash = 'missing_ref'
     else:
         item_hash = item.__hash__()
@@ -111,9 +111,9 @@ def _backreference_build(tag):
         @functools.wraps(func)
         def wrapper(item, *args, **kwargs):
             br_map = args[-1]
-            if isinstance(item, otio.media_reference.External):
+            if isinstance(item, otio.schema.ExternalReference):
                 item_hash = hash(str(item.target_url))
-            elif isinstance(item, otio.media_reference.MissingReference):
+            elif isinstance(item, otio.schema.MissingReference):
                 item_hash = 'missing_ref'
             else:
                 item_hash = item.__hash__()
@@ -219,7 +219,7 @@ def _parse_media_reference(file_e, element_map):
         duration=otio.opentime.RationalTime(duration, file_rate)
     )
 
-    return otio.media_reference.External(
+    return otio.schema.ExternalReference(
         target_url=url.strip(),
         available_range=available_range
     )
@@ -789,7 +789,7 @@ def _build_item(item, timeline_range, transition_offsets, br_map):
     elif isinstance(item, otio.schema.Clip):
         if isinstance(
             item.media_reference,
-            otio.media_reference.MissingReference
+            otio.schema.MissingReference
         ):
             return _build_clip_item_without_media(
                 item,

--- a/opentimelineio/core/__init__.py
+++ b/opentimelineio/core/__init__.py
@@ -58,4 +58,6 @@ from .json_serializer import (
     deserialize_json_from_string,
     deserialize_json_from_file,
 )
-from . import media_reference
+from .media_reference import (
+    MediaReference,
+)

--- a/opentimelineio/core/__init__.py
+++ b/opentimelineio/core/__init__.py
@@ -26,7 +26,9 @@
 
 # flake8: noqa
 
-from . import serializable_object
+from . import (
+    serializable_object,
+)
 from .serializable_object import (
     SerializableObject,
     serializable_field,
@@ -56,3 +58,4 @@ from .json_serializer import (
     deserialize_json_from_string,
     deserialize_json_from_file,
 )
+from . import media_reference

--- a/opentimelineio/core/media_reference.py
+++ b/opentimelineio/core/media_reference.py
@@ -87,7 +87,7 @@ class MediaReference(serializable_object.SerializableObject):
 
     def __repr__(self):
         return (
-            "otio.media_reference.{}("
+            "otio.schema.{}("
             "name={},"
             " available_range={},"
             " metadata={}"
@@ -104,64 +104,5 @@ class MediaReference(serializable_object.SerializableObject):
             self.name,
             self._name,
             self.available_range,
-            self.metadata
-        )
-
-
-@type_registry.register_type
-class MissingReference(MediaReference):
-    """Represents media for which a concrete reference is missing."""
-
-    _serializable_label = "MissingReference.1"
-    _name = "MissingReference"
-
-    @property
-    def is_missing_reference(self):
-        return True
-
-
-@type_registry.register_type
-class External(MediaReference):
-    """Reference to media via a url, for example "file:///var/tmp/foo.mov" """
-
-    _serializable_label = "ExternalReference.1"
-    _name = "External"
-
-    def __init__(
-        self,
-        target_url=None,
-        available_range=None,
-        metadata=None,
-    ):
-        MediaReference.__init__(
-            self,
-            available_range=available_range,
-            metadata=metadata
-        )
-
-        self.target_url = target_url
-
-    target_url = serializable_object.serializable_field(
-        "target_url",
-        doc=(
-            "URL at which this media lives.  For local references, use the "
-            "'file://' format."
-        )
-    )
-
-    def __str__(self):
-        return 'External("{}")'.format(self.target_url)
-
-    def __repr__(self):
-        return 'otio.media_reference.External(target_url={})'.format(
-            repr(self.target_url)
-        )
-
-    def __hash__(self, other):
-        return hash(
-            self.name,
-            self._name,
-            self.available_range,
-            self.target_url,
             self.metadata
         )

--- a/opentimelineio/core/media_reference.py
+++ b/opentimelineio/core/media_reference.py
@@ -24,14 +24,17 @@
 
 """Media Reference Classes and Functions."""
 
-from . import (
+from .. import (
     opentime,
-    core,
+)
+from . import (
+    type_registry,
+    serializable_object,
 )
 
 
-@core.register_type
-class MediaReference(core.SerializableObject):
+@type_registry.register_type
+class MediaReference(serializable_object.SerializableObject):
     """Base Media Reference Class.
 
     Currently handles string printing the child classes, which expose interface
@@ -49,22 +52,22 @@ class MediaReference(core.SerializableObject):
         available_range=None,
         metadata=None
     ):
-        core.SerializableObject.__init__(self)
+        serializable_object.SerializableObject.__init__(self)
 
         self.name = name
         self.available_range = available_range
         self.metadata = metadata or {}
 
-    name = core.serializable_field(
+    name = serializable_object.serializable_field(
         "name",
         doc="Name of this media reference."
     )
-    available_range = core.serializable_field(
+    available_range = serializable_object.serializable_field(
         "available_range",
         opentime.TimeRange,
         doc="Available range of media in this media reference."
     )
-    metadata = core.serializable_field(
+    metadata = serializable_object.serializable_field(
         "metadata",
         dict,
         doc="Metadata dictionary."
@@ -105,7 +108,7 @@ class MediaReference(core.SerializableObject):
         )
 
 
-@core.register_type
+@type_registry.register_type
 class MissingReference(MediaReference):
     """Represents media for which a concrete reference is missing."""
 
@@ -117,7 +120,7 @@ class MissingReference(MediaReference):
         return True
 
 
-@core.register_type
+@type_registry.register_type
 class External(MediaReference):
     """Reference to media via a url, for example "file:///var/tmp/foo.mov" """
 
@@ -138,7 +141,7 @@ class External(MediaReference):
 
         self.target_url = target_url
 
-    target_url = core.serializable_field(
+    target_url = serializable_object.serializable_field(
         "target_url",
         doc=(
             "URL at which this media lives.  For local references, use the "

--- a/opentimelineio/media_linker.py
+++ b/opentimelineio/media_linker.py
@@ -26,11 +26,11 @@
 produce MediaReferences that point at valid, site specific media.
 
 They expose a "link_media_reference" function with the signature:
-link_media_reference :: otio.schema.Clip -> otio.media_reference.MediaReference
+link_media_reference :: otio.schema.Clip -> otio.core.MediaReference
 
 or:
     def linked_media_reference(from_clip):
-        result = otio.media_reference.MediaReference() # whichever subclass
+        result = otio.core.MediaReference() # whichever subclass
         # do stuff
         return result
 

--- a/opentimelineio/schema/__init__.py
+++ b/opentimelineio/schema/__init__.py
@@ -26,6 +26,12 @@
 
 """User facing classes."""
 
+from .missing_reference import (
+    MissingReference
+)
+from .external_reference import (
+    ExternalReference
+)
 from .clip import (
     Clip,
 ) 

--- a/opentimelineio/schema/clip.py
+++ b/opentimelineio/schema/clip.py
@@ -28,7 +28,9 @@ from .. import (
     core,
     exceptions,
 )
-from ..core import media_reference as mr
+from . import (
+    missing_reference
+)
 
 
 @core.register_type
@@ -58,27 +60,27 @@ class Clip(core.Item):
         self.name = name
 
         if not media_reference:
-            media_reference = mr.MissingReference()
+            media_reference = missing_reference.MissingReference()
         self._media_reference = media_reference
 
     name = core.serializable_field("name", doc="Name of this clip.")
     transform = core.deprecated_field()
     _media_reference = core.serializable_field(
         "media_reference",
-        mr.MediaReference,
+        core.MediaReference,
         "Media reference to the media this clip represents."
     )
 
     @property
     def media_reference(self):
         if self._media_reference is None:
-            self._media_reference = mr.MissingReference()
+            self._media_reference = missing_reference.MissingReference()
         return self._media_reference
 
     @media_reference.setter
     def media_reference(self, val):
         if val is None:
-            val = mr.MissingReference()
+            val = missing_reference.MissingReference()
         self._media_reference = val
 
     def available_range(self):

--- a/opentimelineio/schema/clip.py
+++ b/opentimelineio/schema/clip.py
@@ -26,9 +26,9 @@
 
 from .. import (
     core,
-    media_reference as mr,
     exceptions,
 )
+from ..core import media_reference as mr
 
 
 @core.register_type

--- a/opentimelineio/schema/external_reference.py
+++ b/opentimelineio/schema/external_reference.py
@@ -1,0 +1,78 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""
+Implementation of the ExternalReference media reference schema.
+"""
+
+from .. import (
+    core,
+)
+
+
+@core.register_type
+class ExternalReference(core.MediaReference):
+    """Reference to media via a url, for example "file:///var/tmp/foo.mov" """
+
+    _serializable_label = "ExternalReference.1"
+    _name = "ExternalReference"
+
+    def __init__(
+        self,
+        target_url=None,
+        available_range=None,
+        metadata=None,
+    ):
+        core.MediaReference.__init__(
+            self,
+            available_range=available_range,
+            metadata=metadata
+        )
+
+        self.target_url = target_url
+
+    target_url = core.serializable_field(
+        "target_url",
+        doc=(
+            "URL at which this media lives.  For local references, use the "
+            "'file://' format."
+        )
+    )
+
+    def __str__(self):
+        return 'ExternalReference("{}")'.format(self.target_url)
+
+    def __repr__(self):
+        return 'otio.schema.ExternalReference(target_url={})'.format(
+            repr(self.target_url)
+        )
+
+    def __hash__(self, other):
+        return hash(
+            self.name,
+            self._name,
+            self.available_range,
+            self.target_url,
+            self.metadata
+        )

--- a/opentimelineio/schema/missing_reference.py
+++ b/opentimelineio/schema/missing_reference.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""
+Implementation of the MisingReference media reference schema.
+"""
+
+from .. import (
+    core,
+)
+
+
+@core.register_type
+class MissingReference(core.MediaReference):
+    """Represents media for which a concrete reference is missing."""
+
+    _serializable_label = "MissingReference.1"
+    _name = "MissingReference"
+
+    @property
+    def is_missing_reference(self):
+        return True

--- a/tests/baselines/example.py
+++ b/tests/baselines/example.py
@@ -46,7 +46,7 @@ def read_from_string(input_str, suffix=""):
 def link_media_reference(in_clip, media_linker_argument_map):
     d = {'from_test_linker': True}
     d.update(media_linker_argument_map)
-    return otio.media_reference.MissingReference(
+    return otio.schema.MissingReference(
         name=in_clip.name + "_tweaked",
         metadata=d
     )

--- a/tests/test_cdl.py
+++ b/tests/test_cdl.py
@@ -22,13 +22,13 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-__doc__ = """Test CDL support in the EDL adapter."""
-
 # python
 import os
 import unittest
 
 import opentimelineio as otio
+
+__doc__ = """Test CDL support in the EDL adapter."""
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 CDL_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "cdl.edl")

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -89,7 +89,9 @@ class ClipTests(unittest.TestCase):
         )
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", ExternalReference("/var/tmp/foo.mov"), None, {})'
+            'Clip('
+            '"test_clip", ExternalReference("/var/tmp/foo.mov"), None, {}'
+            ')'
         )
         self.assertMultiLineEqual(
             repr(cl),

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -33,7 +33,7 @@ class ClipTests(unittest.TestCase):
         name = "test"
         rt = otio.opentime.RationalTime(5, 24)
         tr = otio.opentime.TimeRange(rt, rt)
-        mr = otio.media_reference.External(
+        mr = otio.schema.ExternalReference(
             available_range=otio.opentime.TimeRange(
                 rt,
                 otio.opentime.RationalTime(10, 24)
@@ -83,19 +83,19 @@ class ClipTests(unittest.TestCase):
     def test_str_with_filepath(self):
         cl = otio.schema.Clip(
             name="test_clip",
-            media_reference=otio.media_reference.External(
+            media_reference=otio.schema.ExternalReference(
                 "/var/tmp/foo.mov"
             )
         )
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", External("/var/tmp/foo.mov"), None, {})'
+            'Clip("test_clip", ExternalReference("/var/tmp/foo.mov"), None, {})'
         )
         self.assertMultiLineEqual(
             repr(cl),
             'otio.schema.Clip('
             "name='test_clip', "
-            "media_reference=otio.media_reference.External("
+            "media_reference=otio.schema.ExternalReference("
             "target_url='/var/tmp/foo.mov'"
             "), "
             'source_range=None, '
@@ -112,7 +112,7 @@ class ClipTests(unittest.TestCase):
 
         cl = otio.schema.Clip(
             name="test_clip",
-            media_reference=otio.media_reference.External(
+            media_reference=otio.schema.ExternalReference(
                 "/var/tmp/foo.mov",
                 available_range=tr
             )
@@ -137,19 +137,19 @@ class ClipTests(unittest.TestCase):
         cl = otio.schema.Clip()
         self.assertEqual(
             cl.media_reference,
-            otio.media_reference.MissingReference()
+            otio.schema.MissingReference()
         )
 
         cl.media_reference = None
         self.assertEqual(
             cl.media_reference,
-            otio.media_reference.MissingReference()
+            otio.schema.MissingReference()
         )
 
-        cl.media_reference = otio.media_reference.External()
+        cl.media_reference = otio.schema.ExternalReference()
         self.assertEqual(
             cl.media_reference,
-            otio.media_reference.External()
+            otio.schema.ExternalReference()
         )
 
 

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -141,7 +141,7 @@ class EDLAdapterTest(unittest.TestCase):
         track = otio.schema.Track()
         tl = otio.schema.Timeline("test_timeline", tracks=[track])
         rt = otio.opentime.RationalTime(5.0, 24.0)
-        mr = otio.media_reference.External(target_url="/var/tmp/test.mov")
+        mr = otio.schema.ExternalReference(target_url="/var/tmp/test.mov")
 
         tr = otio.opentime.TimeRange(
             start_time=otio.opentime.RationalTime(0.0, 24.0),
@@ -367,7 +367,7 @@ class EDLAdapterTest(unittest.TestCase):
         )
         self.assertEqual(
             timeline.tracks[0][0].media_reference,
-            otio.media_reference.External(
+            otio.schema.ExternalReference(
                 target_url=r"S:\path\to\ZZ100_501.take_1.0001.exr"
             )
         )
@@ -381,7 +381,7 @@ class EDLAdapterTest(unittest.TestCase):
         )
         self.assertEqual(
             timeline.tracks[0][1].media_reference,
-            otio.media_reference.External(
+            otio.schema.ExternalReference(
                 target_url=r"S:\path\to\ZZ100_502A.take_2.0101.exr"
             )
         )
@@ -390,7 +390,7 @@ class EDLAdapterTest(unittest.TestCase):
         track = otio.schema.Track()
         tl = otio.schema.Timeline("test_nucoda_timeline", tracks=[track])
         rt = otio.opentime.RationalTime(5.0, 24.0)
-        mr = otio.media_reference.External(target_url=r"S:\var\tmp\test.exr")
+        mr = otio.schema.ExternalReference(target_url=r"S:\var\tmp\test.exr")
 
         tr = otio.opentime.TimeRange(
             start_time=otio.opentime.RationalTime(0.0, 24.0),

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1158,7 +1158,7 @@ class NestingTest(unittest.TestCase):
         stack = timeline.tracks
         track = otio.schema.Track()
         clip = otio.schema.Clip()
-        media = otio.media_reference.MissingReference()
+        media = otio.schema.MissingReference()
         media.available_range = media_range
         clip.media_reference = media
         track.append(clip)

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -234,14 +234,14 @@ class AdaptersFcp7XmlTest(unittest.TestCase):
         timeline = otio.schema.Timeline('test_timeline')
         timeline.tracks.name = 'test_timeline'
 
-        video_reference = otio.media_reference.External(
+        video_reference = otio.schema.ExternalReference(
                 target_url="/var/tmp/test1.mov",
                 available_range=otio.opentime.TimeRange(
                     otio.opentime.RationalTime(value=100, rate=24.0),
                     otio.opentime.RationalTime(value=1000, rate=24.0)
                 )
             )
-        audio_reference = otio.media_reference.External(
+        audio_reference = otio.schema.ExternalReference(
                 target_url="/var/tmp/test1.wav",
                 available_range=otio.opentime.TimeRange(
                     otio.opentime.RationalTime(value=0, rate=24.0),

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -102,7 +102,7 @@ class TestJsonFormat(unittest.TestCase):
     def test_clip(self):
         cl = otio.schema.Clip(
             name="test_clip",
-            media_reference=otio.media_reference.MissingReference()
+            media_reference=otio.schema.MissingReference()
         )
         self.check_against_baseline(cl, "empty_clip")
 
@@ -111,11 +111,11 @@ class TestJsonFormat(unittest.TestCase):
         self.check_against_baseline(fl, "empty_gap")
 
     def test_missing_reference(self):
-        mr = otio.media_reference.MissingReference()
+        mr = otio.schema.MissingReference()
         self.check_against_baseline(mr, "empty_missingreference")
 
     def test_external_reference(self):
-        mr = otio.media_reference.External(target_url="foo.bar")
+        mr = otio.schema.ExternalReference(target_url="foo.bar")
         self.check_against_baseline(mr, "empty_external_reference")
 
     def test_marker(self):

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -68,7 +68,7 @@ class TestPluginMediaLinker(unittest.TestCase):
         cl = otio.schema.Clip(name="foo")
 
         linked_mr = self.mln.link_media_reference(cl, {"extra_data": True})
-        self.assertIsInstance(linked_mr, otio.media_reference.MissingReference)
+        self.assertIsInstance(linked_mr, otio.schema.MissingReference)
         self.assertEqual(linked_mr.name, cl.name + "_tweaked")
         self.assertEqual(linked_mr.metadata.get("extra_data"), True)
 

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -36,25 +36,25 @@ class MediaReferenceTests(unittest.TestCase):
             otio.opentime.RationalTime(5, 24),
             otio.opentime.RationalTime(10, 24.0)
         )
-        mr = otio.media_reference.MissingReference(
+        mr = otio.schema.MissingReference(
             available_range=tr,
             metadata={'show': 'OTIOTheMovie'}
         )
 
         self.assertEqual(mr.available_range, tr)
 
-        mr = otio.media_reference.MissingReference()
+        mr = otio.schema.MissingReference()
         self.assertIsNone(mr.available_range)
 
     def test_str_missing(self):
-        missing = otio.media_reference.MissingReference()
+        missing = otio.schema.MissingReference()
         self.assertMultiLineEqual(
             str(missing),
             "MissingReference(None, None, {})"
         )
         self.assertMultiLineEqual(
             repr(missing),
-            "otio.media_reference.MissingReference("
+            "otio.schema.MissingReference("
             "name=None, available_range=None, metadata={}"
             ")"
         )
@@ -64,14 +64,14 @@ class MediaReferenceTests(unittest.TestCase):
         self.assertEqual(missing, decoded)
 
     def test_filepath(self):
-        filepath = otio.media_reference.External("/var/tmp/foo.mov")
+        filepath = otio.schema.ExternalReference("/var/tmp/foo.mov")
         self.assertMultiLineEqual(
             str(filepath),
-            'External("/var/tmp/foo.mov")'
+            'ExternalReference("/var/tmp/foo.mov")'
         )
         self.assertMultiLineEqual(
             repr(filepath),
-            "otio.media_reference.External("
+            "otio.schema.ExternalReference("
             "target_url='/var/tmp/foo.mov'"
             ")"
         )
@@ -82,30 +82,30 @@ class MediaReferenceTests(unittest.TestCase):
         self.assertEqual(filepath, decoded)
 
     def test_equality(self):
-        filepath = otio.media_reference.External(target_url="/var/tmp/foo.mov")
-        filepath2 = otio.media_reference.External(
+        filepath = otio.schema.ExternalReference(target_url="/var/tmp/foo.mov")
+        filepath2 = otio.schema.ExternalReference(
             target_url="/var/tmp/foo.mov"
         )
         self.assertEqual(filepath, filepath2)
 
-        bl = otio.media_reference.MissingReference()
+        bl = otio.schema.MissingReference()
         self.assertNotEqual(filepath, bl)
 
-        filepath = otio.media_reference.External(target_url="/var/tmp/foo.mov")
-        filepath2 = otio.media_reference.External(
+        filepath = otio.schema.ExternalReference(target_url="/var/tmp/foo.mov")
+        filepath2 = otio.schema.ExternalReference(
             target_url="/var/tmp/foo2.mov"
         )
         self.assertNotEqual(filepath, filepath2)
         self.assertEqual(filepath == filepath2, False)
 
-        bl = otio.media_reference.MissingReference()
+        bl = otio.schema.MissingReference()
         self.assertNotEqual(filepath, bl)
 
     def test_is_missing(self):
-        mr = otio.media_reference.External(target_url="/var/tmp/foo.mov")
+        mr = otio.schema.ExternalReference(target_url="/var/tmp/foo.mov")
         self.assertFalse(mr.is_missing_reference)
 
-        mr = otio.media_reference.MissingReference()
+        mr = otio.schema.MissingReference()
         self.assertTrue(mr.is_missing_reference)
 
 

--- a/tests/test_sequence_algo.py
+++ b/tests/test_sequence_algo.py
@@ -51,7 +51,7 @@ class TransitionExpansionTests(unittest.TestCase):
             otio.opentime.RationalTime(0, 24),
             otio.opentime.RationalTime(50, 24)
         )
-        mr = otio.media_reference.External(
+        mr = otio.schema.ExternalReference(
             available_range=avail_tr,
             target_url="/var/tmp/test.mov"
         )
@@ -145,7 +145,7 @@ class TransitionExpansionTests(unittest.TestCase):
             otio.opentime.RationalTime(0, 24),
             otio.opentime.RationalTime(50, 24)
         )
-        mr = otio.media_reference.External(
+        mr = otio.schema.ExternalReference(
             available_range=avail_tr,
             target_url="/var/tmp/test.mov"
         )

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -31,7 +31,7 @@ class SerializableCollectionTests(unittest.TestCase):
     def setUp(self):
         self.children = [
             otio.schema.Clip(name="testClip"),
-            otio.media_reference.MissingReference()
+            otio.schema.MissingReference()
         ]
         self.md = {'foo': 'bar'}
         self.sc = otio.schema.SerializableCollection(

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -50,7 +50,7 @@ class TimelineTests(unittest.TestCase):
         track = otio.schema.Track(name="test_track")
         tl = otio.schema.Timeline("test_timeline", tracks=[track])
         rt = otio.opentime.RationalTime(5, 24)
-        mr = otio.media_reference.External(
+        mr = otio.schema.ExternalReference(
             available_range=otio.opentime.range_from_start_end_time(
                 otio.opentime.RationalTime(5, 24),
                 otio.opentime.RationalTime(15, 24)
@@ -88,7 +88,7 @@ class TimelineTests(unittest.TestCase):
         track = otio.schema.Track(name="test_track")
         tl = otio.schema.Timeline("test_timeline", tracks=[track])
         rt = otio.opentime.RationalTime(5, 24)
-        mr = otio.media_reference.External(
+        mr = otio.schema.ExternalReference(
             available_range=otio.opentime.range_from_start_end_time(
                 otio.opentime.RationalTime(5, 24),
                 otio.opentime.RationalTime(15, 24)
@@ -133,7 +133,7 @@ class TimelineTests(unittest.TestCase):
         self.maxDiff = None
         clip = otio.schema.Clip(
             name="test_clip",
-            media_reference=otio.media_reference.MissingReference()
+            media_reference=otio.schema.MissingReference()
         )
         track = otio.schema.Track(name="test_track", children=[clip])
         tl = otio.schema.Timeline(name="test_timeline", tracks=[track])
@@ -155,7 +155,7 @@ class TimelineTests(unittest.TestCase):
     def test_serialize_timeline(self):
         clip = otio.schema.Clip(
             name="test_clip",
-            media_reference=otio.media_reference.MissingReference()
+            media_reference=otio.schema.MissingReference()
         )
         tl = otio.schema.timeline_from_clips([clip])
         encoded = otio.adapters.otio_json.write_to_string(tl)
@@ -168,7 +168,7 @@ class TimelineTests(unittest.TestCase):
     def test_serialization_of_subclasses(self):
         clip1 = otio.schema.Clip()
         clip1.name = "Test Clip"
-        clip1.media_reference = otio.media_reference.External(
+        clip1.media_reference = otio.schema.ExternalReference(
             "/tmp/foo.mov"
         )
         tl1 = otio.schema.timeline_from_clips([clip1])


### PR DESCRIPTION
This is to clear room to make `GeneratorReference` a child class of `MediaReference`.

- Move `otio.media_reference` -> `otio.core.media_reference`
- Rename `media_reference.External` to `schema.ExternalReference`
- Move `MissingReference` into Schema.