### PR TITLE
Usability improvements to the schema.track.neighbors_of method.

### DIFF
--- a/opentimelineio/algorithms/track_algo.py
+++ b/opentimelineio/algorithms/track_algo.py
@@ -140,7 +140,7 @@ def _expand_transition(target_transition, from_track):
     trx_duration = target_transition.in_offset + target_transition.out_offset
 
     # make copies of the before and after, and modify their in/out points
-    pre = copy.deepcopy(result[0])
+    pre = copy.deepcopy(result.previous)
 
     if isinstance(pre, schema.Transition):
         raise exceptions.TransitionFollowingATransitionError(
@@ -173,7 +173,7 @@ def _expand_transition(target_transition, from_track):
         pre.source_range.start_time
     )
 
-    post = copy.deepcopy(result[2])
+    post = copy.deepcopy(result.next)
     if isinstance(post, schema.Transition):
         raise exceptions.TransitionFollowingATransitionError(
             "cannot put two transitions next to each other in a  track: "

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -176,7 +176,7 @@ class Track(core.Composition):
         elif index < len(self) - 1:
             next_item = self[index + 1]
 
-        return collections.namedtuple('neighbors', ('previous','next'))(
+        return collections.namedtuple('neighbors', ('previous', 'next'))(
             previous,
             next_item
         )

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -24,6 +24,8 @@
 
 """Implement Track sublcass of composition."""
 
+import collections
+
 from .. import (
     core,
     opentime,
@@ -121,6 +123,24 @@ class Track(core.Composition):
         return self.each_child(search_range, clip.Clip)
 
     def neighbors_of(self, item, insert_gap=NeighborGapPolicy.never):
+        """Returns the neighbors of the item as a namedtuple, (previous, next).
+
+        Can optionally fill in gaps when transitions have no gaps next to them.
+
+        with insert_gap == NeighborGapPolicy.never:
+        [A, B, C] :: neighbors_of(B) -> (A, C)
+        [A, B, C] :: neighbors_of(A) -> (None, B)
+        [A, B, C] :: neighbors_of(C) -> (B, None)
+        [A] :: neighbors_of(A) -> (None, None)
+
+        with insert_gap == NeighborGapPolicy.around_transitions:
+            (assuming A and C are transitions)
+        [A, B, C] :: neighbors_of(B) -> (A, C)
+        [A, B, C] :: neighbors_of(A) -> (Gap, B)
+        [A, B, C] :: neighbors_of(C) -> (B, Gap)
+        [A] :: neighbors_of(A) -> (Gap, Gap)
+        """
+
         try:
             index = self.index(item)
         except ValueError:
@@ -131,7 +151,7 @@ class Track(core.Composition):
                 )
             )
 
-        result = []
+        previous, next_item = None, None
 
         # look before index
         if (
@@ -139,30 +159,27 @@ class Track(core.Composition):
             and insert_gap == NeighborGapPolicy.around_transitions
             and isinstance(item, transition.Transition)
         ):
-            result.append(
-                gap.Gap(
-                    source_range=opentime.TimeRange(duration=item.in_offset)
-                )
+            previous = gap.Gap(
+                source_range=opentime.TimeRange(duration=item.in_offset)
             )
         elif index > 0:
-            result.append(self[index - 1])
-
-        result.append(item)
+            previous = self[index - 1]
 
         if (
             index == len(self) - 1
             and insert_gap == NeighborGapPolicy.around_transitions
             and isinstance(item, transition.Transition)
         ):
-            result.append(
-                gap.Gap(
-                    source_range=opentime.TimeRange(duration=item.out_offset)
-                )
+            next_item = gap.Gap(
+                source_range=opentime.TimeRange(duration=item.out_offset)
             )
         elif index < len(self) - 1:
-            result.append(self[index + 1])
+            next_item = self[index + 1]
 
-        return result
+        return collections.namedtuple('neighbors', ('previous','next'))(
+            previous,
+            next_item
+        )
 
 
 # the original name for "track" was "sequence" - this will turn "Sequence"

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1081,7 +1081,7 @@ class TrackTest(unittest.TestCase):
             seq[0],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, [trans])
+        self.assertEqual(neighbors, (None, None))
 
         # test with the neighbor filling policy on
         neighbors = seq.neighbors_of(
@@ -1093,7 +1093,15 @@ class TrackTest(unittest.TestCase):
                 duration=trans.in_offset
             )
         )
-        self.assertEqual(neighbors, [fill, trans, fill])
+        self.assertEqual(neighbors, ( fill, fill ))
+
+    def test_neighbors_of_no_expand(self):
+        seq = otio.schema.Track()
+        seq.append(otio.schema.Clip())
+        n = seq.neighbors_of(seq[0])
+        self.assertEqual(n, (None,None))
+        self.assertIs(n.previous, (None))
+        self.assertIs(n.next, (None))
 
     def test_neighbors_of_from_data(self):
         self.maxDiff = None
@@ -1109,14 +1117,7 @@ class TrackTest(unittest.TestCase):
             seq[0],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, [seq[0], seq[1]])
