### PR TITLE
Fix iteration of dupes

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -625,7 +625,7 @@ def _expand_transitions(timeline):
             next_clip = next(track_iter, None)
 
     for (track, from_clip, to_transition) in replace_list:
-        track[track.index(from_clip)] = to_transition
+        track[track.index_of_child(from_clip)] = to_transition
 
     for (track, clip_to_remove) in list(set(remove_list)):
         # if clip_to_remove in track:

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -229,6 +229,25 @@ class Composition(item.Item, collections.MutableSequence):
 
         return parents
 
+    def index_of_child(self, child):
+        """Returns the index of the given child object within this Composition.
+        Unlike index() this method checks for the exact child object, not
+        objects that are equal to the given child.
+
+        If the child is not found, a NotAChildError is thrown. If multiple
+        instances of the child are found, an InstancingNotAllowedError is
+        thrown."""
+        indexes = [i for i,c in enumerate(self) if c is child]
+        if len(indexes) == 0:
+            raise exceptions.NotAChildError(
+                "Item '{}' is not a child of '{}'.".format(child, self)
+            )
+        if len(indexes) > 1:
+            raise exceptions.InstancingNotAllowedError(
+                "Item '{}' is used multiple times as child of '{}'.".format(child, self)
+            )
+        return indexes[0]
+
     def range_of_child(self, child, reference_space=None):
         """The range of the child in relation to another item
         (reference_space), not trimmed based on this
@@ -258,7 +277,7 @@ class Composition(item.Item, collections.MutableSequence):
         result_range = None
 
         for parent in parents:
-            index = parent.index(current)
+            index = parent.index_of_child(current)
             parent_range = parent.range_of_child_at_index(index)
 
             if not result_range:
@@ -357,7 +376,7 @@ class Composition(item.Item, collections.MutableSequence):
         result_range = None
 
         for parent in parents:
-            index = parent.index(current)
+            index = parent.index_of_child(current)
             parent_range = parent.trimmed_range_of_child_at_index(index)
 
             if not result_range:

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -237,14 +237,17 @@ class Composition(item.Item, collections.MutableSequence):
         If the child is not found, a NotAChildError is thrown. If multiple
         instances of the child are found, an InstancingNotAllowedError is
         thrown."""
-        indexes = [i for i,c in enumerate(self) if c is child]
+        indexes = [i for i, c in enumerate(self) if c is child]
         if len(indexes) == 0:
             raise exceptions.NotAChildError(
                 "Item '{}' is not a child of '{}'.".format(child, self)
             )
         if len(indexes) > 1:
             raise exceptions.InstancingNotAllowedError(
-                "Item '{}' is used multiple times as child of '{}'.".format(child, self)
+                "Item '{}' is used multiple times as child of '{}'.".format(
+                    child,
+                    self
+                )
             )
         return indexes[0]
 

--- a/opentimelineio/exceptions.py
+++ b/opentimelineio/exceptions.py
@@ -69,6 +69,10 @@ class NotAChildError(OTIOError):
     pass
 
 
+class InstancingNotAllowedError(OTIOError):
+    pass
+
+
 class TransitionFollowingATransitionError(OTIOError):
     pass
 

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -165,7 +165,7 @@ class Track(core.Composition):
         """
 
         try:
-            index = self.index(item)
+            index = self.index_of_child(item)
         except ValueError:
             raise ValueError(
                 "item: {} is not in composition: {}".format(

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -882,23 +882,24 @@ class TrackTest(unittest.TestCase):
         with self.assertRaises(otio.exceptions.NotAChildError):
             other_track.range_of_child(track[1])
 
-        outer_track = otio.schema.Track(
-            name="outer",
-            children=[track.deepcopy(), track]
-        )
-
-        result_range_pre = track.range_of_child_at_index(0)
-        result_range_post = track.range_of_child_at_index(1)
-
-        result = otio.opentime.TimeRange(
-            (
-                result_range_pre.start_time +
-                result_range_pre.duration
-            ),
-            result_range_post.duration
-        )
         # TODO: What are we trying to test here?
         # This doesn't match up, so I'm disabling it for now.
+
+        # outer_track = otio.schema.Track(
+        #     name="outer",
+        #     children=[track.deepcopy(), track]
+        # )
+        #
+        # result_range_pre = track.range_of_child_at_index(0)
+        # result_range_post = track.range_of_child_at_index(1)
+        #
+        # result = otio.opentime.TimeRange(
+        #     (
+        #         result_range_pre.start_time +
+        #         result_range_pre.duration
+        #     ),
+        #     result_range_post.duration
+        # )
         # self.assertEqual(outer_track.range_of_child(track[1]), result)
 
     def test_setitem(self):
@@ -1264,6 +1265,7 @@ class EdgeCases(unittest.TestCase):
                 previous
             )
             previous = item.range_in_parent()
+
 
 class NestingTest(unittest.TestCase):
 


### PR DESCRIPTION
If you have duplicate Clips in a Track (identical, but not instances of the same object) then range_of_child() and other methods don't work as expected. This is because we were using index() to find objects in a Composition, but index() uses the `==` operator instead of `is`.

This PR introduces index_of_child() and fixes a range_of_child() and other related methods to work properly when duplicate clips are present.

Addresses #222 