### PR TITLE
Correctly represent Gaps

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -770,6 +770,7 @@ class EDLWriter(object):
         events = []
         for idx, child in enumerate(track):
             if isinstance(child, otio.schema.Transition):
+                # Transition will be captured in subsequent iteration.
                 continue
 
             prv = track[idx-1] if idx > 0 else None
@@ -786,7 +787,7 @@ class EDLWriter(object):
                         self._style
                     )
                 )
-            elif not isinstance(child, otio.schema.Gap):
+            elif isinstance(child, otio.schema.Clip):
                 events.append(
                     Event(
                         child,
@@ -796,6 +797,10 @@ class EDLWriter(object):
                         self._style
                     )
                 )
+            elif isinstance(child, otio.schema.Gap):
+                # Gaps are represented as missing record timecode, no event
+                # needed.
+                pass
 
         content = "TITLE: {}\n\n".format(title) if title else ''
 

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -775,25 +775,27 @@ class EDLWriter(object):
             prv = track[idx-1] if idx > 0 else None
 
             if isinstance(prv, otio.schema.Transition):
-                event = DissolveEvent(
-                    events[-1] if len(events) else None,
-                    prv,
-                    child,
-                    self._tracks,
-                    track.kind,
-                    self._rate,
-                    self._style
+                events.append(
+                    DissolveEvent(
+                        events[-1] if len(events) else None,
+                        prv,
+                        child,
+                        self._tracks,
+                        track.kind,
+                        self._rate,
+                        self._style
+                    )
                 )
-            else:
-                event = Event(
-                    child,
-                    self._tracks,
-                    track.kind,
-                    self._rate,
-                    self._style
+            elif not isinstance(child, otio.schema.Gap):
+                events.append(
+                    Event(
+                        child,
+                        self._tracks,
+                        track.kind,
+                        self._rate,
+                        self._style
+                    )
                 )
-
-            events.append(event)
 
         content = "TITLE: {}\n\n".format(title) if title else ''
 

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -400,6 +400,12 @@ class EDLAdapterTest(unittest.TestCase):
             media_reference=mr,
             source_range=tr,
         )
+        gap = otio.schema.Gap(
+            source_range=otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24.0),
+                duration=otio.opentime.RationalTime(24.0, 24.0),
+            )
+        )
         cl2 = otio.schema.Clip(
             name="test clip2",
             media_reference=mr,
@@ -407,6 +413,7 @@ class EDLAdapterTest(unittest.TestCase):
         )
         tl.tracks[0].name = "V"
         tl.tracks[0].append(cl)
+        tl.tracks[0].append(gap)
         tl.tracks[0].append(cl2)
 
         result = otio.adapters.write_to_string(
@@ -420,7 +427,7 @@ class EDLAdapterTest(unittest.TestCase):
 001  AX       V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 * FROM CLIP NAME:  test clip1
 * FROM FILE: S:\var\tmp\test.exr
-002  AX       V     C        00:00:00:00 00:00:00:05 00:00:00:05 00:00:00:10
+002  AX       V     C        00:00:00:00 00:00:00:05 00:00:01:05 00:00:01:10
 * FROM CLIP NAME:  test clip2
 * FROM FILE: S:\var\tmp\test.exr
 '''

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -349,6 +349,29 @@ class EDLAdapterTest(unittest.TestCase):
             ]
         )
 
+    def test_read_generators(self):
+        # EXERCISE
+        tl = otio.adapters.read_from_string(
+            '1 BL V C 00:00:00:00 00:00:01:00 00:00:00:00 00:00:01:00\n'
+            '1 BLACK V C 00:00:00:00 00:00:01:00 00:00:01:00 00:00:02:00\n'
+            '1 BARS V C 00:00:00:00 00:00:01:00 00:00:02:00 00:00:03:00\n',
+            adapter_name="cmx_3600"
+        )
+
+        # VALIDATE
+        self.assertEqual(
+            tl.tracks[0][0].media_reference.generator_kind,
+            'black'
+        )
+        self.assertEqual(
+            tl.tracks[0][1].media_reference.generator_kind,
+            'black'
+        )
+        self.assertEqual(
+            tl.tracks[0][2].media_reference.generator_kind,
+            'SMPTEBars'
+        )
+
     def test_nucoda_edl_read(self):
         edl_path = NUCODA_EXAMPLE_PATH
         fps = 24


### PR DESCRIPTION
`Gap`s were incorrectly being written as EDL events.  This will produce an actual gap in the record timecode.