### PR TITLE
Setuptools plugins

### DIFF
--- a/examples/sample_plugin/otio_counter/__init__.py
+++ b/examples/sample_plugin/otio_counter/__init__.py
@@ -1,4 +1,5 @@
-import os
+import pkg_resources
+
 from opentimelineio.plugins import manifest
 
 """
@@ -42,6 +43,6 @@ as below.
 
 
 def plugin_manifest():
-    return manifest.manifest_from_file(
-        os.path.join(os.path.dirname(__file__), 'plugin_manifest.json')
+    return manifest.manifest_from_string(
+        pkg_resources.resource_string(__name__, 'plugin_manifest.json')
     )

--- a/examples/sample_plugin/otio_counter/__init__.py
+++ b/examples/sample_plugin/otio_counter/__init__.py
@@ -1,6 +1,45 @@
 import os
 from opentimelineio.plugins import manifest
 
+"""
+In the ``setup.py`` the top-level module was provided as the entry point. When
+OTIO loads a plugin, it then looks for a manifest object provided by the
+``plugin_manifest`` function. In this case we deserialize it from a json file
+we include in the module.
+
+Below is an example of what the manifest json might look like (also included
+as a file in this package.)
+
+.. codeblock:: JSON
+
+    {
+        "OTIO_SCHEMA" : "PluginManifest.1",
+        "adapters": [
+            {
+                "OTIO_SCHEMA": "Adapter.1",
+                "name": "track_counter",
+                "execution_scope": "in process",
+                "filepath": "adapter.py",
+                "suffixes": ["count"]
+            }
+        ]
+    }
+
+
+While this example shows an adapter, you may also define Media Linker plugins
+as below.
+
+.. codeblock:: JSON
+
+    {
+        "OTIO_SCHEMA" : "MediaLinker.1",
+        "name" : "linker_example",
+        "execution_scope" : "in process",
+        "filepath" : "linker.py"
+    }
+
+"""
+
 
 def plugin_manifest():
     return manifest.manifest_from_file(

--- a/examples/sample_plugin/otio_counter/__init__.py
+++ b/examples/sample_plugin/otio_counter/__init__.py
@@ -4,12 +4,18 @@ from opentimelineio.plugins import manifest
 
 """
 In the ``setup.py`` the top-level module was provided as the entry point. When
-OTIO loads a plugin, it then looks for a manifest object provided by the
-``plugin_manifest`` function. In this case we deserialize it from a json file
-we include in the module.
+OTIO loads a plugin, it will look for ``plugin_manifest.json`` in the package
+and register the plugins declared.
+
+If you wish to programmatically generate the manifest, you may return a
+:class:`Manifest` instance from your entry point's ``plugin_manifest``
+function.
+
+For example purposes, this simply deserializes it from the json file included
+in the package.
 
 Below is an example of what the manifest json might look like (also included
-as a file in this package.)
+as a file in this package).
 
 .. codeblock:: JSON
 
@@ -43,6 +49,15 @@ as below.
 
 
 def plugin_manifest():
+    """
+    If, for some reason, the Manifest needs to be generated at runtime, it can
+    be done here. This function takes precedence over ``plugin_manifest.json``
+    automatic discovery.
+
+    Note the example implemenation's behavior is identical to the default when
+    this function isn't defined. In most cases ``plugin_manifest.json`` should
+    be sufficient and the ``__init__.py`` file can be left empty.
+    """
     return manifest.manifest_from_string(
         pkg_resources.resource_string(__name__, 'plugin_manifest.json')
     )

--- a/examples/sample_plugin/otio_counter/__init__.py
+++ b/examples/sample_plugin/otio_counter/__init__.py
@@ -1,0 +1,8 @@
+import os
+from opentimelineio.plugins import manifest
+
+
+def plugin_manifest():
+    return manifest.manifest_from_file(
+        os.path.join(os.path.dirname(__file__), 'plugin_manifest.json')
+    )

