### PR TITLE
Frame numbers (not just timecode) are ok

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -472,6 +472,18 @@ class ClipHandler(object):
                 'incorrect number of fields [{0}] in form statement: {1}'
                 ''.format(field_count, line))
 
+        # Frame numbers (not just timecode) are ok
+        for prop in ['source_tc_in', 'source_tc_out', 'record_tc_in', 'record_tc_out']:
+            if ':' not in getattr(self, prop):
+                setattr(
+                    self,
+                    prop,
+                    otio.opentime.to_timecode(
+                        otio.opentime.from_frames(int(getattr(self, prop)), self.edl_rate),
+                        self.edl_rate
+                    )
+                )
+
 
 class CommentHandler(object):
     # this is the for that all comment 'id' tags take

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -473,13 +473,21 @@ class ClipHandler(object):
                 ''.format(field_count, line))
 
         # Frame numbers (not just timecode) are ok
-        for prop in ['source_tc_in', 'source_tc_out', 'record_tc_in', 'record_tc_out']:
+        for prop in [
+            'source_tc_in',
+            'source_tc_out',
+            'record_tc_in',
+            'record_tc_out'
+        ]:
             if ':' not in getattr(self, prop):
                 setattr(
                     self,
                     prop,
                     otio.opentime.to_timecode(
-                        otio.opentime.from_frames(int(getattr(self, prop)), self.edl_rate),
+                        otio.opentime.from_frames(
+                            int(getattr(self, prop)),
+                            self.edl_rate
+                        ),
                         self.edl_rate
                     )
                 )

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -699,3 +699,21 @@ class EDLAdapterTest(unittest.TestCase):
                 duration=otio.opentime.from_timecode("00:00:01:24", 25)
             )
         )
+
+    def test_can_read_frame_cut_points(self):
+        # EXERCISE
+        tl = otio.adapters.read_from_string(
+            '1 CLPA V C     113 170 0 57\n'
+            '2 CLPA V C     170 170 57 57\n'
+            '2 CLPB V D 027 162 189 57 84\n'
+            '3 CLPB V C     189 381 84 276\n',
+            adapter_name="cmx_3600"
+        )
+
+        # VALIDATE
+        self.assertEqual(tl.duration().value, 276)
+        self.assertEqual(len(tl.tracks[0]), 3)
+        self.assertEqual(tl.tracks[0][0].duration().value, 70)
+        self.assertEqual(tl.tracks[0][1].in_offset.value, 13)
+        self.assertEqual(tl.tracks[0][1].out_offset.value, 14)
+        self.assertEqual(tl.tracks[0][2].duration().value, 206)


### PR DESCRIPTION
We've observed that EDLs with frame numbers, as opposed to timecode, are valid.  For example:

```
1 CLPA V C     113 170 0  57
2 CLPA V C     170 170 57 57
2 CLPB V D 027 162 189 57 84
3 CLPB V C     189 381 84 276
```