-
-        # neighbors of first transition
-        neighbors = seq.neighbors_of(
-            seq[0],
-            otio.schema.NeighborGapPolicy.never
-        )
-        self.assertEqual(neighbors, [seq[0], seq[1]])
+        self.assertEqual(neighbors, ( None, seq[1] ))
 
         fill = otio.schema.Gap(
             source_range=otio.opentime.TimeRange(
@@ -1128,28 +1129,28 @@ class TrackTest(unittest.TestCase):
             seq[0],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, [fill, seq[0], seq[1]])
+        self.assertEqual(neighbors, ( fill, seq[1] ))
 
         # neighbor around second transition
         neighbors = seq.neighbors_of(
             seq[2],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, [seq[1], seq[2], seq[3]])
+        self.assertEqual(neighbors, ( seq[1], seq[3] ))
 
         # no change w/ different policy
         neighbors = seq.neighbors_of(
             seq[2],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, [seq[1], seq[2], seq[3]])
+        self.assertEqual(neighbors, ( seq[1], seq[3] ))
 
         # neighbor around third transition
         neighbors = seq.neighbors_of(
             seq[5],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, [seq[4], seq[5]])
+        self.assertEqual(neighbors, ( seq[4], None ))
 
         fill = otio.schema.Gap(
             source_range=otio.opentime.TimeRange(
@@ -1161,7 +1162,7 @@ class TrackTest(unittest.TestCase):
             seq[5],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, [seq[4], seq[5], fill])
+        self.assertEqual(neighbors, ( seq[4], fill ))
 
 
 class EdgeCases(unittest.TestCase):

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1093,13 +1093,13 @@ class TrackTest(unittest.TestCase):
                 duration=trans.in_offset
             )
         )
-        self.assertEqual(neighbors, ( fill, fill ))
+        self.assertEqual(neighbors, (fill, fill))
 
     def test_neighbors_of_no_expand(self):
         seq = otio.schema.Track()
         seq.append(otio.schema.Clip())
         n = seq.neighbors_of(seq[0])
-        self.assertEqual(n, (None,None))
+        self.assertEqual(n, (None, None))
         self.assertIs(n.previous, (None))
         self.assertIs(n.next, (None))
 
@@ -1117,7 +1117,7 @@ class TrackTest(unittest.TestCase):
             seq[0],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, ( None, seq[1] ))
+        self.assertEqual(neighbors, (None, seq[1]))
 
         fill = otio.schema.Gap(
             source_range=otio.opentime.TimeRange(
@@ -1129,28 +1129,28 @@ class TrackTest(unittest.TestCase):
             seq[0],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, ( fill, seq[1] ))
+        self.assertEqual(neighbors, (fill, seq[1]))
 
         # neighbor around second transition
         neighbors = seq.neighbors_of(
             seq[2],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, ( seq[1], seq[3] ))
+        self.assertEqual(neighbors, (seq[1], seq[3]))
 
         # no change w/ different policy
         neighbors = seq.neighbors_of(
             seq[2],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, ( seq[1], seq[3] ))
+        self.assertEqual(neighbors, (seq[1], seq[3]))
 
         # neighbor around third transition
         neighbors = seq.neighbors_of(
             seq[5],
             otio.schema.NeighborGapPolicy.never
         )
-        self.assertEqual(neighbors, ( seq[4], None ))
+        self.assertEqual(neighbors, (seq[4], None))
 
         fill = otio.schema.Gap(
             source_range=otio.opentime.TimeRange(
@@ -1162,7 +1162,7 @@ class TrackTest(unittest.TestCase):
             seq[5],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, ( seq[4], fill ))
+        self.assertEqual(neighbors, (seq[4], fill))
 
 
 class EdgeCases(unittest.TestCase):


### PR DESCRIPTION
Switch track.neighbors_of to return a collections.namedtuple: `(previous, next)`

- now returns a `collections.namedtuple`, so `result.previous` is always the previous item, and `result.next` is always the next one
- if set to not expand around transitions or if the item is not a transition, will return None as the next/previous item.
- Better documentation on how the method behaves.