--- a/examples/sample_plugin/otio_counter/adapter.py
+++ b/examples/sample_plugin/otio_counter/adapter.py
@@ -1,5 +1,13 @@
 import opentimelineio as otio
 
+"""
+This is the implementation of the contrived example adapter that simply writes
+the number of tracks in the timeline to a file, or will read an integer from a
+file and create a timeline with that number of tracks.
+
+This would be where your plugin implementation would be.
+"""
+
 
 def write_to_string(input_otio):
     return '{}'.format(len(input_otio.tracks))

--- a/examples/sample_plugin/otio_counter/adapter.py
+++ b/examples/sample_plugin/otio_counter/adapter.py
@@ -1,0 +1,14 @@
+import opentimelineio as otio
+
+
+def write_to_string(input_otio):
+    return '{}'.format(len(input_otio.tracks))
+
+
+def read_from_string(input_str):
+    t = otio.schema.Timeline()
+
+    for i in range(int(input_str)):
+        t.tracks.append(otio.schema.Track())
+
+    return t

--- a/examples/sample_plugin/otio_counter/plugin_manifest.json
+++ b/examples/sample_plugin/otio_counter/plugin_manifest.json
@@ -1,0 +1,12 @@
+{
+    "OTIO_SCHEMA" : "PluginManifest.1",
+    "adapters": [
+        {
+            "OTIO_SCHEMA": "Adapter.1",
+            "name": "otio_counter",
+            "execution_scope": "in process",
+            "filepath": "adapter.py",
+            "suffixes": ["count"]
+        }
+    ]
+}

