### PR TITLE
Add functions for filtering OTIO hierarchies.

### DIFF
--- a/opentimelineio/algorithms/__init__.py
+++ b/opentimelineio/algorithms/__init__.py
@@ -35,6 +35,6 @@ from .stack_algo import (
 )
 
 from .filter import (
-    filtered_items,
+    filtered_composition,
     filtered_with_sequence_context
 )

--- a/opentimelineio/algorithms/__init__.py
+++ b/opentimelineio/algorithms/__init__.py
@@ -33,3 +33,8 @@ from .track_algo import (
 from .stack_algo import (
     flatten_stack
 )
+
+from .filter import (
+    filtered_items,
+    reduced_items
+)

--- a/opentimelineio/algorithms/__init__.py
+++ b/opentimelineio/algorithms/__init__.py
@@ -36,5 +36,5 @@ from .stack_algo import (
 
 from .filter import (
     filtered_items,
-    reduced_items
+    filtered_with_sequence_context
 )

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -41,7 +41,7 @@ def filtered_items(
     input_object,
     unary_filter_fn,
     types_to_prune=None,
-    types_to_pass_through=None,
+    types_to_filter=None,
 ):
     """Filter input_object with unary_filter_fn to make a new copy of object.
 
@@ -116,10 +116,7 @@ def filtered_items(
         if (types_to_prune and _isinstance_in(child, types_to_prune)):
             result = None
         # then try to pass through
-        elif (
-            types_to_pass_through
-            and _isinstance_in(child, types_to_pass_through)
-        ):
+        elif types_to_filter and not _isinstance_in(child, types_to_filter):
             result = child
         # finally call the user function
         else:
@@ -151,7 +148,7 @@ def filtered_with_sequence_context(
     input_object,
     reduce_fn,
     types_to_prune=None,
-    types_to_pass_through=None,
+    types_to_filter=None,
 ):
     """Filter input_object with reduce_fn to make a new copy of object.
 
@@ -211,14 +208,15 @@ def filtered_with_sequence_context(
     So the result is:
         [A, D, E, C]
 
-    Additionally, types_to_prune and types_to_pass_through let you skip or 
+    Additionally, types_to_prune and types_to_filter let you skip or 
     prune classes without having to build logic into your function.
 
     The order of operation is:
         for each thing to iterate on: 
             1 if it isinstance of anything in the prune list, prune it.
-            2 if it isinstance of anything in the pass_through_list, pass it 
-                through, without giving it to your function
+            2 if it is not isinstance of anything in the types_to_filter, 
+                or the types_to_filter is None, pass it through, without 
+                giving it to your function
             3 otherwise, call the reduce_fn and process according to the result.
     """
 
@@ -265,10 +263,7 @@ def filtered_with_sequence_context(
         if (types_to_prune and _isinstance_in(child, types_to_prune)):
             result = None
         # then try to pass through
-        elif (
-            types_to_pass_through
-            and _isinstance_in(child, types_to_pass_through)
-        ):
+        elif types_to_filter and not _isinstance_in(child, types_to_filter):
             result = child
         # finally call the user function
         else:

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -29,7 +29,6 @@ import copy
 import opentimelineio as otio
 
 
-
 def _filtered_iterable(iterable, unary_filter_fn):
     # filter the root object
     new_parent = unary_filter_fn(copy.deepcopy(iterable))
@@ -49,10 +48,11 @@ def _filtered_iterable(iterable, unary_filter_fn):
 
     return new_parent
 
+
 def filtered_items(input_object, unary_filter_fn):
-    """Create a new copy of input_object whose children have been processed by 
-    unary_filter_fn.  If unary_filter_fn returns an object, that object will 
-    get placed there, otherwise if unary_filter_fn returns none, it will be 
+    """Create a new copy of input_object whose children have been processed by
+    unary_filter_fn.  If unary_filter_fn returns an object, that object will
+    get placed there, otherwise if unary_filter_fn returns none, it will be
     skipped.
     """
 
@@ -90,36 +90,42 @@ def _reduced_iterable(iterable, reduce_fn, prev=None, next_item=None):
     next_item = next(target_iter, None)
 
     while current_item is not None:
-        reduced_child = reduced_items(current_item, reduce_fn, prev_item, next_item)
+        reduced_child = reduced_items(
+            current_item,
+            reduce_fn,
+            prev_item,
+            next_item
+        )
         if reduced_child:
             if not isinstance(reduced_child, tuple):
                 reduced_child = [reduced_child]
             new_parent.extend(reduced_child)
 
-         # iterate
+        # iterate
         prev_item = current_item
         current_item = next_item
         next_item = next(target_iter, None)
 
     return new_parent
 
+
 def reduced_items(input_object, reduce_fn, prev_item=None, next_item=None):
-    """Create a new copy of input_object whose children have been processed by 
-    reduce_fn, which is a function that takes three arguments: 
+    """Create a new copy of input_object whose children have been processed by
+    reduce_fn, which is a function that takes three arguments:
         (prev, current, next)
-    If reduce_fn returns an object, that object will get placed there (as 
+    If reduce_fn returns an object, that object will get placed there (as
     current), otherwise if reduce_fn returns none, it will be skipped.
 
     If an object from the parent is skipped, it will still be the prev item to
     the next invocation.
 
-    EG if you filter [A,B,C] and your reduce_fn removes B only, the reduce_fn 
+    EG if you filter [A,B,C] and your reduce_fn removes B only, the reduce_fn
     will be called three times with the arguments:
         (None, A, B) => modified version of A
         (A, B, C) => None
         (B, C, None) => modified version of C.
 
-    Every argument has been deepcopy'd from the source, so this is non 
+    Every argument has been deepcopy'd from the source, so this is non
     destructive.
     """
 
@@ -139,5 +145,3 @@ def reduced_items(input_object, reduce_fn, prev_item=None, next_item=None):
         result = reduce_fn(prev_item, input_object, next_item)
 
     return result
-
-

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""Algorithms for filtering OTIO files.  """
+
+import copy
+import opentimelineio as otio
+
+
+
+def _filtered_iterable(iterable, unary_filter_fn):
+    # filter the root object
+    new_parent = unary_filter_fn(copy.deepcopy(iterable))
+    if not new_parent:
+        return None
+
+    # empty the new parent
+    del new_parent[:]
+
+    # filter the children
+    for child in iterable:
+        filtered_child = filtered_items(child, unary_filter_fn)
+        if filtered_child:
+            new_parent.append(filtered_child)
+
+    return new_parent
+
+def filtered_items(input_object, unary_filter_fn):
+    """Create a new copy of input_object whose children have been processed by 
+    unary_filter_fn.  If unary_filter_fn returns an object, that object will 
+    get placed there, otherwise if unary_filter_fn returns none, it will be 
+    skipped.
+    """
+
+    if isinstance(input_object, otio.schema.Timeline):
+        result = copy.deepcopy(input_object)
+        del result.tracks[:]
+        child = filtered_items(input_object.tracks, unary_filter_fn)
+        if child:
+            result.tracks.extend(child)
+    elif isinstance(input_object, otio.core.Composition):
+        result = copy.deepcopy(input_object)
+        del result[:]
+        child = _filtered_iterable(input_object, unary_filter_fn)
+        if child:
+            result.extend(child)
+    else:
+        result = unary_filter_fn(input_object)
+
+    return result
+
+
+def _reduced_iterable(iterable, reduce_fn, prev=None, next_item=None):
+    # filter the root object
+    new_parent = reduce_fn(prev, copy.deepcopy(iterable), next_item)
+    if not new_parent:
+        return None
+
+    # empty the new parent
+    del new_parent[:]
+
+    target_iter = iter(iterable)
+
+    prev_item = None
+    current_item = next(target_iter, None)
+    next_item = next(target_iter, None)
+
+    while current_item is not None:
+        reduced_child = reduced_items(current_item, reduce_fn, prev_item, next_item)
+        if reduced_child:
+            new_parent.append(reduced_child)
+
+        # iterate
+        prev_item = current_item
+        current_item = next_item
+        next_item = next(target_iter, None)
+
+    return new_parent
+    
+
+
+def reduced_items(input_object, reduce_fn, prev_item=None, next_item=None):
+    """Create a new copy of input_object whose children have been processed by 
+    reduce_fn, which is a function that takes three arguments: 
+        (prev, current, next)
+    If reduce_fn returns an object, that object will get placed there (as 
+    current), otherwise if reduce_fn returns none, it will be skipped.
+
+    If an object from the parent is skipped, it will still be the prev item to
+    the next invocation.
+
+    EG if you filter [A,B,C] and your reduce_fn removes B only, the reduce_fn 
+    will be called three times with the arguments:
+        (None, A, B) => modified version of A
+        (A, B, C) => None
+        (B, C, None) => modified version of C.
+
+    Every argument has been deepcopy'd from the source, so this is non 
+    destructive.
+    """
+
+    if isinstance(input_object, otio.schema.Timeline):
+        result = copy.deepcopy(input_object)
+        del result.tracks[:]
+        child = reduced_items(input_object.tracks, reduce_fn)
+        if child:
+            result.tracks.extend(child)
+    elif isinstance(input_object, otio.core.Composition):
+        result = copy.deepcopy(input_object)
+        del result[:]
+        child = _reduced_iterable(input_object, reduce_fn)
+        if child:
+            result.extend(child)
+    else:
+        result = reduce_fn(prev_item, input_object, next_item)
+
+    return result
+
+

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -49,6 +49,7 @@ def _filtered_iterable(iterable, unary_filter_fn):
     return new_parent
 
 
+# @TODO: does the unary function get a copy or not
 def filtered_items(input_object, unary_filter_fn):
     """Create a new copy of input_object whose children have been processed by
     unary_filter_fn.  If unary_filter_fn returns an object, that object will
@@ -60,9 +61,11 @@ def filtered_items(input_object, unary_filter_fn):
         result = copy.deepcopy(input_object)
         del result.tracks[:]
         child = filtered_items(input_object.tracks, unary_filter_fn)
+        # @TODO: this case is problematic, the stack gets copied and extended twice
         if child:
             result.tracks.extend(child)
     elif isinstance(input_object, otio.core.Composition):
+        # @TODO: doesn't need to copy the parent again
         result = copy.deepcopy(input_object)
         del result[:]
         child = _filtered_iterable(input_object, unary_filter_fn)

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -43,7 +43,9 @@ def _filtered_iterable(iterable, unary_filter_fn):
     for child in iterable:
         filtered_child = filtered_items(child, unary_filter_fn)
         if filtered_child:
-            new_parent.append(filtered_child)
+            if not isinstance(filtered_child, tuple):
+                filtered_child = [filtered_child]
+            new_parent.extend(filtered_child)
 
     return new_parent
 
@@ -90,16 +92,16 @@ def _reduced_iterable(iterable, reduce_fn, prev=None, next_item=None):
     while current_item is not None:
         reduced_child = reduced_items(current_item, reduce_fn, prev_item, next_item)
         if reduced_child:
-            new_parent.append(reduced_child)
+            if not isinstance(reduced_child, tuple):
+                reduced_child = [reduced_child]
+            new_parent.extend(reduced_child)
 
-        # iterate
+         # iterate
         prev_item = current_item
         current_item = next_item
         next_item = next(target_iter, None)
 
     return new_parent
-    
-
 
 def reduced_items(input_object, reduce_fn, prev_item=None, next_item=None):
     """Create a new copy of input_object whose children have been processed by 

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -208,16 +208,16 @@ def filtered_with_sequence_context(
     So the result is:
         [A, D, E, C]
 
-    Additionally, types_to_prune and types_to_filter let you skip or 
+    Additionally, types_to_prune and types_to_filter let you skip or
     prune classes without having to build logic into your function.
 
     The order of operation is:
-        for each thing to iterate on: 
+        for each thing to iterate on:
             1 if it isinstance of anything in the prune list, prune it.
-            2 if it is not isinstance of anything in the types_to_filter, 
-                or the types_to_filter is None, pass it through, without 
+            2 if it is not isinstance of anything in the types_to_filter,
+                or the types_to_filter is None, pass it through, without
                 giving it to your function
-            3 otherwise, call the reduce_fn and process according to the result.
+            3 otherwise, call the reduce_fn and process according to the result
     """
 
     # deep copy everything

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -134,7 +134,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
         result = otio.algorithms.filtered_items(
             tr,
-            lambda _:_,
+            lambda _: _,
             types_to_prune=(otio.schema.Clip,)
         )
         self.assertEqual(0, len(result))
@@ -153,7 +153,8 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         tr.append(otio.schema.Gap(name='gap1', metadata=md))
 
         self.called = 0
-        def should_get_called_once(_, __,___):
+
+        def should_get_called_once(_, __, ___):
             self.called += 1
             return __
 
@@ -272,7 +273,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         result = otio.algorithms.filtered_with_sequence_context(
             tr,
-            lambda _,__,___:__,
+            lambda _, __, ___: __,
             types_to_prune=(otio.schema.Clip,)
         )
         self.assertEqual(0, len(result))
@@ -291,6 +292,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         tr.append(otio.schema.Gap(name='gap1', metadata=md))
 
         self.called = 0
+
         def should_get_called_once(_):
             self.called += 1
             return _

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -147,30 +147,6 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         del tr[:]
         self.assertEqual(tr, result)
 
-    def test_passthrough_by_type(self):
-        """Test pass through using the types_to_filter list"""
-
-        md = {'test': 'bar'}
-        tr = otio.schema.Track(name='foo', metadata=md)
-        tr.append(otio.schema.Clip(name='cl1', metadata=md))
-        tr.append(otio.schema.Gap(name='gap1', metadata=md))
-
-        self.called = 0
-
-        def should_get_called_once(_, __, ___):
-            self.called += 1
-            return __
-
-        result = otio.algorithms.filtered_with_sequence_context(
-            tr,
-            should_get_called_once,
-            types_to_filter=(otio.schema.Clip,)
-        )
-
-        # emptying the track should have the same effect
-        self.assertEqual(tr, result)
-        self.assertEqual(self.called, 1)
-
     def test_copy(self):
         md = {'test': 'bar'}
         tl = otio.schema.Timeline(name='foo', metadata=md)
@@ -284,30 +260,6 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         # emptying the track should have the same effect
         del tr[:]
-        self.assertEqual(tr, result)
-
-    def test_passthrough_by_type(self):
-        """Test pass through using the types_to_filter list"""
-
-        md = {'test': 'bar'}
-        tr = otio.schema.Track(name='foo', metadata=md)
-        tr.append(otio.schema.Clip(name='cl1', metadata=md))
-        tr.append(otio.schema.Gap(name='gap1', metadata=md))
-
-        self.called = 0
-
-        def should_get_called_once(_):
-            self.called += 1
-            return _
-
-        result = otio.algorithms.filtered_composition(
-            tr,
-            should_get_called_once,
-            types_to_filter=(otio.schema.Clip,)
-        )
-        self.assertEqual(1, self.called)
-
-        # emptying the track should have the same effect
         self.assertEqual(tr, result)
 
     def test_insert_tuple(self):

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -125,6 +125,47 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         del tr[:]
         self.assertEqual(tr, result)
 
+    def test_prune_by_type_args(self):
+        """Test pruning using the types_to_prune list"""
+
+        md = {'test': 'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        result = otio.algorithms.filtered_items(
+            tr,
+            lambda _:_,
+            types_to_prune=(otio.schema.Clip,)
+        )
+        self.assertEqual(0, len(result))
+        self.assertEqual(tr.metadata, result.metadata)
+
+        # emptying the track should have the same effect
+        del tr[:]
+        self.assertEqual(tr, result)
+
+    def test_passthrough_by_type(self):
+        """Test pass through using the types_to_pass_through list"""
+
+        md = {'test': 'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        called = False
+        def shouldnt_get_called(_, __,___):
+            global called
+            called = True
+
+        result = otio.algorithms.filtered_with_sequence_context(
+            tr,
+            shouldnt_get_called,
+            types_to_pass_through=(otio.schema.Clip,)
+        )
+        self.assertFalse(called)
+
+        # emptying the track should have the same effect
+        self.assertEqual(tr, result)
+
     def test_copy(self):
         md = {'test': 'bar'}
         tl = otio.schema.Timeline(name='foo', metadata=md)
@@ -216,6 +257,48 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         result = otio.algorithms.filtered_with_sequence_context(tr, no_clips)
         self.assertEqual(0, len(result))
         self.assertEqual(tr.metadata, result.metadata)
+
+        # emptying the track should have the same effect
+        del tr[:]
+        self.assertEqual(tr, result)
+
+    def test_prune_clips_using_types_to_prune(self):
+        """Test pruning otio.schema.clip using the types_to_prune argument"""
+
+        md = {'test': 'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        result = otio.algorithms.filtered_with_sequence_context(
+            tr,
+            lambda _,__,___:__,
+            types_to_prune=(otio.schema.Clip,)
+        )
+        self.assertEqual(0, len(result))
+        self.assertEqual(tr.metadata, result.metadata)
+
+        # emptying the track should have the same effect
+        del tr[:]
+        self.assertEqual(tr, result)
+
+    def test_passthrough_by_type(self):
+        """Test pass through using the types_to_pass_through list"""
+
+        md = {'test': 'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        called = False
+        def shouldnt_get_called(_):
+            global called
+            called = True
+
+        result = otio.algorithms.filtered_items(
+            tr,
+            shouldnt_get_called,
+            types_to_pass_through=(otio.schema.Timeline,otio.schema.Clip,)
+        )
+        self.assertFalse(called)
 
         # emptying the track should have the same effect
         del tr[:]

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -30,6 +30,7 @@ import copy
 
 import opentimelineio as otio
 
+
 class OTIOAssertions(object):
     def assertJsonEqual(self, known, test_result):
         """Convert to json and compare that (more readable)."""
@@ -39,16 +40,18 @@ class OTIOAssertions(object):
 
         self.assertMultiLineEqual(known_str, test_str)
 
+
 class FilterTest(unittest.TestCase, OTIOAssertions):
     maxDiff = None
+
     def test_copy_track(self):
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.filtered_items(tr, lambda _:_),
+            otio.algorithms.filtered_items(tr, lambda _: _),
             'otio_json'
         )
 
@@ -56,13 +59,13 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
     def test_copy_stack(self):
         """Test a no op filter that copies the timeline."""
- 
-        md = {'test':'bar'}
+
+        md = {'test': 'bar'}
         tr = otio.schema.Stack(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
-        result = otio.algorithms.filtered_items(tr, lambda _:_)
+        result = otio.algorithms.filtered_items(tr, lambda _: _)
         test = otio.adapters.write_to_string(result, 'otio_json')
 
         self.assertJsonEqual(known, test)
@@ -71,7 +74,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
     def test_prune_clips(self):
         """test a filter that removes clips"""
 
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
@@ -89,14 +92,14 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         self.assertEqual(tr, result)
 
     def test_copy(self):
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tl = otio.schema.Timeline(name='foo', metadata=md)
         tl.tracks.append(otio.schema.Track(name='track1', metadata=md))
         tl.tracks[0].append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tl, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.filtered_items(tl, lambda _:_),
+            otio.algorithms.filtered_items(tl, lambda _: _),
             'otio_json'
         )
 
@@ -108,7 +111,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
     def test_insert_tuple(self):
         """test a reduce that takes each clip in a sequence and triples it"""
 
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
@@ -128,14 +131,15 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
 class ReduceTest(unittest.TestCase, OTIOAssertions):
     maxDiff = None
+
     def test_copy_track(self):
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.reduced_items(tr, lambda __, _, ___:_),
+            otio.algorithms.reduced_items(tr, lambda __, _, ___: _),
             'otio_json'
         )
 
@@ -143,13 +147,13 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
     def test_copy_stack(self):
         """Test a no op reduce that copies the timeline."""
- 
-        md = {'test':'bar'}
+
+        md = {'test': 'bar'}
         tr = otio.schema.Stack(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
-        result = otio.algorithms.reduced_items(tr, lambda __, _, ___:_)
+        result = otio.algorithms.reduced_items(tr, lambda __, _, ___: _)
         test = otio.adapters.write_to_string(result, 'otio_json')
 
         self.assertJsonEqual(known, test)
@@ -158,7 +162,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
     def test_prune_clips(self):
         """test a reduce that removes clips"""
 
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
@@ -178,7 +182,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
     def test_insert_tuple(self):
         """test a reduce that takes each clip in a sequence and triples it"""
 
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
@@ -192,13 +196,13 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         self.assertEqual(tr.metadata, result.metadata)
 
         # emptying the track should have the same effect
-        tr.extend([copy.deepcopy(tr[0]), copy.deepcopy(tr[0])])
+        tr.extend((copy.deepcopy(tr[0]), copy.deepcopy(tr[0])))
         self.assertJsonEqual(tr, result)
 
     def test_prune_clips_after_transitions(self):
         """test a reduce that removes clips that follow transitions"""
 
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         for i in range(5):
             ind = str(i)
@@ -221,25 +225,24 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         # ...but that things have been properly deep copied
         self.assertIsNot(tr.metadata, result.metadata)
 
-        # emptying the track of transitions and the clips they follow and 
+        # emptying the track of transitions and the clips they follow and
         # should have the same effect
         del tr[2:6]
         self.assertJsonEqual(tr, result)
 
     def test_copy(self):
         """Test that a simple reduce results in a copy"""
-        md = {'test':'bar'}
+        md = {'test': 'bar'}
         tl = otio.schema.Timeline(name='foo', metadata=md)
         tl.tracks.append(otio.schema.Track(name='track1', metadata=md))
         tl.tracks[0].append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tl, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.reduced_items(tl, lambda __, _, ___:_),
+            otio.algorithms.reduced_items(tl, lambda __, _, ___: _),
             'otio_json'
         )
 
         # make sure the original timeline didn't get nuked
         self.assertEqual(len(tl.tracks), 1)
         self.assertJsonEqual(known, test)
-

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -257,16 +257,18 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
             return thing
 
         result = otio.algorithms.reduced_items(tr, no_clips_after_transitions)
+
+        # emptying the track of transitions and the clips they follow and
+        # should have the same effect
+        del tr[2:6]
+        self.assertJsonEqual(tr, result)
+
         self.assertEqual(3, len(result))
         self.assertEqual(tr.metadata, result.metadata)
 
         # ...but that things have been properly deep copied
         self.assertIsNot(tr.metadata, result.metadata)
 
-        # emptying the track of transitions and the clips they follow and
-        # should have the same effect
-        del tr[2:6]
-        self.assertJsonEqual(tr, result)
 
     def test_copy(self):
         """Test that a simple reduce results in a copy"""

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -175,7 +175,10 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.filtered_with_sequence_context(tr, lambda __, _, ___: _),
+            otio.algorithms.filtered_with_sequence_context(
+                tr,
+                lambda __, _, ___: _
+            ),
             'otio_json'
         )
 
@@ -189,7 +192,10 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
-        result = otio.algorithms.filtered_with_sequence_context(tr, lambda __, _, ___: _)
+        result = otio.algorithms.filtered_with_sequence_context(
+            tr,
+            lambda __, _, ___: _
+        )
         test = otio.adapters.write_to_string(result, 'otio_json')
 
         self.assertJsonEqual(known, test)
@@ -227,7 +233,10 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
                 return thing
             return (thing, copy.deepcopy(thing), copy.deepcopy(thing))
 
-        result = otio.algorithms.filtered_with_sequence_context(tr, triple_clips)
+        result = otio.algorithms.filtered_with_sequence_context(
+            tr,
+            triple_clips
+        )
         self.assertEqual(3, len(result))
         self.assertEqual(tr.metadata, result.metadata)
 
@@ -254,7 +263,10 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
                 return None
             return thing
 
-        result = otio.algorithms.filtered_with_sequence_context(tr, no_clips_after_transitions)
+        result = otio.algorithms.filtered_with_sequence_context(
+            tr,
+            no_clips_after_transitions
+        )
 
         # emptying the track of transitions and the clips they follow and
         # should have the same effect
@@ -276,7 +288,10 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         known = otio.adapters.write_to_string(tl, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.filtered_with_sequence_context(tl, lambda __, _, ___: _),
+            otio.algorithms.filtered_with_sequence_context(
+                tl,
+                lambda __, _, ___: _
+            ),
             'otio_json'
         )
 

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -145,26 +145,27 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         self.assertEqual(tr, result)
 
     def test_passthrough_by_type(self):
-        """Test pass through using the types_to_pass_through list"""
+        """Test pass through using the types_to_filter list"""
 
         md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
+        tr.append(otio.schema.Gap(name='gap1', metadata=md))
 
-        called = False
-        def shouldnt_get_called(_, __,___):
-            global called
-            called = True
+        self.called = 0
+        def should_get_called_once(_, __,___):
+            self.called += 1
+            return __
 
         result = otio.algorithms.filtered_with_sequence_context(
             tr,
-            shouldnt_get_called,
-            types_to_pass_through=(otio.schema.Clip,)
+            should_get_called_once,
+            types_to_filter=(otio.schema.Clip,)
         )
-        self.assertFalse(called)
 
         # emptying the track should have the same effect
         self.assertEqual(tr, result)
+        self.assertEqual(self.called, 1)
 
     def test_copy(self):
         md = {'test': 'bar'}
@@ -282,26 +283,26 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         self.assertEqual(tr, result)
 
     def test_passthrough_by_type(self):
-        """Test pass through using the types_to_pass_through list"""
+        """Test pass through using the types_to_filter list"""
 
         md = {'test': 'bar'}
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
+        tr.append(otio.schema.Gap(name='gap1', metadata=md))
 
-        called = False
-        def shouldnt_get_called(_):
-            global called
-            called = True
+        self.called = 0
+        def should_get_called_once(_):
+            self.called += 1
+            return _
 
         result = otio.algorithms.filtered_items(
             tr,
-            shouldnt_get_called,
-            types_to_pass_through=(otio.schema.Timeline,otio.schema.Clip,)
+            should_get_called_once,
+            types_to_filter=(otio.schema.Clip,)
         )
-        self.assertFalse(called)
+        self.assertEqual(1, self.called)
 
         # emptying the track should have the same effect
-        del tr[:]
         self.assertEqual(tr, result)
 
     def test_insert_tuple(self):

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python
+#
+# Copyright 2018 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""Test harness for the filter algorithms."""
+
+import unittest
+
+import opentimelineio as otio
+
+class FilterTest(unittest.TestCase):
+    maxDiff = None
+    def test_copy_track(self):
+        md = {'test':'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        known = otio.adapters.write_to_string(tr, 'otio_json')
+        test = otio.adapters.write_to_string(
+            otio.algorithms.filtered_items(tr, lambda _:_),
+            'otio_json'
+        )
+
+        self.assertMultiLineEqual(known, test)
+
+    def test_copy_stack(self):
+        """Test a no op filter that copies the timeline."""
+ 
+        md = {'test':'bar'}
+        tr = otio.schema.Stack(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        known = otio.adapters.write_to_string(tr, 'otio_json')
+        result = otio.algorithms.filtered_items(tr, lambda _:_)
+        test = otio.adapters.write_to_string(result, 'otio_json')
+
+        self.assertMultiLineEqual(known, test)
+        self.assertIsNot(tr[0], result)
+
+    def test_prune_clips(self):
+        """test a filter that removes clips"""
+
+        md = {'test':'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        def no_clips(thing):
+            if not isinstance(thing, otio.schema.Clip):
+                return thing
+            return None
+
+        result = otio.algorithms.filtered_items(tr, no_clips)
+        self.assertEqual(0, len(result))
+        self.assertEqual(tr.metadata, result.metadata)
+
+        # emptying the track should have the same effect
+        del tr[:]
+        self.assertEqual(tr, result)
+
+    def test_copy(self):
+        md = {'test':'bar'}
+        tl = otio.schema.Timeline(name='foo', metadata=md)
+        tl.tracks.append(otio.schema.Track(name='track1', metadata=md))
+        tl.tracks[0].append(otio.schema.Clip(name='cl1', metadata=md))
+
+        known = otio.adapters.write_to_string(tl, 'otio_json')
+        test = otio.adapters.write_to_string(
+            otio.algorithms.filtered_items(tl, lambda _:_),
+            'otio_json'
+        )
+
+        # make sure the original timeline didn't get nuked
+        self.assertEqual(len(tl.tracks), 1)
+
+        self.assertMultiLineEqual(known, test)
+
+
+class ReduceTest(unittest.TestCase):
+    maxDiff = None
+    def test_copy_track(self):
+        md = {'test':'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        known = otio.adapters.write_to_string(tr, 'otio_json')
+        test = otio.adapters.write_to_string(
+            otio.algorithms.reduced_items(tr, lambda __, _, ___:_),
+            'otio_json'
+        )
+
+        self.assertMultiLineEqual(known, test)
+
+    def test_copy_stack(self):
+        """Test a no op reduce that copies the timeline."""
+ 
+        md = {'test':'bar'}
+        tr = otio.schema.Stack(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        known = otio.adapters.write_to_string(tr, 'otio_json')
+        result = otio.algorithms.reduced_items(tr, lambda __, _, ___:_)
+        test = otio.adapters.write_to_string(result, 'otio_json')
+
+        self.assertMultiLineEqual(known, test)
+        self.assertIsNot(tr[0], result)
+
+    def test_prune_clips(self):
+        """test a reduce that removes clips"""
+
+        md = {'test':'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        tr.append(otio.schema.Clip(name='cl1', metadata=md))
+
+        def no_clips(_, thing, __):
+            if not isinstance(thing, otio.schema.Clip):
+                return thing
+            return None
+
+        result = otio.algorithms.reduced_items(tr, no_clips)
+        self.assertEqual(0, len(result))
+        self.assertEqual(tr.metadata, result.metadata)
+
+        # emptying the track should have the same effect
+        del tr[:]
+        self.assertEqual(tr, result)
+
+    def test_prune_clips_after_transitions(self):
+        """test a reduce that removes clips that follow transitions"""
+
+        md = {'test':'bar'}
+        tr = otio.schema.Track(name='foo', metadata=md)
+        for i in range(5):
+            ind = str(i)
+            if i in (2, 3):
+                tr.append(otio.schema.Transition(name='should_be_pruned'+ind))
+            tr.append(otio.schema.Clip(name='cl'+ind, metadata=md))
+
+        def no_clips_after_transitions(prev, thing, __):
+            if (
+                isinstance(prev, otio.schema.Transition) or
+                isinstance(thing, otio.schema.Transition)
+            ):
+                return None
+            return thing
+
+        result = otio.algorithms.reduced_items(tr, no_clips_after_transitions)
+        self.assertEqual(3, len(result))
+        self.assertEqual(tr.metadata, result.metadata)
+
+        # ...but that things have been properly deep copied
+        self.assertIsNot(tr.metadata, result.metadata)
+
+        # emptying the track of transitions and the clips they follow and 
+        # should have the same effect
+        del tr[2:6]
+        self.assertEqual(tr, result)
+
+
+    def test_copy(self):
+        """Test that a simple reduce results in a copy"""
+        md = {'test':'bar'}
+        tl = otio.schema.Timeline(name='foo', metadata=md)
+        tl.tracks.append(otio.schema.Track(name='track1', metadata=md))
+        tl.tracks[0].append(otio.schema.Clip(name='cl1', metadata=md))
+
+        known = otio.adapters.write_to_string(tl, 'otio_json')
+        test = otio.adapters.write_to_string(
+            otio.algorithms.reduced_items(tl, lambda __, _, ___:_),
+            'otio_json'
+        )
+
+        # make sure the original timeline didn't get nuked
+        self.assertEqual(len(tl.tracks), 1)
+        self.assertMultiLineEqual(known, test)
+

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -52,7 +52,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.filtered_items(tr, lambda _: _),
+            otio.algorithms.filtered_composition(tr, lambda _: _),
             'otio_json'
         )
 
@@ -66,7 +66,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
-        result = otio.algorithms.filtered_items(tr, lambda _: _)
+        result = otio.algorithms.filtered_composition(tr, lambda _: _)
         test = otio.adapters.write_to_string(result, 'otio_json')
 
         self.assertJsonEqual(known, test)
@@ -93,7 +93,10 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
             else:
                 return thing
 
-        result = otio.algorithms.filtered_items(tr, nothing_that_starts_with_a)
+        result = otio.algorithms.filtered_composition(
+            tr,
+            nothing_that_starts_with_a
+        )
 
         # make sure that the track being pruned means the child was never
         # visited
@@ -117,7 +120,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
                 return thing
             return None
 
-        result = otio.algorithms.filtered_items(tr, no_clips)
+        result = otio.algorithms.filtered_composition(tr, no_clips)
         self.assertEqual(0, len(result))
         self.assertEqual(tr.metadata, result.metadata)
 
@@ -132,7 +135,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         tr = otio.schema.Track(name='foo', metadata=md)
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
-        result = otio.algorithms.filtered_items(
+        result = otio.algorithms.filtered_composition(
             tr,
             lambda _: _,
             types_to_prune=(otio.schema.Clip,)
@@ -176,7 +179,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
         known = otio.adapters.write_to_string(tl, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.filtered_items(tl, lambda _: _),
+            otio.algorithms.filtered_composition(tl, lambda _: _),
             'otio_json'
         )
 
@@ -199,7 +202,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
                 return thing
             return (thing, copy.deepcopy(thing), copy.deepcopy(thing))
 
-        result = otio.algorithms.filtered_items(tr, triple_clips)
+        result = otio.algorithms.filtered_composition(tr, triple_clips)
         self.assertEqual(3, len(result))
         self.assertEqual(tr.metadata, result.metadata)
 
@@ -297,7 +300,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
             self.called += 1
             return _
 
-        result = otio.algorithms.filtered_items(
+        result = otio.algorithms.filtered_composition(
             tr,
             should_get_called_once,
             types_to_filter=(otio.schema.Clip,)

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -32,7 +32,6 @@ import opentimelineio as otio
 
 
 class OTIOAssertions(object):
-    maxDiff = None
     def assertJsonEqual(self, known, test_result):
         """Convert to json and compare that (more readable)."""
         self.maxDiff = None
@@ -96,7 +95,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
         result = otio.algorithms.filtered_items(tr, nothing_that_starts_with_a)
 
-        # make sure that the track being pruned means the child was never 
+        # make sure that the track being pruned means the child was never
         # visited
         self.assertNotIn('a_cl2', visited)
 
@@ -105,7 +104,6 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         del tr[1]
 
         self.assertJsonEqual(tr, result)
-
 
     def test_prune_clips(self):
         """test a filter that removes clips"""
@@ -177,7 +175,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.reduced_items(tr, lambda __, _, ___: _),
+            otio.algorithms.filtered_with_sequence_context(tr, lambda __, _, ___: _),
             'otio_json'
         )
 
@@ -191,7 +189,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         tr.append(otio.schema.Clip(name='cl1', metadata=md))
 
         known = otio.adapters.write_to_string(tr, 'otio_json')
-        result = otio.algorithms.reduced_items(tr, lambda __, _, ___: _)
+        result = otio.algorithms.filtered_with_sequence_context(tr, lambda __, _, ___: _)
         test = otio.adapters.write_to_string(result, 'otio_json')
 
         self.assertJsonEqual(known, test)
@@ -209,7 +207,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
                 return thing
             return None
 
-        result = otio.algorithms.reduced_items(tr, no_clips)
+        result = otio.algorithms.filtered_with_sequence_context(tr, no_clips)
         self.assertEqual(0, len(result))
         self.assertEqual(tr.metadata, result.metadata)
 
@@ -229,7 +227,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
                 return thing
             return (thing, copy.deepcopy(thing), copy.deepcopy(thing))
 
-        result = otio.algorithms.reduced_items(tr, triple_clips)
+        result = otio.algorithms.filtered_with_sequence_context(tr, triple_clips)
         self.assertEqual(3, len(result))
         self.assertEqual(tr.metadata, result.metadata)
 
@@ -256,7 +254,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
                 return None
             return thing
 
-        result = otio.algorithms.reduced_items(tr, no_clips_after_transitions)
+        result = otio.algorithms.filtered_with_sequence_context(tr, no_clips_after_transitions)
 
         # emptying the track of transitions and the clips they follow and
         # should have the same effect
@@ -269,7 +267,6 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
         # ...but that things have been properly deep copied
         self.assertIsNot(tr.metadata, result.metadata)
 
-
     def test_copy(self):
         """Test that a simple reduce results in a copy"""
         md = {'test': 'bar'}
@@ -279,7 +276,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         known = otio.adapters.write_to_string(tl, 'otio_json')
         test = otio.adapters.write_to_string(
-            otio.algorithms.reduced_items(tl, lambda __, _, ___: _),
+            otio.algorithms.filtered_with_sequence_context(tl, lambda __, _, ___: _),
             'otio_json'
         )
 


### PR DESCRIPTION
Adds functions for filtering OTIO files:

- `otio.algorithms.filtered_items(<input otio object>, <unary function>)` - if the unary function returns an object, that object is placed into the hierarchy.  If it returns none, it is pruned.  Note that if you delete children, it will still visit them.
- `otio.algorithms.filtered_items_sequence_context(<input otio object>, <ternary function>)` ternary function that takes (prev, child, next) for items in tracks.  Otherwise will get passed (None, child, None).  behaves like above.
- both functions have arguments `types_to_prune` and `types_to_filter`.  
- If `types_to_prune` is not `None`, each item that is derived from a type in the `types_to_prune` list will be pruned from the result (the function will not be called on it)
- if `types_to_filter` is not `None`, each item that is not derived from a type in type to filter will be copied automatically to the result (the filter function will not be called on it either).
- if neither is specified or neither condition is met, then the object will be filtered by the passed in function.

Idea is to make common transformation patterns easier to write on OTIO objects - "turn all the transitions into shots" or "all gaps into a specific clip with media reference"

