### PR TITLE
[WIP] functions for trimming and translating time across hierarchy

### DIFF
--- a/opentimelineio/__init__.py
+++ b/opentimelineio/__init__.py
@@ -42,3 +42,6 @@ from . import (
     algorithms,
     test_utils,
 )
+from .algorithms import (
+    range_of
+)

--- a/opentimelineio/algorithms/__init__.py
+++ b/opentimelineio/algorithms/__init__.py
@@ -38,3 +38,7 @@ from .filter import (
     filtered_composition,
     filtered_with_sequence_context
 )
+
+from .time_transforms import (
+    range_of
+)

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -87,9 +87,12 @@ def relative_transform(from_item, to_item):
     return result
 
 
+# @TODO: Target is something along these lines:
+# range_of(cl.before_effects, parent_track.after_effects, trimmed_to=parent_track)
+
 def range_of(
-    item,
-    relative_to=None,    # must be a parent or child of item (Default is: item)
+    source_frame,
+    target_frame=None, # must be a parent or child of item (Default is: item)
     trimmed_to=None,  # must be a parent of item (default is: item)
     # with_transitions=False, # @TODO
 ):

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -22,17 +22,14 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-__doc__ = """Implementation of functions for query time."""
-
 import copy
 
 from .. import (
     schema
 )
 
-class _SearchDirection(object):
-    down = 0
-    up = 1
+__doc__ = """Implementation of functions for query time."""
+
 
 def _transform_range(range_to_transform, from_space, to_space, trim_to=None):
     found_trim = trim_to is None
@@ -61,18 +58,18 @@ def _transform_range(range_to_transform, from_space, to_space, trim_to=None):
 
         from_space = from_space.parent()
 
-
     return range_to_transform
+
 
 # @TODO: CURRENTLY ONLY WORKS IF item is a child of IN_SCOPE AND TRIMMED_TO
 def range_of(
     item,
     # @TODO: scope?  Or space? reference frame?
-    in_scope=None, # must be a parent or child of item (Default is: item)
-    trimmed_to=None, # must be a parent of item (default is: item)
-    # with_transitions=False, # @TODO 
+    in_scope=None,    # must be a parent or child of item (Default is: item)
+    trimmed_to=None,  # must be a parent of item (default is: item)
+    # with_transitions=False, # @TODO
 ):
-    """ Return the range of the specified item in the specified scope, trimmed 
+    """ Return the range of the specified item in the specified scope, trimmed
     to the specified scope.
 
     item      :: otio.core.Item