--- a/examples/sample_plugin/otio_counter/plugin_manifest.json
+++ b/examples/sample_plugin/otio_counter/plugin_manifest.json
@@ -3,7 +3,7 @@
     "adapters": [
         {
             "OTIO_SCHEMA": "Adapter.1",
-            "name": "otio_counter",
+            "name": "track_counter",
             "execution_scope": "in process",
             "filepath": "adapter.py",
             "suffixes": ["count"]

--- a/examples/sample_plugin/setup.py
+++ b/examples/sample_plugin/setup.py
@@ -24,14 +24,17 @@ setup(
     entry_points={
         'opentimelineio.plugins': 'track_counter = otio_counter'
     },
+    packages=['otio_counter'],
     package_data={
         'otio_counter': [
             'plugin_manifest.json',
         ],
     },
+    keywords='plugin OpenTimelineIO sample',
+    platforms='any',
     version='1.0.0',
     description='Adapter writes number of tracks to file.',
-    packages=['otio_counter'],
+    license='Modified Apache 2.0 License',
     author='Pixar Animation Studios',
     author_email='opentimelineio@pixar.com',
     url='http://opentimeline.io',

--- a/examples/sample_plugin/setup.py
+++ b/examples/sample_plugin/setup.py
@@ -13,7 +13,7 @@ setup(
     version='1.0.0',
     description='Adapter writes number of tracks to file.',
     packages=['otio_counter'],
-    author='PIX System, LLC',
-    author_email='ereinecke@pixsystem.com',
-    keywords=['library', 'opentimelineio plugin'],
+    author='Pixar Animation Studios',
+    author_email='opentimelineio@pixar.com',
+    url='http://opentimeline.io',
 )

--- a/examples/sample_plugin/setup.py
+++ b/examples/sample_plugin/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+
+setup(
+    name='otio_counter',
+    entry_points={
+        'opentimelineio.plugins': 'otio_counter = otio_counter'
+    },
+    package_data={
+        'otio_counter': [
+            'plugin_manifest.json',
+        ],
+    },
+    version='1.0.0',
+    description='Adapter writes number of tracks to file.',
+    packages=['otio_counter'],
+    author='PIX System, LLC',
+    author_email='ereinecke@pixsystem.com',
+    keywords=['library', 'opentimelineio plugin'],
+)

--- a/examples/sample_plugin/setup.py
+++ b/examples/sample_plugin/setup.py
@@ -1,9 +1,28 @@
 from setuptools import setup
 
+"""
+This is an example of how to an OpenTimelineIO plugin installable as a separate
+python package.
+
+For the most part, the module can be built like any other python module, the
+one exception is that it must expose an ``opentimelineio.plugins`` entry point
+to allow OTIO to discover it.
+
+The entry point defined below can be read as:
+    1. Declaring this module provides for the entry point group
+    ``opentimelineio.plugins``.
+    2. Declaring that for the ``opentimelineio.plugins`` group, this module
+    provides a plugin named ``track_counter`` and the module that should be
+    loaded for tha plugin is the ``otio_counter`` module.
+
+For more information about python plugins, see the python packaging guide:
+    https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
+"""
+
 setup(
     name='otio_counter',
     entry_points={
-        'opentimelineio.plugins': 'otio_counter = otio_counter'
+        'opentimelineio.plugins': 'track_counter = otio_counter'
     },
     package_data={
         'otio_counter': [

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -158,13 +158,14 @@ def load_manifest():
                     'plugin_manifest.json'
                 ):
                     raise
-                manifest_string = pkg_resources.resource_string(
+                manifest_stream = pkg_resources.resource_stream(
                     plugin.module_name,
                     'plugin_manifest.json'
                 )
                 plugin_manifest = core.deserialize_json_from_string(
-                    manifest_string
+                    manifest_stream.read().decode('utf-8')
                 )
+                manifest_stream.close()
 
         except Exception:
             logging.exception("could not load plugin: {}".format(plugin_name))

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -156,7 +156,7 @@ def load_manifest():
             continue
 
         result.adapters.extend(plugin_manifest.adapters)
-        result.adapters.extend(plugin_manifest.media_linkers)
+        result.media_linkers.extend(plugin_manifest.media_linkers)
 
     # read local adapter manifests, if they exist
     _local_manifest_path = os.environ.get("OTIO_PLUGIN_MANIFEST_PATH", None)

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -145,7 +145,7 @@ def load_manifest():
     except ImportError:
         pass
 
-    # Discover python module plugins
+    # Discover setuptools-based plugins
     for plugin in pkg_resources.iter_entry_points("opentimelineio.plugins"):
         plugin_name = plugin.name
         try:
@@ -153,6 +153,7 @@ def load_manifest():
             plugin_manifest = plugin_entry_point.plugin_manifest()
         except Exception:
             logging.exception("could not load plugin: {}".format(plugin_name))
+            continue
 
         result.adapters.extend(plugin_manifest.adapters)
         result.adapters.extend(plugin_manifest.media_linkers)

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -150,7 +150,22 @@ def load_manifest():
         plugin_name = plugin.name
         try:
             plugin_entry_point = plugin.load()
-            plugin_manifest = plugin_entry_point.plugin_manifest()
+            try:
+                plugin_manifest = plugin_entry_point.plugin_manifest()
+            except AttributeError:
+                if not pkg_resources.resource_exists(
+                    plugin.module_name,
+                    'plugin_manifest.json'
+                ):
+                    raise
+                manifest_string = pkg_resources.resource_string(
+                    plugin.module_name,
+                    'plugin_manifest.json'
+                )
+                plugin_manifest = core.deserialize_json_from_string(
+                    manifest_string
+                )
+
         except Exception:
             logging.exception("could not load plugin: {}".format(plugin_name))
             continue

--- a/setup.py
+++ b/setup.py
@@ -153,7 +153,7 @@ setup(
     },
 
     test_suite='setup.test_otio',
-      
+
     tests_require=['mock;python_version<"3.3"'],
 
     # because we need to open() the adapters manifest, we aren't zip-safe

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,10 @@ setup(
             'coverage==4.5',
         ]
     },
+
     test_suite='setup.test_otio',
+      
+    tests_require=['mock;python_version<"3.3"'],
 
     # because we need to open() the adapters manifest, we aren't zip-safe
     zip_safe=False,

--- a/tests/baseline_reader.py
+++ b/tests/baseline_reader.py
@@ -52,8 +52,12 @@ def json_from_file_as_string(fpath):
         return json_from_string(fo.read())
 
 
+def path_to_baseline_directory():
+    return os.path.join(MODPATH, "baselines")
+
+
 def path_to_baseline(name):
-    return os.path.join(MODPATH, "baselines", "{0}.json".format(name))
+    return os.path.join(path_to_baseline_directory(), "{0}.json".format(name))
 
 
 def json_baseline(name):

--- a/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
@@ -1,0 +1,11 @@
+Metadata-Version: 1.0
+Name: otio-jsonplugin
+Version: 1.0.0
+Summary: Dummy plugin used for testing.
+Home-page: http://opentimeline.io
+Author: Pixar Animation Studios
+Author-email: opentimelineio@pixar.com
+License: Modified Apache 2.0 License
+Description-Content-Type: UNKNOWN
+Description: UNKNOWN
+Platform: any

--- a/tests/baselines/plugin_module/otio_jsonplugin.egg-info/entry_points.txt
+++ b/tests/baselines/plugin_module/otio_jsonplugin.egg-info/entry_points.txt
@@ -1,0 +1,3 @@
+[opentimelineio.plugins]
+mock_plugin = otio_jsonplugin
+

--- a/tests/baselines/plugin_module/otio_jsonplugin/plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_jsonplugin/plugin_manifest.json
@@ -1,0 +1,20 @@
+{
+    "OTIO_SCHEMA" : "PluginManifest.1",
+    "adapters": [
+        {
+            "OTIO_SCHEMA": "Adapter.1",
+            "name": "mock_adapter_json",
+            "execution_scope": "in process",
+            "filepath": "adapter.py",
+            "suffixes": ["mockadapter"]
+        }
+    ],
+    "media_linkers": [
+        {
+            "OTIO_SCHEMA" : "MediaLinker.1",
+            "name" : "mock_linker_json",
+            "execution_scope" : "in process",
+            "filepath" : "linker.py"
+        }
+    ]
+}

--- a/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
@@ -1,0 +1,11 @@
+Metadata-Version: 1.0
+Name: otio-mockplugin
+Version: 1.0.0
+Summary: Stands in for an actual plugin for testing.
+Home-page: http://opentimeline.io
+Author: Pixar Animation Studios
+Author-email: opentimelineio@pixar.com
+License: UNKNOWN
+Description-Content-Type: UNKNOWN
+Description: UNKNOWN
+Platform: UNKNOWN

--- a/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
@@ -1,11 +1,11 @@
 Metadata-Version: 1.0
 Name: otio-mockplugin
 Version: 1.0.0
-Summary: Stands in for an actual plugin for testing.
+Summary: Dummy plugin used for testing.
 Home-page: http://opentimeline.io
 Author: Pixar Animation Studios
 Author-email: opentimelineio@pixar.com
-License: UNKNOWN
+License: Modified Apache 2.0 License
 Description-Content-Type: UNKNOWN
 Description: UNKNOWN
-Platform: UNKNOWN
+Platform: any

--- a/tests/baselines/plugin_module/otio_mockplugin.egg-info/entry_points.txt
+++ b/tests/baselines/plugin_module/otio_mockplugin.egg-info/entry_points.txt
@@ -1,0 +1,3 @@
+[opentimelineio.plugins]
+mock_plugin = otio_mockplugin
+

--- a/tests/baselines/plugin_module/otio_mockplugin/__init__.py
+++ b/tests/baselines/plugin_module/otio_mockplugin/__init__.py
@@ -1,0 +1,9 @@
+import pkg_resources
+
+from opentimelineio.plugins import manifest
+
+
+def plugin_manifest():
+    return manifest.manifest_from_string(
+        pkg_resources.resource_string(__name__, 'plugin_manifest.json')
+    )

--- a/tests/baselines/plugin_module/otio_mockplugin/plugin_manifest.json
+++ b/tests/baselines/plugin_module/otio_mockplugin/plugin_manifest.json
@@ -1,0 +1,20 @@
+{
+    "OTIO_SCHEMA" : "PluginManifest.1",
+    "adapters": [
+        {
+            "OTIO_SCHEMA": "Adapter.1",
+            "name": "mock_adapter",
+            "execution_scope": "in process",
+            "filepath": "adapter.py",
+            "suffixes": ["mockadapter"]
+        }
+    ],
+    "media_linkers": [
+        {
+            "OTIO_SCHEMA" : "MediaLinker.1",
+            "name" : "mock_linker",
+            "execution_scope" : "in process",
+            "filepath" : "linker.py"
+        }
+    ]
+}

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -90,10 +90,10 @@ class TestSetuptoolsPlugin(unittest.TestCase):
 
         # Make sure adapters and linkers landed in the proper place
         for adapter in man.adapters:
-            self.assertTrue(isinstance(adapter, otio.adapters.Adapter))
+            self.assertIsInstance(adapter, otio.adapters.Adapter)
 
         for linker in man.media_linkers:
-            self.assertTrue(isinstance(linker, otio.media_linker.MediaLinker))
+            self.assertIsInstance(linker, otio.media_linker.MediaLinker)
 
     def test_detect_pugin_json_manifest(self):
         # Test detecting a plugin that rather than exposing the plugin_manifest
@@ -111,7 +111,7 @@ class TestSetuptoolsPlugin(unittest.TestCase):
 
         # Make sure adapters and linkers landed in the proper place
         for adapter in man.adapters:
-            self.assertTrue(isinstance(adapter, otio.adapters.Adapter))
+            self.assertIsInstance(adapter, otio.adapters.Adapter)
 
         for linker in man.media_linkers:
-            self.assertTrue(isinstance(linker, otio.media_linker.MediaLinker))
+            self.assertIsInstance(linker, otio.media_linker.MediaLinker)

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -22,7 +22,6 @@
 # language governing permissions and limitations under the Apache License.
 #
 import unittest
-import logging
 import os
 import pkg_resources
 import sys

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -1,0 +1,97 @@
+#
+# Copyright 2018 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+import unittest
+from unittest import mock
+from unittest.mock import patch
+import logging
+import os
+import pkg_resources
+
+import opentimelineio as otio
+import baseline_reader
+
+
+class TestSetuptoolsPlugin(unittest.TestCase):
+    def setUp(self):
+        # Get the location of the mock plugin module metadata
+        mock_module_path = os.path.join(
+            baseline_reader.path_to_baseline_directory(),
+            'plugin_module',
+        )
+
+        # Create a WorkingSet as if the module were installed
+        entries = [mock_module_path] + pkg_resources.working_set.entries
+        working_set = pkg_resources.WorkingSet(entries)
+
+        # Make a mock of the loaded plugin module
+        self.mock_adapter = mock.Mock()
+        self.mock_linker = mock.Mock()
+        mock_manifest = otio.plugins.manifest.Manifest()
+        mock_manifest.adapters = [self.mock_adapter]
+        mock_manifest.media_linkers = [self.mock_linker]
+        self.mock_plugin_module = mock.Mock(
+            plugin_manifest=mock.Mock(return_value=mock_manifest)
+        )
+
+        # Patch the plugin module as if it was loaded as otio_mockplugin
+        self.module_patcher = patch.dict(
+            'sys.modules',
+            otio_mockplugin=self.mock_plugin_module
+        )
+        self.module_patcher.start()
+
+        # linker from the entry point
+        self.entry_patcher = patch(
+            'pkg_resources.iter_entry_points',
+            working_set.iter_entry_points
+        )
+        self.entry_patcher.start()
+
+    def tearDown(self):
+        self.module_patcher.stop()
+        self.entry_patcher.stop()
+
+    def test_detect_pugin(self):
+        # Create a manifest and ensure it detected the mock adapter and linker
+        man = otio.plugins.manifest.load_manifest()
+        self.assertIn(self.mock_adapter, man.adapters)
+        self.assertIn(self.mock_linker, man.media_linkers)
+        self.assertNotIn(self.mock_linker, man.adapters)
+        self.assertNotIn(self.mock_adapter, man.media_linkers)
+
+    def test_failed_plugin_load(self):
+        # Disable the error logging to keep the test from being scary
+        logging.disable(logging.CRITICAL)
+
+        self.mock_plugin_module.plugin_manifest = mock.Mock(
+            side_effect=Exception
+        )
+
+        # Ensure we can load the manifest, safely
+        man = otio.plugins.manifest.load_manifest()
+        self.assertNotIn(self.mock_adapter, man.adapters)
+        self.assertNotIn(self.mock_linker, man.media_linkers)
+
+        # Reset the logging
+        logging.disable(logging.NOTSET)

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -22,11 +22,16 @@
 # language governing permissions and limitations under the Apache License.
 #
 import unittest
-from unittest import mock
-from unittest.mock import patch
 import logging
 import os
 import pkg_resources
+
+try:
+    # Python 3.3 forward includes the mock module
+    from unittest import mock
+except ImportError:
+    # Fallback for older python
+    import mock
 
 import opentimelineio as otio
 import baseline_reader
@@ -55,14 +60,14 @@ class TestSetuptoolsPlugin(unittest.TestCase):
         )
 
         # Patch the plugin module as if it was loaded as otio_mockplugin
-        self.module_patcher = patch.dict(
+        self.module_patcher = mock.patch.dict(
             'sys.modules',
             otio_mockplugin=self.mock_plugin_module
         )
         self.module_patcher.start()
 
         # linker from the entry point
-        self.entry_patcher = patch(
+        self.entry_patcher = mock.patch(
             'pkg_resources.iter_entry_points',
             working_set.iter_entry_points
         )

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -29,14 +29,25 @@ import pkg_resources
 try:
     # Python 3.3 forward includes the mock module
     from unittest import mock
+    could_import_mock = True
 except ImportError:
-    # Fallback for older python
-    import mock
+    # Fallback for older python (not included in standard library)
+    try:
+        import mock
+        could_import_mock = True
+    except ImportError:
+        # Mock appears to not be installed
+        could_import_mock = False
+
 
 import opentimelineio as otio
 import baseline_reader
 
 
+@unittest.skipIf(
+    not could_import_mock,
+    "mock module not found. Install mock from pypi or use python >= 3.3."
+)
 class TestSetuptoolsPlugin(unittest.TestCase):
     def setUp(self):
         # Get the location of the mock plugin module metadata


### PR DESCRIPTION
Submit for discussion, an approach to allow for plugin modules to be registered using setuptools entry points.

If the approach looks reasonable, I can do a pass to further document and finalize.

Here is an example of how to try this out:
```[ereinecke@airwolf:~/github/OpenTimelineIO]$ virtualenv plugintest
[ereinecke@airwolf:~/github/OpenTimelineIO]$ virtualenv plugintest
[ereinecke@airwolf:~/github/OpenTimelineIO]$ source plugintest/bin/activate
(plugintest) [ereinecke@airwolf:~/github/OpenTimelineIO]$ pip install .
(plugintest) [ereinecke@airwolf:~/github/OpenTimelineIO]$ cd examples/sample_plugin/
(plugintest) [ereinecke@airwolf:~/github/OpenTimelineIO]$ pip install .
(plugintest) [ereinecke@airwolf:~/github/OpenTimelineIO]$ cd ../..
(plugintest) [ereinecke@airwolf:~/github/OpenTimelineIO]$ python
>>> import opentimelineio as otio
>>> otio.adapters.read_from_string('6', 'otio_counter')
```


That call will return you a timeline with 6 tracks, per the adapter implementation.