### PR TITLE
opentime.py.to_timecode: Use given opentime object's rate for default

### DIFF
--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -556,18 +556,20 @@ def from_timecode(timecode_str, rate):
     return RationalTime(value, nominal_fps)
 
 
-def to_timecode(time_obj, rate):
+def to_timecode(time_obj, rate=None):
     """Convert a RationalTime into a timecode string.
 
     :param time_obj: (:class:`RationalTime`) instance to express as timecode.
     :param rate: (:class:`float`) The frame-rate to calculate timecode in
-        terms of.
+        terms of. (Default time_obj.rate)
 
     :return: (:class:`str`) The timecode.
     """
 
     if time_obj is None:
         return None
+
+    rate = rate or time_obj.rate
 
     # First, we correct the time unit total as if the content were playing
     # back at "nominal" fps

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -811,6 +811,20 @@ class TestTimeRange(unittest.TestCase):
         self.assertEqual(full, r1.extended_by(r2))
         self.assertEqual(full, r2.extended_by(r1))
 
+    def test_to_timecode_mixed_rates(self):
+        timecode = "00:06:56:17"
+        t = otio.opentime.from_timecode(timecode, 24)
+        self.assertEqual(timecode, otio.opentime.to_timecode(t))
+        self.assertEqual(timecode, otio.opentime.to_timecode(t, 24))
+        self.assertNotEqual(timecode, otio.opentime.to_timecode(t, 12))
+
+    def test_to_frames_mixed_rates(self):
+        frame = 100
+        t = otio.opentime.from_frames(frame, 24)
+        self.assertEqual(frame, otio.opentime.to_frames(t))
+        self.assertEqual(frame, otio.opentime.to_frames(t, 24))
+        self.assertNotEqual(frame, otio.opentime.to_frames(t, 12))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -100,7 +100,7 @@ class TestTime(unittest.TestCase):
     def test_time_timecode_convert(self):
         timecode = "00:06:56:17"
         t = otio.opentime.from_timecode(timecode, 24)
-        self.assertEqual(timecode, otio.opentime.to_timecode(t, 24))
+        self.assertEqual(timecode, otio.opentime.to_timecode(t))
 
     def test_timecode_24(self):
         timecode = "00:00:01:00"
@@ -133,7 +133,7 @@ class TestTime(unittest.TestCase):
         final_frame_number = 24 * 60 * 60 * 24 - 1
         final_time = otio.opentime.from_frames(final_frame_number, 24)
         self.assertEqual(
-            otio.opentime.to_timecode(final_time, 24),
+            otio.opentime.to_timecode(final_time),
             "23:59:59:23"
         )
 
@@ -152,10 +152,10 @@ class TestTime(unittest.TestCase):
         # Adding by a non-multiple of 24
         for fnum in range(1113, final_frame_number, 1113):
             rt = otio.opentime.from_frames(fnum, 24)
-            tc = otio.opentime.to_timecode(rt, 24)
+            tc = otio.opentime.to_timecode(rt)
             rt2 = otio.opentime.from_timecode(tc, 24)
             self.assertEqual(rt, rt2)
-            self.assertEqual(tc, otio.opentime.to_timecode(rt2, 24))
+            self.assertEqual(tc, otio.opentime.to_timecode(rt2))
 
     def test_timecode_23976_fps(self):
         # These are reference value from a clip with burnt-in timecode


### PR DESCRIPTION
If no rate is provided then use the rate of the of the given opentime
object.