@@ -85,7 +82,7 @@ def range_of(
         T1:: Track      [A1], trimmed_range = (2, 5)
 
         range_of(A, in_scope=A1, trimmed_to=A1)  => (10, 20)
-        range_of(A, in_scope=T1, trimmed_to=A1)  => (0,  20) 
+        range_of(A, in_scope=T1, trimmed_to=A1)  => (0,  20)
         range_of(A, in_scope=A1, trimmed_to=T1)  => (12, 5)
         range_of(A, in_scope=T1, trimmed_to=T1)  => (2,  5)
     """
@@ -99,7 +96,7 @@ def range_of(
     # @TODO: should this already be a copy?
     range_in_item_space = copy.deepcopy(item.trimmed_range())
 
-    # @TODO: in the clip, trimmed_range returns a value in media space, *not* 
+    # @TODO: in the clip, trimmed_range returns a value in media space, *not*
     #        in the intrinsic [0,dur) space.
     if in_scope is not None and isinstance(item, schema.Clip):
         range_in_item_space.start_time.value = 0

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -246,6 +246,7 @@ def _trimmed_range(range_to_trim, from_space, trim_to):
 def _path_to_parent(*args, **kwargs):
     return []
 
+
 def relative_transform(from_item, to_item):
     result = opentime.TimeTransform()
 
@@ -276,10 +277,8 @@ def relative_transform(from_item, to_item):
     return result
 
 
-
-
-
-# @TODO: CURRENTLY ONLY WORKS IF item is a child of relative_to AND TRIMMED_TO
+# @TODO: Works as long as trimmed_to and relative_to have no ancestors between
+#        them
 def range_of(
     item,
     relative_to=None,    # must be a parent or child of item (Default is: item)
@@ -305,7 +304,7 @@ def range_of(
     """
 
     relative_to = relative_to or item
-    trimmed_to  = trimmed_to or item
+    trimmed_to = trimmed_to or item
 
     # if we're going from the current to the same space, shortcut
     if ((item is relative_to) and (item is trimmed_to)):
@@ -324,27 +323,3 @@ def range_of(
         range_to_xform = trim_range.clamp(range_to_xform)
 
     return range_to_xform
-
-    
-
-
-    # if relative_to is item:
-    #     relative_to = None
-    #
-    # if trimmed_to is item:
-    #     trimmed_to = None
-
-    # @TODO: should this already be a copy?
-    # range_in_item_space = copy.deepcopy(item.trimmed_range())
-
-    # @TODO: in the clip, trimmed_range returns a value in media space, *not*
-    #        in the intrinsic [0,dur) space as it does in most other cases.
-    # if relative_to is not None and isinstance(item, schema.Clip):
-    #     range_in_item_space.start_time.value = 0
-
-    # if relative_to is None and trimmed_to is None:
-    #     return range_in_item_space
-
-    # trimmed_range = _trimmed_range(range_in_item_space, item, trimmed_to)
-
-    # return _transform_range(range_in_item_space, item, relative_to)

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2018 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+__doc__ = """Implementation of functions for query time."""
+
+from .. import (
+    opentime
+)
+
+def range_of(
+    item,
+    in_scope=None, # must be a parent or child of item
+    trimmed_to=None, # must be a parent of item
+    # with_transitions=False, #todo make this an enum
+):
+    range_in_item_space = item.trimmed_range()
+    if trimmed_to is not None and trimmed_to is not item:
+        range_in_item_space = _trim_to(item, trimmed_to)
+
+    if in_scope is None or in_scope is item:
+        return range_in_item_space
+
+    return _transform_range(range_in_item_space, item, in_scope)
+
+
+

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -250,7 +250,9 @@ def relative_transform(from_item, to_item):
     result = opentime.TimeTransform()
 
     # check to find parent
-    if to_item.is_parent_of(from_item):
+    if to_item is from_item:
+        return result
+    elif to_item.is_parent_of(from_item):
         from_item_is_parent = False
         parent = to_item
         child = from_item
@@ -302,15 +304,26 @@ def range_of(
         range_of(A1, relative_to=T1, trimmed_to=T1)  => (2,  5)
     """
 
-    # @TODO: start without thinking about trims
+    relative_to = relative_to or item
+    trimmed_to  = trimmed_to or item
 
     # if we're going from the current to the same space, shortcut
-    if item is relative_to:
+    if ((item is relative_to) and (item is trimmed_to)):
         return item.trimmed_range()
 
     xform = relative_transform(from_item=item, to_item=relative_to)
 
-    return xform * item.trimmed_range()
+    range_to_xform = xform * item.trimmed_range()
+
+    if trimmed_to is not item:
+        trim_xform = relative_transform(
+            from_item=trimmed_to,
+            to_item=relative_to
+        )
+        trim_range = trim_xform * trimmed_to.trimmed_range()
+        range_to_xform = trim_range.clamp(range_to_xform)
+
+    return range_to_xform
 
     
 

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -132,13 +132,11 @@ def relative_transform(src_frame, dst_frame):
     return result
 
 
-# @TODO: Target is something along these lines:
-# range_of(cl.before_effects, parent_track.after_effects, trimmed_to=parent_track)
 
 def range_of(
-    source_frame,
+    src_frame,
     # must be a parent or child of item (Default is: item)
-    relative_to_frame=None, 
+    dst_frame=None,
     trimmed_to=None,  # must be a parent of item (default is: item)
     # with_transitions=False, # @TODO
 ):
@@ -160,25 +158,24 @@ def range_of(
         range_of(A1, relative_to=T1, trimmed_to=T1)  => (2,  5)
     """
 
-    if not isinstance(source_frame, core.ReferenceFrame):
+    if not isinstance(src_frame, core.ReferenceFrame):
         raise NotImplementedError("range of only takes ReferenceFrames")
 
-    relative_to_frame = relative_to_frame or source_frame
-    trimmed_to = trimmed_to or source_frame.parent
+    dst_frame = dst_frame or src_frame
+    trimmed_to = trimmed_to or src_frame.parent
 
     # if we're going from the current to the same space, shortcut
     if (
-            (source_frame is relative_to_frame)
-            and (source_frame.parent is trimmed_to)
+            (src_frame is dst_frame)
+            and (src_frame.parent is trimmed_to)
     ):
-        return source_frame.parent.trimmed_range()
+        return src_frame.parent.trimmed_range()
 
-    source_item = source_frame.parent
-    target_item = relative_to_frame.parent
+    source_item = src_frame.parent
 
-    xform = relative_transform(from_item=source_frame, to_item=relative_to_frame)
+    xform = relative_transform(src_frame=src_frame, dst_frame=dst_frame)
 
-    range_to_xform = xform * source_item.trimmed_range(source_frame)
+    range_to_xform = xform * source_item.trimmed_range(src_frame)
 
     if trimmed_to is not source_item:
         # walk trims all the way up to the trimmed to from source_item
@@ -203,7 +200,7 @@ def range_of(
         # at this point result_bounds should be trimmed in the parent space
         # so transform them to the target_item space so that they can be
         # applied to range_to_xform
-        trim_to_target_xform = relative_transform(trim_path[-1], target_item)
+        trim_to_target_xform = relative_transform(trim_path[-1].after_effects, dst_frame)
         result_bounds = trim_to_target_xform * result_bounds
 
         # apply the new trim to the final bounds

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -28,12 +28,28 @@ from .. import (
     opentime
 )
 
+def _transform_range(range_to_transform, from_space, to_space):
+    if from_space is to_space:
+        return range_to_transform
+
+    parent_space = to_space
+    child_space = from_space
+    if from_space.is_parent_of(to_space):
+        parent_space = from_space
+        child_space = to_space
+
+    # @TODO: here you go
+    while parent_space
+
+
+
 def range_of(
     item,
-    in_scope=None, # must be a parent or child of item
-    trimmed_to=None, # must be a parent of item
+    in_scope=None, # must be a parent or child of item (Default is: item)
+    trimmed_to=None, # must be a parent of item (default is: item)
     # with_transitions=False, #todo make this an enum
 ):
+
     range_in_item_space = item.trimmed_range()
     if trimmed_to is not None and trimmed_to is not item:
         range_in_item_space = _trim_to(item, trimmed_to)

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -130,7 +130,9 @@ def _trimmed_range(range_to_trim, from_space, trim_to):
 
         # trim from parent down to trim_to (ending in trim_to space)
         for (child, parent) in path_to_trim:
-            trimmed_c_range = copy.deepcopy(parent.trimmed_range_of_child(child))
+            trimmed_c_range = copy.deepcopy(
+                parent.trimmed_range_of_child(child)
+            )
 
             # trim the range to the current child
             start_time = max(
@@ -158,17 +160,16 @@ def _trimmed_range(range_to_trim, from_space, trim_to):
             range_to_trim.start_time = start_time_in_child
             range_to_trim.duration = range_in_parent.duration
 
-
         # project trimmed range from trim_to space back up into the from_space
         for (child, parent) in path_from_trim:
-             range_in_parent = parent.range_of_child(child)
+            range_in_parent = parent.range_of_child(child)
 
-             offset = (
-                 range_in_parent.start_time - 
-                 child.trimmed_range().start_time
-             )
+            offset = (
+                range_in_parent.start_time -
+                child.trimmed_range().start_time
+            )
 
-             range_to_trim.start_time += offset
+            range_to_trim.start_time += offset
 
     else:
         # child -> parent
@@ -182,7 +183,7 @@ def _trimmed_range(range_to_trim, from_space, trim_to):
             range_in_parent = parent.range_of_child(child)
 
             offset = (
-                range_in_parent.start_time 
+                range_in_parent.start_time
                 - child.trimmed_range().start_time
             )
 
@@ -191,7 +192,9 @@ def _trimmed_range(range_to_trim, from_space, trim_to):
 
             # trim in parent space
             # @TODO: this shouldn't need to deepcopy
-            trimmed_c_range = copy.deepcopy(parent.trimmed_range_of_child(child))
+            trimmed_c_range = copy.deepcopy(
+                parent.trimmed_range_of_child(child)
+            )
 
             # trim the range to the current child
             start_time = max(
@@ -206,45 +209,42 @@ def _trimmed_range(range_to_trim, from_space, trim_to):
 
             # # project this into the child space
             # offset = (
-            #     child.trimmed_range().start_time 
+            #     child.trimmed_range().start_time
             #     - trimmed_c_range.start_time
             # )
             #
             # start_time_in_child = offset + start_time
-            # end_time_in_child = offset + end_time 
+            # end_time_in_child = offset + end_time
             #
             range_to_trim = opentime.range_from_start_end_time(
                 start_time,
                 end_time
             )
 
-
-        # project trimmed range from trim_to space back down into the from_space
+        # project trimmed range from trim_to space back down into the
+        # from_space
         for (child, parent) in path_from_trim:
-             # range_in_parent = parent.range_of_child(child)
-             #
-             # offset = (
-             #     range_in_parent.start_time - 
-             #     child.trimmed_range().start_time
-             # )
-             #
-             # range_to_trim.start_time += offset
+            # range_in_parent = parent.range_of_child(child)
+            #
+            # offset = (
+            #     range_in_parent.start_time -
+            #     child.trimmed_range().start_time
+            # )
+            #
+            # range_to_trim.start_time += offset
 
             offset = (
-                child.trimmed_range().start_time 
+                child.trimmed_range().start_time
                 - parent.range_of_child(child).start_time
             )
 
             range_to_trim.start_time += offset
-
 
     return range_to_trim
 
 
 def _path_to_parent(*args, **kwargs):
     return []
-
-
 
 
 # @TODO: CURRENTLY ONLY WORKS IF item is a child of relative_to AND TRIMMED_TO

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -65,6 +65,7 @@ def path_between(from_item, to_item):
 
     return tuple(result)
 
+
 def relative_transform(from_item, to_item):
     result = opentime.TimeTransform()
 
@@ -137,7 +138,7 @@ def range_of(
             # if this has a parent *and* it isn't the last thing in the chain
             if child.parent() and not count == len(trim_path) - 1:
                 result_bounds = (
-                    child.local_to_parent_transform() 
+                    child.local_to_parent_transform()
                     * result_bounds
                 )
 

--- a/opentimelineio/algorithms/time_transforms.py
+++ b/opentimelineio/algorithms/time_transforms.py
@@ -32,27 +32,26 @@ __doc__ = """Implementation of functions for query time."""
 
 
 def _transform_range(range_to_transform, from_space, to_space, trim_to=None):
-    found_trim = trim_to is None
-    found_transform = to_space is None
+    found_trim      = trim_to is None
+    found_transform = to_space is None 
 
-    child_space = from_space
-    parent_space = to_space
-    if not parent_space.is_parent_of(child_space):
-        child_space = to_space
-        parent_space = from_space
+    # child_space = from_space
+    # parent_space = to_space
+    # if not parent_space.is_parent_of(child_space):
 
-    __import__('ipdb').set_trace()
+    child_space = to_space if to_space is not None else trim_to
+    parent_space = from_space
 
     while not found_transform or not found_trim:
         parent_range = child_space.range_in_parent()
         if not found_trim:
             trim_parent_range = child_space.trimmed_range_in_parent()
             if trim_parent_range.start_time != parent_range.start_time:
-                diff = trim_parent_range.start_time - parent_range.start_time
+                start_max = max(trim_parent_range.start_time, parent_range.start_time)
+                range_to_transform.start_time = start_max
 
-            range_to_transform.start_time += diff
-
-            if child_space.parent() is trim_to:
+            # import ipdb; ipdb.set_trace()
+            if child_space.parent() is trim_to or child_space is trim_to:
                 found_trim = True
             range_to_transform.duration = min(
                 range_to_transform.duration,
@@ -60,11 +59,42 @@ def _transform_range(range_to_transform, from_space, to_space, trim_to=None):
             )
 
         if not found_transform:
-            range_to_transform.start_time += parent_range.start_time
+            child_range = child_space.trimmed_range()
+            parent_offset = parent_range.start_time - range_to_transform.start_time
+            range_to_transform.start_time = child_range.start_time - parent_offset
+
             if child_space.parent() is parent_space:
                 found_transform = True
 
         child_space = child_space.parent()
+
+        
+
+    # __import__('ipdb').set_trace()
+
+    # while not found_transform or not found_trim:
+    #     # parent_range = child_space.range_in_parent()
+    #     parent_range = child_space.trimmed_range()
+    #     if not found_trim:
+    #         trim_parent_range = child_space.trimmed_range_in_parent()
+    #         if trim_parent_range.start_time != parent_range.start_time:
+    #             diff = trim_parent_range.start_time - parent_range.start_time
+    #             range_to_transform.start_time += diff
+    #
+    #         # import ipdb; ipdb.set_trace()
+    #         if child_space.parent() is trim_to:
+    #             found_trim = True
+    #         range_to_transform.duration = min(
+    #             range_to_transform.duration,
+    #             trim_parent_range.duration
+    #         )
+    #
+    #     if not found_transform:
+    #         range_to_transform.start_time += parent_range.start_time
+    #         if child_space.parent() is found_transform:
+    #             found_transform = True
+    #
+    #     child_space = child_space.parent()
 
     return range_to_transform
 

--- a/opentimelineio/core/__init__.py
+++ b/opentimelineio/core/__init__.py
@@ -61,3 +61,7 @@ from .json_serializer import (
 from .media_reference import (
     MediaReference,
 )
+from .reference_frame import (
+    ReferenceFrame,
+    TransformName,
+)

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -27,8 +27,10 @@
 An object that can be composed by tracks.
 """
 
-from . import serializable_object
-from . import type_registry
+from . import (
+    serializable_object,
+    type_registry,
+)
 
 
 @type_registry.register_type
@@ -103,7 +105,6 @@ class Composable(serializable_object.SerializableObject):
             other = other._parent
 
         return False
-
     # @}
 
     def __repr__(self):

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -95,7 +95,13 @@ class Composable(serializable_object.SerializableObject):
         self._parent = new_parent
 
     def is_parent_of(self, other):
-        """Returns true if self is a parent or ancestor of other."""
+        """Returns true if self is a parent or ancestor of other.
+
+        clip.is_parent_of(clip) # returns False
+        """
+
+        if other is self:
+            return False
 
         visited = set([])
         while other._parent is not None and other._parent not in visited:

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -176,7 +176,7 @@ class Composition(item.Item, collections.MutableSequence):
         raise NotImplementedError
 
     def local_to_child_transform(self, child):
-        if not child in self:
+        if child not in self:
             raise exceptions.NotAChildError(child)
 
         result = opentime.TimeTransform()

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -175,6 +175,21 @@ class Composition(item.Item, collections.MutableSequence):
 
         raise NotImplementedError
 
+    def local_to_child_transform(self, child):
+        if not child in self:
+            raise exceptions.NotAChildError(child)
+
+        result = opentime.TimeTransform()
+
+        # @TODO: really read scale
+        float_scale_inverted = 1.0/float(result.scale)
+
+        rng = self.range_of_child(child)
+
+        result.offset = rng.start_time * -float_scale_inverted
+
+        return result
+
     def __copy__(self):
         result = super(Composition, self).__copy__()
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -179,16 +179,9 @@ class Composition(item.Item, collections.MutableSequence):
         if child not in self:
             raise exceptions.NotAChildError(child)
 
-        result = opentime.TimeTransform()
-
-        # @TODO: really read scale
-        float_scale_inverted = 1.0/float(result.scale)
-
-        rng = self.range_of_child(child)
-
-        result.offset = rng.start_time * -float_scale_inverted
-
-        return result
+        # @TODO: would it be better to directly compute the inverse matrix
+        #        rather than compute the l2p and *then* invert it?
+        return child.local_to_parent_transform().inverted()
 
     def __copy__(self):
         result = super(Composition, self).__copy__()
@@ -534,13 +527,17 @@ class Composition(item.Item, collections.MutableSequence):
                     str(item)
                 )
             )
-
+        # @TODO: is this check necesary?  its expensive for building large
+        #        compositions....
+        #        maybe there is a cheaper version - check parent pointer?
+        #
+        #
         if item in self:
             raise ValueError(
                 "Composable {} already present in this container, instancing"
                 " not allowed in otio compositions.".format(item)
             )
-
+        #
         item._set_parent(self)
         self._children.insert(index, item)
 

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -193,6 +193,22 @@ class Item(composable.Composable):
             tr.duration
         )
 
+    # @{ Transform functions
+    def local_to_parent_transform(self):
+        if not self._parent:
+            raise RuntimeError(
+                "Cannot compute local to parent transform with no parent."
+            )
+
+        result = opentime.TimeTransform()
+
+        rng = self.range_in_parent()
+
+        result.offset = rng.start_time
+
+        return result
+    # @}
+
     markers = serializable_object.serializable_field(
         "markers",
         doc="List of markers on this item."

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -206,6 +206,14 @@ class Item(composable.Composable):
 
         result.offset = rng.start_time - self.trimmed_range().start_time
 
+        # handle scale
+        for ef in reversed(self.effects):
+            try:
+                result.scale = 1.0 / float(ef.time_scalar)
+                break
+            except AttributeError:
+                pass
+
         return result
     # @}
 

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -148,10 +148,7 @@ class Item(composable.Composable):
             # @TODO: create a 'core.BlindEffect' to indicate that its an unknown,
             #        uninterpreted kind of effect that can go into schema
             if hasattr(ef, 'transform'):
-                try:
-                    last_xform = ef.transform().inverted()
-                except:
-                    continue
+                last_xform = ef.transform().inverted()
 
         return last_xform
 

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -204,7 +204,7 @@ class Item(composable.Composable):
 
         rng = self.range_in_parent()
 
-        result.offset = rng.start_time
+        result.offset = rng.start_time - self.trimmed_range().start_time
 
         return result
     # @}

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -112,10 +112,10 @@ def _encoded_time_range(input_otio):
 
 def _encoded_transform(input_otio):
     return {
+        # @TODO: should this get versioned up?  or left as version 1
         "OTIO_SCHEMA": "TimeTransform.1",
-        'offset': _encoded_time(input_otio.offset),
         'scale': input_otio.scale,
-        'rate': input_otio.rate
+        'offset': _encoded_time(input_otio.offset),
     }
 # @}
 
@@ -147,8 +147,8 @@ def _decoded_time_range(input_otio):
 
 def _decoded_transform(input_otio):
     return opentime.TimeTransform(
-        input_otio['offset'],
-        input_otio['scale']
+        input_otio['scale'],
+        input_otio['offset']
     )
 # @}
 

--- a/opentimelineio/core/reference_frame.py
+++ b/opentimelineio/core/reference_frame.py
@@ -1,0 +1,76 @@
+"""Represents a reference frame of time associated with an item in OTIO.
+"""
+
+import collections
+
+# @TODO: Promote this up to the top level of OTIO
+# eg: some_clip.local_space
+#     some_clip.duration(otio.TransformSpace.Local)
+#     some_clip.duration(otio.TransformSpace.Final)
+# result = transformed_to(
+#     some_time,
+#     some_clip.local_space,
+#     other_clip.final_space,
+# )
+# cl_range = range_of(
+#     some_clip,
+#     other_clip.final_space,
+#     clipped_to=other_clip,
+#     transitions=True
+# )
+
+def FakeEnum(cl_name, fields):
+    return collections.namedtuple(cl_name, fields)(*fields)
+#
+# # using collections.NamedTuple to make an immutable enum-like object that is
+# # python 2 compatible.
+# TransformName = collections.namedtuple(
+#     "TransformName",
+#     (
+#         # Goes from 0-pre transform duration
+#         # if you want a zero-based coordinate system
+#         "Intrinsic",
+#
+#         # [source_range.start_frame -> pre transform duration]
+#         # with the "origin" set to the source_range.start_frame but before scale
+#         "Local",
+#
+#         # [source_range.start_frame -> post transform duration]
+#         # what the parent will see
+#         # computation is always done in this space
+#         "Final",
+#     )
+# )("Intrinsic", "Local", "Final")
+
+# using collections.NamedTuple to make an immutable enum-like object that is
+# python 2 compatible.
+TransformName = FakeEnum("TransformName", ("BeforeEffects", "AfterEffects"))
+
+# class TransformName:
+#     # Goes from 0-pre transform duration
+#     # if you want a zero-based coordinate system
+#     Intrinsic = "intrinsic"
+#
+#     # [source_range.start_frame -> pre transform duration]
+#     # with the "origin" set to the source_range.start_frame but before scale
+#     Local = "local"
+#
+#     # [source_range.start_frame -> post transform duration]
+#     # what the parent will see
+#     # computation is always done in this space
+#     Final = "final"
+
+class ReferenceFrame(object):
+    def __init__(self, parent, space_enum):
+        self._parent = parent
+        self._space = space_enum
+
+    @property
+    def parent(self):
+        return self._parent
+
+    @property
+    def space(self):
+        return self._space
+
+

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -300,6 +300,42 @@ class TimeTransform(object):
                 "TimeTransform or RationalTime, not a {}".format(type(other))
             )
 
+    def inverted(self):
+        """Return the inverse of this time transform.
+
+        ** assumes that scale is non-zero **
+        
+        Because the TimeTransform is a 2x2 matrix of the form:
+            | scale offset | 
+            |   0     1    |
+
+        The inverse is:
+            | 1/scale -offset/scale |
+            |   0           1       |
+
+        To derive this:
+            | A B | * | S O |   | 1 0 |
+            | C D |   | 0 1 | = | 0 1 |
+            =>
+            A*S = 1 => A = 1/S
+            A*O + B = 0 => B = -O/S
+            C * S = 0 => C = 0
+            C * O + D = 1 => D = 1
+        """
+
+        if self.scale == 0:
+            raise RuntimeError("Cannot invert transform with scale of 0.")
+
+        inv_float_scale = 1/float(self.scale)
+
+        return TimeTransform(
+            scale=inv_float_scale,
+            offset=RationalTime(
+                -self.offset.value*inv_float_scale,
+                self.offset.rate
+            )
+        )
+
     def __repr__(self):
         return (
             "otio.opentime.TimeTransform(scale={}, offset={})".format(

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -304,9 +304,9 @@ class TimeTransform(object):
         """Return the inverse of this time transform.
 
         ** assumes that scale is non-zero **
-        
+
         Because the TimeTransform is a 2x2 matrix of the form:
-            | scale offset | 
+            | scale offset |
             |   0     1    |
 
         The inverse is:
@@ -482,7 +482,7 @@ class TimeRange(object):
     ):
         """Clamp a RationalTime or TimeRange with this TimeRange.
 
-        Returns a new instance of the same class after applying boundary 
+        Returns a new instance of the same class after applying boundary
         strategy (by default clamp both start and end).
 
         For example:
@@ -490,18 +490,18 @@ class TimeRange(object):
             # For a RationalTime
             tr = TimeRange(RationalTime(0, 24), RationalTime(10, 24))
             tr.clamp(RationalTime(-1, 24)) => (copy of) tr.start_time
-            tr.clamp(RationalTime(-1, 24), BoundStrategy.Free) 
+            tr.clamp(RationalTime(-1, 24), BoundStrategy.Free)
             => RationalTime(-1, 24)
 
             tr.clamp(RationalTime(12, 24)) => (copy of) tr.end_time_inclusive()
-            tr.clamp(RationalTime(12, 24), end_bound=BoundStrategy.Free) => 
+            tr.clamp(RationalTime(12, 24), end_bound=BoundStrategy.Free) =>
             => RationalTime(12, 24)
 
             # For a TimeRange
             tr = TimeRange(RationalTime(0, 24), RationalTime(10, 24))
             test = TimeRange(RationalTime(-1, 24), RationalTime(20, 24))
             tr.clamp(test) => (copy of) tr
-            tr.clamp(test, BoundStrategy.Free, BoundStrategy.Free) => 
+            tr.clamp(test, BoundStrategy.Free, BoundStrategy.Free) =>
             (copy of) test
 
         Does not modify anything in place.
@@ -518,7 +518,10 @@ class TimeRange(object):
             test_range = copy.copy(thing_to_clamp)
             end = test_range.end_time_exclusive()
             if start_bound == BoundStrategy.Clamp:
-                test_range.start_time = max(thing_to_clamp.start_time, self.start_time)
+                test_range.start_time = max(
+                    thing_to_clamp.start_time,
+                    self.start_time
+                )
             if end_bound == BoundStrategy.Clamp:
                 end = min(
                     test_range.end_time_exclusive(),

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -367,6 +367,9 @@ class TimeTransform(object):
     def __hash__(self):
         return hash((self.scale, self.offset))
 
+    def is_identity(self):
+        return (self.scale == 1 and self.offset.value == 0)
+
 
 class BoundStrategy(object):
     """Different bounding strategies for TimeRange """

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -116,6 +116,17 @@ class RationalTime(object):
     def __mul__(self, num):
         if isinstance(num, numbers.Number):
             return RationalTime(self.value*num, self.rate)
+        elif isinstance(num, TimeTransform):
+            raise RuntimeError(
+                "RationalTime must be the right hand argument when multiplied"
+                " against a TimeTransform, not the left hand side.  IE: TT*RT,"
+                " not RT*TT."
+            )
+        else:
+            raise TypeError(
+                "RationalTime may be multiplied by numbers and TimeTransforms,"
+                " not '{}' objects.".format(type(num))
+            )
 
     def __iadd__(self, other):
         """ += operator for self with another RationalTime.
@@ -281,7 +292,7 @@ class TimeTransform(object):
         elif isinstance(other, TimeTransform):
             return TimeTransform(
                 scale=self.scale*other.scale,
-                offset=self.scale*other.offset + self.offset
+                offset=other.offset*self.scale + self.offset
             )
         else:
             raise TypeError(

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -31,6 +31,7 @@ simple.
 
 import math
 import copy
+import numbers
 
 
 VALID_NON_DROPFRAME_TIMECODE_RATES = (
@@ -111,6 +112,10 @@ class RationalTime(object):
 
         except AttributeError:
             return False
+
+    def __mul__(self, num):
+        if isinstance(num, numbers.Number):
+            return RationalTime(self.value*num, self.rate)
 
     def __iadd__(self, other):
         """ += operator for self with another RationalTime.

--- a/opentimelineio/schema/effect.py
+++ b/opentimelineio/schema/effect.py
@@ -25,7 +25,8 @@
 """Implementation of Effect OTIO class."""
 
 from .. import (
-    core
+    core,
+    opentime,
 )
 
 
@@ -89,7 +90,10 @@ class Effect(core.SerializableObject):
 class TimeEffect(Effect):
     "Base Time Effect Class"
     _serializable_label = "TimeEffect.1"
-    pass
+
+    def transform(self):
+        NotImplementedError
+
 
 
 @core.register_type
@@ -105,6 +109,9 @@ class LinearTimeWarp(TimeEffect):
             metadata=metadata
         )
         self.time_scalar = time_scalar
+
+    def transform(self):
+        return opentime.TimeTransform(scale=self.time_scalar)
 
     time_scalar = core.serializable_field(
         "time_scalar",

--- a/tests/baselines/empty_timetransform.json
+++ b/tests/baselines/empty_timetransform.json
@@ -3,6 +3,5 @@
     "offset" : {
         "FROM_TEST_FILE" : "empty_rationaltime.json"
     },
-    "scale" : 1.0,
-    "rate" : null
+    "scale" : 1.0
 }

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -206,6 +206,63 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         p2c = tr.local_to_child_transform(it)
         self.assertEqual(p2c.offset, otio.opentime.RationalTime(-10, 24))
 
+    def test_local_to_child_with_scale(self):
+        # Track
+        #    Gap               Clip (x2 effect)
+        # [0             30][0       10]
+
+        # Frame 35 of Track = frame 10 of clip
+        # Frame 2 of clip = Frame 31 of Track
+
+        it = otio.core.Item()
+        it.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0, 24),
+            otio.opentime.RationalTime(30, 24)
+        )
+
+        tr = otio.schema.Track()
+        tr.append(
+            otio.schema.Gap(
+                source_range=otio.opentime.TimeRange(
+                    otio.opentime.RationalTime(0, 24),
+                    otio.opentime.RationalTime(10, 24)
+                )
+            )
+        )
+        tr.append(it)
+
+        it.effects.append(otio.schema.LinearTimeWarp(time_scalar=2))
+        test_frame = otio.opentime.RationalTime(10, 24)
+
+        l2c = tr.local_to_child_transform(it)
+        self.assertEqual(l2c, it.local_to_parent_transform().inverted())
+        test_frame_parent = otio.opentime.RationalTime(15, 24)
+        self.assertEqual(l2c * test_frame_parent, test_frame)
+
+    def test_inverse_local_to_child(self):
+        it = otio.core.Item()
+        it.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0, 24),
+            otio.opentime.RationalTime(30, 24)
+        )
+
+        tr = otio.schema.Track()
+        tr.append(
+            otio.schema.Gap(
+                source_range=otio.opentime.TimeRange(
+                    otio.opentime.RationalTime(0, 24),
+                    otio.opentime.RationalTime(10, 24)
+                )
+            )
+        )
+        tr.append(it)
+        it.effects.append(otio.schema.LinearTimeWarp(time_scalar=2))
+        self.assertEqual(
+            tr.local_to_child_transform(it),
+            it.local_to_parent_transform().inverted()
+        )
+
+
 
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -263,9 +263,7 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
 
-
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
-
     def test_cons(self):
         st = otio.schema.Stack(name="test")
         self.assertEqual(st.name, "test")

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -186,6 +186,26 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             all_children
         )
 
+    def test_transform_to_child(self):
+        it = otio.core.Item()
+        it.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0, 24),
+            otio.opentime.RationalTime(20, 24)
+        )
+        tr = otio.schema.Track()
+        tr.append(
+            otio.schema.Gap(
+                source_range=otio.opentime.TimeRange(
+                    otio.opentime.RationalTime(0, 24),
+                    otio.opentime.RationalTime(10, 24)
+                )
+            )
+        )
+        tr.append(it)
+
+        p2c = tr.local_to_child_transform(it)
+        self.assertEqual(p2c.offset, otio.opentime.RationalTime(-10, 24))
+
 
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -91,6 +91,25 @@ class TestLinearTimeWarp(unittest.TestCase):
         self.assertEqual(ef.time_scalar, 2.5)
         self.assertEqual(ef.metadata, {"foo": "bar"})
 
+    def test_duration(self):
+        test_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(10, 24),
+            otio.opentime.RationalTime(30, 24),
+        )
+        cl = otio.schema.Clip(
+            "TestClip",
+            source_range=test_range
+        )
+        ef = otio.schema.LinearTimeWarp("Foo", 2.5, {'foo': 'bar'})
+        cl.effects.append(ef)
+        self.assertEqual(cl.duration(), test_range.duration)
+        self.assertEqual(
+            cl.duration(cl.before_effects),
+            otio.opentime.TimeTransform(scale=1/2.5)*test_range.duration
+        )
+        self.assertEqual(cl.duration(cl.after_effects), test_range.duration)
+
+
 
 class TestFreezeFrame(unittest.TestCase):
     def test_cons(self):

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -35,8 +35,8 @@ class EffectTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             effect_name="blur",
             metadata={"foo": "bar"}
         )
-        encoded = otio.adapters.otio_json.write_to_string(ef)
-        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        encoded = otio.adapters.write_to_string(ef, 'otio_json')
+        decoded = otio.adapters.read_from_string(encoded, 'otio_json')
         self.assertIsOTIOEquivalentTo(ef, decoded)
         self.assertEqual(decoded.name, "blur it")
         self.assertEqual(decoded.effect_name, "blur")
@@ -124,3 +124,32 @@ class TestFreezeFrame(unittest.TestCase):
         self.assertEqual(ef.name, "Foo")
         self.assertEqual(ef.time_scalar, 0)
         self.assertEqual(ef.metadata, {"foo": "bar"})
+
+    def test_transform(self):
+        ef = otio.schema.FreezeFrame()
+        self.assertEqual(
+            ef.transform(),
+            otio.opentime.TimeTransform(scale=0)
+        )
+
+    def SKIP_test_apply_transform(self):
+        # @TODO: add support for 0 scale (freeze frames) here
+        test_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(10, 24),
+            otio.opentime.RationalTime(30, 24),
+        )
+        cl = otio.schema.Clip(
+            "TestClip",
+            source_range=test_range
+        )
+        ef = otio.schema.FreezeFrame()
+        cl.effects.append(ef)
+        xform = otio.algorithms.time_transforms.relative_transform(
+            cl.before_effects,
+            cl.after_effects
+        )
+
+        self.assertEqual(
+        )
+
+

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -109,6 +109,12 @@ class TestLinearTimeWarp(unittest.TestCase):
         )
         self.assertEqual(cl.duration(cl.after_effects), test_range.duration)
 
+    def test_transform(self):
+        ef = otio.schema.LinearTimeWarp("Foo", 2.5, {'foo': 'bar'})
+        self.assertEqual(
+            ef.transform(),
+            otio.opentime.TimeTransform(scale=2.5)
+        )
 
 
 class TestFreezeFrame(unittest.TestCase):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -606,6 +606,13 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             otio.opentime.TimeTransform()
         )
 
+        # ignore effects that don't have the transform function.
+        it.effects.append(otio.schema.Effect())
+        self.assertEqual(
+            it.effects_time_transform(),
+            otio.opentime.TimeTransform()
+        )
+
         it.effects.append(otio.schema.LinearTimeWarp(time_scalar=2))
         self.assertEqual(
             it.effects_time_transform(),

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -599,6 +599,5 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertEqual(l2c * test_frame_parent, test_frame)
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -521,6 +521,39 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             [item.visible_range() for item in timeline.each_clip()]
         )
 
+    def test_local_to_parent_transform(self):
+        it = otio.core.Item()
+        it.source_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0, 24),
+            otio.opentime.RationalTime(20, 24)
+        )
+        
+        # @TODO: Should having no parent mean identity transform?  
+        # or exception?
+        # disconnected from a parent, what should the behavior be?
+        with self.assertRaises(RuntimeError):
+            l2p = it.local_to_parent_transform()
+
+        tr = otio.schema.Track()
+        tr.append(
+            otio.schema.Gap(
+                source_range=otio.opentime.TimeRange(
+                    otio.opentime.RationalTime(0, 24),
+                    otio.opentime.RationalTime(10, 24)
+                )
+            )
+        )
+        tr.append(it)
+        l2p = it.local_to_parent_transform()
+
+        self.assertEqual(l2p.offset, otio.opentime.RationalTime(10, 24))
+
+        test_frame = otio.opentime.RationalTime(5, 24)
+        frame_in_parent = l2p * test_frame
+        self.assertEqual(frame_in_parent.value, 15)
+
+        # @TODO: test scale
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -525,7 +525,7 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         it = otio.core.Item()
         it.source_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0, 24),
-            otio.opentime.RationalTime(20, 24)
+            otio.opentime.RationalTime(30, 24)
         )
         
         # @TODO: Should having no parent mean identity transform?  
@@ -544,11 +544,21 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             )
         )
         tr.append(it)
-        l2p = it.local_to_parent_transform()
 
+        # without a source range offset
+        l2p = it.local_to_parent_transform()
         self.assertEqual(l2p.offset, otio.opentime.RationalTime(10, 24))
 
         test_frame = otio.opentime.RationalTime(5, 24)
+        frame_in_parent = l2p * test_frame
+        self.assertEqual(frame_in_parent.value, 15)
+
+        # with a source range offset
+        it.source_range.start_time = otio.opentime.RationalTime(30, 24)
+        l2p = it.local_to_parent_transform()
+        self.assertEqual(l2p.offset, otio.opentime.RationalTime(-20, 24))
+
+        test_frame = otio.opentime.RationalTime(35, 24)
         frame_in_parent = l2p * test_frame
         self.assertEqual(frame_in_parent.value, 15)
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -598,6 +598,21 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         test_frame_parent = otio.opentime.RationalTime(15, 24)
         self.assertEqual(l2c * test_frame_parent, test_frame)
 
+    def test_effects_transform(self):
+        it = otio.core.Item()
+
+        self.assertEqual(
+            it.effects_time_transform(),
+            otio.opentime.TimeTransform()
+        )
+
+        it.effects.append(otio.schema.LinearTimeWarp(time_scalar=2))
+        self.assertEqual(
+            it.effects_time_transform(),
+            otio.opentime.TimeTransform(scale=1.0/2.0)
+        )
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -527,8 +527,8 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             otio.opentime.RationalTime(0, 24),
             otio.opentime.RationalTime(30, 24)
         )
-        
-        # @TODO: Should having no parent mean identity transform?  
+
+        # @TODO: Should having no parent mean identity transform?
         # or exception?
         # disconnected from a parent, what should the behavior be?
         with self.assertRaises(RuntimeError):

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -553,21 +553,21 @@ class TestTimeTransform(unittest.TestCase):
     def test_identity_transform(self):
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform()
-        self.assertEqual(tstart, txform.applied_to(tstart))
+        self.assertEqual(tstart, txform*tstart)
 
         tstart = otio.opentime.RationalTime(12, 25)
-        txform = otio.opentime.TimeTransform(rate=50)
-        self.assertEqual(24, txform.applied_to(tstart).value)
+        txform = otio.opentime.TimeTransform()
+        self.assertEqual(tstart, txform*tstart)
 
     def test_offset(self):
         tstart = otio.opentime.RationalTime(12, 25)
         toffset = otio.opentime.RationalTime(10, 25)
         txform = otio.opentime.TimeTransform(offset=toffset)
-        self.assertEqual(tstart + toffset, txform.applied_to(tstart))
+        self.assertEqual(tstart + toffset, txform*tstart)
 
         tr = otio.opentime.TimeRange(tstart, tstart)
         self.assertEqual(
-            txform.applied_to(tr),
+            txform*tr,
             otio.opentime.TimeRange(tstart + toffset, tstart)
         )
 
@@ -576,20 +576,15 @@ class TestTimeTransform(unittest.TestCase):
         txform = otio.opentime.TimeTransform(scale=2)
         self.assertEqual(
             otio.opentime.RationalTime(24, 25),
-            txform.applied_to(tstart)
+            txform*tstart
         )
 
         tr = otio.opentime.TimeRange(tstart, tstart)
         tstart_scaled = otio.opentime.RationalTime(24, 25)
         self.assertEqual(
-            txform.applied_to(tr),
+            txform*tr,
             otio.opentime.TimeRange(tstart_scaled, tstart_scaled)
         )
-
-    def test_rate(self):
-        txform1 = otio.opentime.TimeTransform()
-        txform2 = otio.opentime.TimeTransform(rate=50)
-        self.assertEqual(txform2.rate, txform1.applied_to(txform2).rate)
 
     def test_string(self):
         tstart = otio.opentime.RationalTime(12, 25)
@@ -597,18 +592,17 @@ class TestTimeTransform(unittest.TestCase):
         self.assertEqual(
             repr(txform),
             "otio.opentime.TimeTransform("
+            "scale=2, "
             "offset=otio.opentime.RationalTime("
             "value=12, "
             "rate=25"
-            "), "
-            "scale=2, "
-            "rate=None"
+            ")"
             ")"
         )
 
         self.assertEqual(
             str(txform),
-            "TimeTransform(RationalTime(12, 25), 2, None)"
+            "TimeTransform(2, RationalTime(12, 25))"
         )
 
     def test_hash(self):
@@ -620,9 +614,6 @@ class TestTimeTransform(unittest.TestCase):
         self.assertEqual(hash(txform), hash(txform2))
 
         txform2 = otio.opentime.TimeTransform(offset=tstart, scale=3)
-        self.assertNotEqual(hash(txform), hash(txform2))
-
-        txform2 = otio.opentime.TimeTransform(offset=tstart, scale=2, rate=10)
         self.assertNotEqual(hash(txform), hash(txform2))
 
     def test_comparison(self):

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -552,6 +552,8 @@ class TestTime(unittest.TestCase):
         self.assertEqual((rt1*2).value, 24)
 
         with self.assertRaises(TypeError):
+            2*rt1
+        with self.assertRaises(TypeError):
             rt1*"foo"
 
 
@@ -601,7 +603,7 @@ class TestTimeTransform(unittest.TestCase):
             tt1*tt2,
             otio.opentime.TimeTransform(
                 tt1.scale*tt2.scale,
-                tt1.scale*tt2.offset + tt1.offset
+                tt2.offset*tt1.scale + tt1.offset
             )
         )
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -613,6 +613,30 @@ class TestTimeTransform(unittest.TestCase):
             )
         )
 
+    def test_inverted(self):
+        tt1 = otio.opentime.TimeTransform(
+            2,
+            otio.opentime.RationalTime(26, 24)
+        )
+
+        tt1_inv = tt1.inverted()
+
+        self.assertEqual(tt1_inv.scale, 1/float(tt1.scale))
+        self.assertEqual(tt1_inv.offset, (tt1.offset*-1)*(1/float(tt1.scale)))
+
+        ident_hopefully = tt1*tt1_inv
+        self.assertEqual(ident_hopefully.scale, 1)
+        self.assertEqual(ident_hopefully.offset.value, 0)
+
+        rt = otio.opentime.RationalTime(10, 24)
+
+        # test that the identity works after transformation
+        self.assertEqual(tt1_inv*(tt1 * rt), rt)
+
+        tt1.scale = 0
+        with self.assertRaises(RuntimeError):
+            tt1.inverted()
+
     def test_string(self):
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform(offset=tstart, scale=2)

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -596,8 +596,14 @@ class TestTimeTransform(unittest.TestCase):
         )
 
     def test_multiply_with_transform(self):
-        tt1= otio.opentime.TimeTransform(1, otio.opentime.RationalTime(12, 24))
-        tt2= otio.opentime.TimeTransform(2, otio.opentime.RationalTime(26, 24))
+        tt1 = otio.opentime.TimeTransform(
+            1,
+            otio.opentime.RationalTime(12, 24)
+        )
+        tt2 = otio.opentime.TimeTransform(
+            2,
+            otio.opentime.RationalTime(26, 24)
+        )
 
         self.assertEqual(
             tt1*tt2,

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -547,6 +547,13 @@ class TestTime(unittest.TestCase):
 
         self.assertEqual(tend, tdur)
 
+    def test_multiply(self):
+        rt1 = otio.opentime.RationalTime(12, 24)
+        self.assertEqual((rt1*2).value, 24)
+
+        with self.assertRaises(TypeError):
+            rt1*"foo"
+
 
 class TestTimeTransform(unittest.TestCase):
 
@@ -584,6 +591,18 @@ class TestTimeTransform(unittest.TestCase):
         self.assertEqual(
             txform*tr,
             otio.opentime.TimeRange(tstart_scaled, tstart_scaled)
+        )
+
+    def test_multiply_with_transform(self):
+        tt1= otio.opentime.TimeTransform(1, otio.opentime.RationalTime(12, 24))
+        tt2= otio.opentime.TimeTransform(2, otio.opentime.RationalTime(26, 24))
+
+        self.assertEqual(
+            tt1*tt2,
+            otio.opentime.TimeTransform(
+                tt1.scale*tt2.scale,
+                tt1.scale*tt2.offset + tt1.offset
+            )
         )
 
     def test_string(self):

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -637,6 +637,22 @@ class TestTimeTransform(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             tt1.inverted()
 
+    def test_inverted_range(self):
+        tt1 = otio.opentime.TimeTransform(
+            2,
+            otio.opentime.RationalTime(26, 24)
+        )
+
+        tr = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(10, 24),
+            otio.opentime.RationalTime(15, 24)
+        )
+
+        tt1_inv = tt1.inverted()
+
+        # test that the identity works after transformation
+        self.assertEqual(tt1_inv*(tt1 * tr), tr)
+
     def test_string(self):
         tstart = otio.opentime.RationalTime(12, 25)
         txform = otio.opentime.TimeTransform(offset=tstart, scale=2)

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -696,6 +696,17 @@ class TestTimeTransform(unittest.TestCase):
         self.assertNotEqual(txform, txform3)
         self.assertFalse(txform == txform3)
 
+    def test_is_identity(self):
+        t = otio.opentime.TimeTransform()
+        self.assertTrue(t.is_identity())
+
+        t.scale = 5
+        self.assertFalse(t.is_identity())
+
+        t.scale -= 4
+        self.assertTrue(t.is_identity())
+
+
 
 class TestTimeRange(unittest.TestCase):
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -785,7 +785,7 @@ class TestTimeRange(unittest.TestCase):
         )
 
         # @{ Test against RationalTime
-        # by default clamps 
+        # by default clamps
         self.assertEqual(tr.clamp(test_point_min), tr.start_time)
         self.assertEqual(tr.clamp(test_point_mid), test_point_mid)
         self.assertEqual(tr.clamp(test_point_max), tr.end_time_inclusive())

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -42,7 +42,7 @@ class OpenTimeTypeSerializerTest(unittest.TestCase):
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         self.assertEqual(tr, decoded)
 
-        tt = otio.opentime.TimeTransform(rt, scale=1.5)
+        tt = otio.opentime.TimeTransform(offset=rt, scale=1.5)
         encoded = otio.adapters.otio_json.write_to_string(tt)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         self.assertEqual(tt, decoded)

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -37,7 +37,9 @@ __doc__ = """Test range_of function from algorithms."""
 # utility constructors
 # @{
 def new_gap(duration_in_24fps):
-    return otio.schema.Gap(source_range=new_range(0, duration_in_24fps, 24))
+    return otio.schema.Gap(
+        duration=otio.opentime.RationalTime(duration_in_24fps, 24)
+    )
 
 
 def new_range(start, dur, rate=24):

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -28,10 +28,7 @@ import opentimelineio as otio
 
 __doc__ = """Test range_of function from algorithms."""
 
-# @TODO: A case with scales
 # @TODO: freeze frame & inverting a 0 scale transform
-# @TODO: Transforms
-# @TODO: up-and-down in one call
 
 
 # utility constructors

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -28,10 +28,15 @@ import opentimelineio as otio
 
 __doc__ = """Test range_of function from algorithms."""
 
+# @TODO: track that is shorter than a clip, both directions
+# @TODO: track that is longer than a single clip, both directions
+# @TODO: track within a track with a clip, both directions
+# @TODO: case where you have a common parent
+
 
 class RangeInTests(unittest.TestCase):
-    def test_source_range(self):
-        """Test using range_of to query for clip space."""
+    def test_range_of(self):
+        """Test the range_of function for a shorter track containing a clip."""
 
         tr = otio.schema.Track(name="Parent Track")
         rn = otio.opentime.TimeRange(
@@ -56,12 +61,19 @@ class RangeInTests(unittest.TestCase):
         )
         cl_1 = tr[0]
 
-        argument_to_result_map = [
             # arg               # result
-            ((cl_1, cl_1, cl_1), (10, 20)),
-            ((cl_1, tr,   cl_1), (0, 20)),
-            ((cl_1, cl_1, tr),   (12, 5)),
-            ((cl_1, tr, tr),     (2, 5)),
+        argument_to_result_map = [
+            # from the clip up to the track
+            # ((cl_1, cl_1, cl_1), (10, 20)),
+            # ((cl_1, tr,   cl_1), (0, 20)),
+            # ((cl_1, cl_1, tr),   (12, 5)),
+            # ((cl_1, tr, tr),     (2, 5)),
+
+            # from the track down to the clip
+            ((tr, cl_1, cl_1), (10, 20)),
+            # ((tr, tr,   cl_1), (0, 20)),
+            # ((tr, cl_1, tr),   (12, 5)),
+            # ((tr, tr, tr),     (2, 5)),
         ]
 
         for args, expected_result in argument_to_result_map:

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -29,8 +29,10 @@ import opentimelineio as otio
 __doc__ = """Test range_of function from algorithms."""
 
 # @TODO: A case with scales
+# @TODO: freeze frame & inverting a 0 scale transform
 # @TODO: Transforms
 # @TODO: up-and-down in one call
+
 
 # utility constructors
 # @{
@@ -110,8 +112,6 @@ class TimeTransformUtilityTests(unittest.TestCase):
             otio.algorithms.time_transforms.path_between(tr_mid, new_gap(10))
 
 
-
-# @unittest.skip
 class RangeOfTests(unittest.TestCase):
     def test_range_no_trims_no_scales(self):
         tr_top = otio.schema.Track(name="Parent Track")
@@ -345,7 +345,6 @@ class RangeOfTests(unittest.TestCase):
                 (expected_result),
                 msg="failed test iteration {}".format(i)
             )
-
 
 
 if __name__ == '__main__':

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -111,6 +111,20 @@ class TimeTransformUtilityTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             otio.algorithms.time_transforms.path_between(tr_mid, new_gap(10))
 
+def range_of_test_runner(self, arg_map):
+    for i, (args, expected_result) in enumerate(arg_map):
+        measured_result_range = otio.range_of(*args)
+        measured_result = (
+            measured_result_range.start_time.value,
+            measured_result_range.duration.value
+        )
+
+        self.longMessage = True
+        self.assertEqual(
+            measured_result,
+            expected_result,
+            msg="failed test iteration {}".format(i)
+        )
 
 class RangeOfTests(unittest.TestCase):
     def test_range_no_trims_no_scales(self):
@@ -134,13 +148,7 @@ class RangeOfTests(unittest.TestCase):
             ((tr_top, tr_top), (0, 88)),
         ]
 
-        for test_args, results in argument_to_result_map:
-            test_result = otio.range_of(*test_args)
-            known_result = new_range(*results)
-            self.assertTupleEqual(
-                (test_result.start_time.value, test_result.duration.value),
-                (known_result.start_time.value, known_result.duration.value),
-            )
+        range_of_test_runner(self, argument_to_result_map)
 
     def test_range_of_track_shorter_than_clip(self):
         """Test the range_of for a shorter track containing a longer clip."""
@@ -191,24 +199,7 @@ class RangeOfTests(unittest.TestCase):
             ((tr, tr, tr),     (35, 3)),
         ]
 
-        for i, (args, expected_result) in enumerate(argument_to_result_map):
-            measured_result_range = otio.range_of(*args)
-            measured_result = (
-                measured_result_range.start_time.value,
-                measured_result_range.duration.value
-            )
-
-            # make sure we didn't edit anything in place
-            self.assertIsNot(measured_result, args[0].trimmed_range())
-            self.assertIsNot(measured_result, args[1].trimmed_range())
-            self.assertIsNot(measured_result, args[2].trimmed_range())
-
-            self.longMessage = True
-            self.assertEqual(
-                (measured_result),
-                (expected_result),
-                msg="failed test iteration {}".format(i)
-            )
+        range_of_test_runner(self, argument_to_result_map)
 
     def test_range_of_track_longer_than_clip(self):
         """Test the range_of for a longer track containing a shorter clip."""
@@ -257,24 +248,7 @@ class RangeOfTests(unittest.TestCase):
             ((tr, tr, tr),     (0, 40)),
         ]
 
-        for i, (args, expected_result) in enumerate(argument_to_result_map):
-            measured_result_range = otio.range_of(*args)
-            measured_result = (
-                measured_result_range.start_time.value,
-                measured_result_range.duration.value
-            )
-
-            # make sure we didn't edit anything in place
-            self.assertIsNot(measured_result, args[0].trimmed_range())
-            self.assertIsNot(measured_result, args[1].trimmed_range())
-            self.assertIsNot(measured_result, args[2].trimmed_range())
-
-            self.longMessage = True
-            self.assertEqual(
-                (measured_result),
-                (expected_result),
-                msg="failed test iteration {}".format(i)
-            )
+        range_of_test_runner(self, argument_to_result_map)
 
     def test_range_of_with_small_middle_track(self):
         # Stack
@@ -327,24 +301,8 @@ class RangeOfTests(unittest.TestCase):
             ((tr, st, st),     (0, 3)),
         ]
 
-        for i, (args, expected_result) in enumerate(argument_to_result_map):
-            measured_result_range = otio.range_of(*args)
-            measured_result = (
-                measured_result_range.start_time.value,
-                measured_result_range.duration.value
-            )
+        range_of_test_runner(self, argument_to_result_map)
 
-            # make sure we didn't edit anything in place
-            self.assertIsNot(measured_result, args[0].trimmed_range())
-            self.assertIsNot(measured_result, args[1].trimmed_range())
-            self.assertIsNot(measured_result, args[2].trimmed_range())
-
-            self.longMessage = True
-            self.assertEqual(
-                (measured_result),
-                (expected_result),
-                msg="failed test iteration {}".format(i)
-            )
 
 
 if __name__ == '__main__':

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -35,8 +35,8 @@ __doc__ = """Test range_of function from algorithms."""
 
 
 class RangeInTests(unittest.TestCase):
-    def test_range_of(self):
-        """Test the range_of function for a shorter track containing a clip."""
+    def test_range_of_track_shorter_than_clip(self):
+        """Test the range_of for a shorter track containing a longer clip."""
 
         tr = otio.schema.Track(name="Parent Track")
         rn = otio.opentime.TimeRange(
@@ -61,19 +61,23 @@ class RangeInTests(unittest.TestCase):
         )
         cl_1 = tr[0]
 
+        # ranges
+        # track: 2, 5
+        # clip: 10, 20
+
             # arg               # result
         argument_to_result_map = [
             # from the clip up to the track
-            # ((cl_1, cl_1, cl_1), (10, 20)),
-            # ((cl_1, tr,   cl_1), (0, 20)),
-            # ((cl_1, cl_1, tr),   (12, 5)),
-            # ((cl_1, tr, tr),     (2, 5)),
+            ((cl_1, cl_1, cl_1), (10, 20)),
+            ((cl_1, cl_1, tr),   (12, 5)),
+            ((cl_1, tr,   cl_1), (0, 20)),
+            ((cl_1, tr, tr),     (2, 5)),
 
             # from the track down to the clip
-            ((tr, cl_1, cl_1), (10, 20)),
-            # ((tr, tr,   cl_1), (0, 20)),
-            # ((tr, cl_1, tr),   (12, 5)),
-            # ((tr, tr, tr),     (2, 5)),
+            ((tr, cl_1, cl_1), (12, 5)),
+            ((tr, cl_1, tr),   (12, 5)),
+            ((tr, tr,   cl_1), (2, 5)),
+            ((tr, tr, tr),     (2, 5)),
         ]
 
         for args, expected_result in argument_to_result_map:

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -111,6 +111,7 @@ class TimeTransformUtilityTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             otio.algorithms.time_transforms.path_between(tr_mid, new_gap(10))
 
+
 def range_of_test_runner(self, arg_map):
     for i, (args, expected_result) in enumerate(arg_map):
         measured_result_range = otio.range_of(*args)
@@ -125,6 +126,7 @@ def range_of_test_runner(self, arg_map):
             expected_result,
             msg="failed test iteration {}".format(i)
         )
+
 
 class RangeOfTests(unittest.TestCase):
     def test_range_no_trims_no_scales(self):
@@ -302,7 +304,6 @@ class RangeOfTests(unittest.TestCase):
         ]
 
         range_of_test_runner(self, argument_to_result_map)
-
 
 
 if __name__ == '__main__':

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -199,7 +199,6 @@ def range_of_test_runner(self, arg_map):
         )
 
 
-@unittest.skip
 class RangeOfTests(unittest.TestCase):
     def test_range_no_trims_no_scales(self):
         tr_top = otio.schema.Track(name="Parent Track")
@@ -220,11 +219,16 @@ class RangeOfTests(unittest.TestCase):
             ((cl_leaf.after_effects, tr_top.after_effects), (76, 12)),
             ((tr_top.after_effects, cl_leaf.after_effects), (-73, 88)),
             ((tr_top.after_effects, tr_top.after_effects), (0, 88)),
+
+            ((cl_leaf.before_effects, cl_leaf.after_effects), (3, 12)),
+            ((cl_leaf.before_effects, tr_top.after_effects), (76, 12)),
+            ((tr_top.after_effects, cl_leaf.after_effects), (-73, 88)),
+            ((tr_top.after_effects, tr_top.after_effects), (0, 88)),
         ]
 
         range_of_test_runner(self, argument_to_result_map)
 
-    def SKIP_test_range_of_track_shorter_than_clip(self):
+    def test_range_of_track_shorter_than_clip(self):
         """Test the range_of for a shorter track containing a longer clip."""
 
         # Track
@@ -275,7 +279,7 @@ class RangeOfTests(unittest.TestCase):
 
         range_of_test_runner(self, argument_to_result_map)
 
-    def SKIP_test_range_of_track_longer_than_clip(self):
+    def test_range_of_track_longer_than_clip(self):
         """Test the range_of for a longer track containing a shorter clip."""
 
         # Track
@@ -324,7 +328,7 @@ class RangeOfTests(unittest.TestCase):
 
         range_of_test_runner(self, argument_to_result_map)
 
-    def SKIP_test_range_of_with_small_middle_track(self):
+    def test_range_of_with_small_middle_track(self):
         # Stack
         #                                   [0 gap ... 40]
         #                                   [0 stack space                 40]

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -121,7 +121,7 @@ class RangeInTests(unittest.TestCase):
         for i in range(4):
             tr.append(
                 otio.schema.Clip(
-                    name='cl'+ str(i),
+                    name='cl' + str(i),
                     source_range=clip_range,
                     media_reference=mr_1
                 )

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2018 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import unittest
+
+import opentimelineio as otio
+
+__doc__ = """Test range_of function from algorithms."""
+
+class RangeInTests(unittest.TestCase):
+    def test_source_range(self):
+        """Test using range_of to query for clip space."""
+
+        tr = otio.schema.Track()
+        rn = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0, 24),
+            otio.opentime.RationalTime(10, 24),
+        )
+        src_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(5, 24),
+            otio.opentime.RationalTime(3, 24),
+        )
+        mr_1 = otio.schema.ExternalReference(available_range=rn)
+        mr_2 = otio.schema.ExternalReference(available_range=rn)
+        tr.append(
+            otio.schema.Clip(
+                name='cl1',
+                source_range=src_range,
+                media_reference=mr_1
+            )
+        )
+        tr.append(
+            otio.schema.Clip(
+                name='cl2',
+                source_range=src_range,
+                media_reference=mr_2
+            )
+        )
+        cl_1 = tr[0]
+        cl_2 = tr[1]
+
+        result = otio.range_of(
+            cl_1,
+            in_scope=cl_1,
+            trimmed_to=cl_1,
+            # include_transitions=True,
+        )
+
+        self.assertEqual(cl_1.source_range, otio.range_of(cl_1))
+        self.assertEqual(result, otio.range_of(cl_1))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -33,10 +33,12 @@ __doc__ = """Test range_of function from algorithms."""
 # @TODO: track within a track with a clip, both directions
 # @TODO: case where you have a common parent
 
+
 # utility constructors
 # @{
 def new_gap(duration_in_24fps):
     return otio.schema.Gap(source_range=new_range(0, duration_in_24fps, 24))
+
 
 def new_range(start, dur, rate=24):
     return otio.opentime.TimeRange(
@@ -44,6 +46,7 @@ def new_range(start, dur, rate=24):
         otio.opentime.RationalTime(dur, rate),
     )
 # @}
+
 
 class TimeTransformUtilityTests(unittest.TestCase):
     def test_hierarchy_path(self):
@@ -80,9 +83,9 @@ class TimeTransformUtilityTests(unittest.TestCase):
 
         self.assertEqual(
             otio.algorithms.time_transforms.relative_transform(tr_top, tr_top),
-            otio.opentime.TimeTransform(1, otio.opentime.RationalTime(0,24))
+            otio.opentime.TimeTransform(1, otio.opentime.RationalTime(0, 24))
         )
-        
+
 
 # @unittest.skip
 class RangeOfTests(unittest.TestCase):
@@ -248,7 +251,6 @@ class RangeOfTests(unittest.TestCase):
                 (expected_result),
                 msg="failed test iteration {}".format(i)
             )
-
 
 
 if __name__ == '__main__':

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -77,6 +77,11 @@ class TimeTransformUtilityTests(unittest.TestCase):
             l2p,
             otio.opentime.TimeTransform(1, otio.opentime.RationalTime(73, 24))
         )
+
+        self.assertEqual(
+            otio.algorithms.time_transforms.relative_transform(tr_top, tr_top),
+            otio.opentime.TimeTransform(1, otio.opentime.RationalTime(0,24))
+        )
         
 
 # @unittest.skip
@@ -146,11 +151,11 @@ class RangeOfTests(unittest.TestCase):
             # the clip's range
             ((cl_1, cl_1, cl_1), (10, 10)),
             # the clip's range but trimmed to the track's range
-            # ((cl_1, cl_1, tr),   (12, 5)),
+            ((cl_1, cl_1, tr),   (15, 3)),
             # the clip's range in the space of the track trimmed to the clip
             ((cl_1, tr,   cl_1), (30, 10)),
             # the clip's range in the space and trimmed to the track
-            # ((cl_1, tr, tr),     (2, 5)),
+            ((cl_1, tr, tr),     (35, 3)),
 
             # from the track down to the clip
             ((tr, cl_1, cl_1), (15, 3)),
@@ -212,16 +217,16 @@ class RangeOfTests(unittest.TestCase):
             # the clip's range
             ((cl_1, cl_1, cl_1), (10, 10)),
             # the clip's range but trimmed to the track's range
-            # ((cl_1, cl_1, tr),   (12, 5)),
+            ((cl_1, cl_1, tr),   (10, 10)),
             # the clip's range in the space of the track trimmed to the clip
             ((cl_1, tr,   cl_1), (30, 10)),
             # the clip's range in the space and trimmed to the track
-            # ((cl_1, tr, tr),     (2, 5)),
+            ((cl_1, tr, tr),     (30, 10)),
 
             # from the track down to the clip
             ((tr, cl_1, tr),   (-20, 40)),
-            # ((tr, cl_1, cl_1), (10, 10)),
-            # ((tr, tr,   cl_1), (30, 10)),
+            ((tr, cl_1, cl_1), (10, 10)),
+            ((tr, tr,   cl_1), (30, 10)),
             ((tr, tr, tr),     (0, 40)),
         ]
 

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -70,6 +70,17 @@ class RangeInTests(unittest.TestCase):
         self.assertEqual(cl_1.source_range, otio.range_of(cl_1))
         self.assertEqual(result, otio.range_of(cl_1))
 
+        self.assertEqual(
+            otio.range_of(cl_1, tr),
+            otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(3, 24),
+            )
+        )
+
+            
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -28,6 +28,7 @@ import opentimelineio as otio
 
 __doc__ = """Test range_of function from algorithms."""
 
+
 class RangeInTests(unittest.TestCase):
     def test_source_range(self):
         """Test using range_of to query for clip space."""

--- a/tests/test_time_transforms_algo.py
+++ b/tests/test_time_transforms_algo.py
@@ -65,7 +65,7 @@ class RangeInTests(unittest.TestCase):
         # track: 2, 5
         # clip: 10, 20
 
-            # arg               # result
+        #   # arg               # result
         argument_to_result_map = [
             # from the clip up to the track
             ((cl_1, cl_1, cl_1), (10, 20)),


### PR DESCRIPTION
Adds the `range_of` function, which:
- Lets you ask for the range of an OTIO object in the space of a parent or child
- with the trims applied from a print or child
- Examples: 
  - what range of the top level timeline does this clip occupy?
  - Which frame of the media is playing at frame 50 in the top timeline?

Additionally:
- `Item` has a `local_to_parent_transform` function and `Composable` has a `local_to_child_transform` method, which take into consideration effects which impact timing
- `TimeTransform`:
  - `TimeTransform` now has `scale` and `offset`, but no more rate argument and the math is clarified for how they compose with each other and with `RationalTime`/`TimeRange`.
  - `TimeTransform` has an `inverted` method which returns an inverted transform
  - `TimeTransform` behaves like a traditional transform matrix
- Fixed a bug in the `clamped` method on `TimeRange`

TODO:
- Add support for expanding transitions
- handle invert for scale of zero (freeze-frames create a 0 scale transform)
- smaller stuff:
  - refactor path stuff out
  - support up-and-down searches using common parent and getting relative times in sibling scopes (not just up or down)
