### PR TITLE
Make test runs test-contrib, so these don't need to be run twice.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ install:
 script:
     - make lint
     - make test
-    - make test-contrib
     - make coverage

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,18 @@ test-contrib: python-version
 python-version:
 	@python --version
 
-coverage: python-version
+coverage: coverage-core coverage-contrib
+
+coverage-core: python-version
 ifndef COV_PROG
 	$(error "coverage is not available please see: "\
 		"https://coverage.readthedocs.io/en/coverage-4.2/install.html")
 endif
 	@${COV_PROG} run --source=opentimelineio -m unittest discover tests
 	@${COV_PROG} report -m
+
+coverage-contrib: python-version
+	@make -C opentimelineio_contrib/adapters coverage VERBOSE=$(VERBOSE)
 
 # run all the unit tests, stopping at the first failure
 test_first_fail: python-version

--- a/opentimelineio_contrib/adapters/Makefile
+++ b/opentimelineio_contrib/adapters/Makefile
@@ -2,6 +2,7 @@
 
 export PYTHONPATH:=../../
 TEST_ARGS=
+COV_PROG := $(shell command -v coverage 2> /dev/null)
 
 ifeq ($(VERBOSE), 1)
 	TEST_ARGS:=-v
@@ -10,3 +11,13 @@ endif
 
 test:
 	@python -m unittest discover tests $(TEST_ARGS)
+
+coverage:
+ifndef COV_PROG
+	$(error "coverage is not available please see: "\
+		"https://coverage.readthedocs.io/en/coverage-4.2/install.html")
+endif
+	@${COV_PROG} run -m unittest discover tests
+	@${COV_PROG} report -m
+
+


### PR DESCRIPTION
Originally, `make test` didn't run `make test-contrib` - but now it does!  So we don't need to run it twice on travis.  Will make travis CI run slightly faster (2s or so).