### PR TITLE
Reference type implementation

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -671,7 +671,7 @@ def _expand_transitions(timeline):
             next_clip = next(track_iter, None)
 
     for (track, from_clip, to_transition) in replace_list:
-        track[track.index_of_child(from_clip)] = to_transition
+        track[track.index(from_clip)] = to_transition
 
     for (track, clip_to_remove) in list(set(remove_list)):
         # if clip_to_remove in track:

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -78,7 +78,7 @@ def _populate_backreference_map(item, br_map):
     elif isinstance(item, otio.schema.MissingReference):
         item_hash = 'missing_ref'
     else:
-        item_hash = item.__hash__()
+        item_hash = hash(id(item))
 
     # skip unspecified tags
     if tag is not None:

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -122,7 +122,7 @@ def filtered_composition(
         parent = None
         child_index = None
         if _safe_parent(child) is not None:
-            child_index = child.parent().index_of_child(child)
+            child_index = child.parent().index(child)
             parent = child.parent()
             del child.parent()[child_index]
 
@@ -258,7 +258,7 @@ def filtered_with_sequence_context(
         parent = None
         child_index = None
         if _safe_parent(child) is not None:
-            child_index = child.parent().index_of_child(child)
+            child_index = child.parent().index(child)
             parent = child.parent()
             del child.parent()[child_index]
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -229,28 +229,6 @@ class Composition(item.Item, collections.MutableSequence):
 
         return parents
 
-    def index_of_child(self, child):
-        """Returns the index of the given child object within this Composition.
-        Unlike index() this method checks for the exact child object, not
-        objects that are equal to the given child.
-
-        If the child is not found, a NotAChildError is thrown. If multiple
-        instances of the child are found, an InstancingNotAllowedError is
-        thrown."""
-        indexes = [i for i, c in enumerate(self) if c is child]
-        if len(indexes) == 0:
-            raise exceptions.NotAChildError(
-                "Item '{}' is not a child of '{}'.".format(child, self)
-            )
-        if len(indexes) > 1:
-            raise exceptions.InstancingNotAllowedError(
-                "Item '{}' is used multiple times as child of '{}'.".format(
-                    child,
-                    self
-                )
-            )
-        return indexes[0]
-
     def range_of_child(self, child, reference_space=None):
         """The range of the child in relation to another item
         (reference_space), not trimmed based on this
@@ -280,7 +258,7 @@ class Composition(item.Item, collections.MutableSequence):
         result_range = None
 
         for parent in parents:
-            index = parent.index_of_child(current)
+            index = parent.index(current)
             parent_range = parent.range_of_child_at_index(index)
 
             if not result_range:
@@ -379,7 +357,7 @@ class Composition(item.Item, collections.MutableSequence):
         result_range = None
 
         for parent in parents:
-            index = parent.index_of_child(current)
+            index = parent.index(current)
             parent_range = parent.trimmed_range_of_child_at_index(index)
 
             if not result_range:

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -461,10 +461,9 @@ class Composition(item.Item, collections.MutableSequence):
             isect = set_outside_old.intersection(set_value)
             if isect:
                 raise ValueError(
-                    "Attempting to insert duplicates of items {} already present "
-                    "in container, instancing not allowed in Compositions".format(
-                        isect
-                    )
+                    "Attempting to insert duplicates of items {} already "
+                    "present in container, instancing not allowed in "
+                    "Compositions".format(isect)
                 )
 
             # update old parent
@@ -478,7 +477,6 @@ class Composition(item.Item, collections.MutableSequence):
         if value:
             for val in value:
                 val._set_parent(self)
-
 
     def __setitem__(self, key, value):
         # fetch the current thing at that index/slice

--- a/opentimelineio/core/media_reference.py
+++ b/opentimelineio/core/media_reference.py
@@ -98,11 +98,3 @@ class MediaReference(serializable_object.SerializableObject):
             repr(self.available_range),
             repr(self.metadata)
         )
-
-    def __hash__(self, other):
-        return hash(
-            self.name,
-            self._name,
-            self.available_range,
-            self.metadata
-        )

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -81,8 +81,10 @@ class SerializableObject(object):
     # comparison is pointer comparison, but you can use 'is_equivalent_to' to
     # check if the contents of the SerializableObject are the same as some
     # other SerializableObject's contents.
-    def __eq__(self, other):
-        return self is other
+    #
+    # Implicitly:
+    # def __eq__(self, other):
+    #     return self is other
 
     def is_equivalent_to(self, other):
         """Returns true if the contents of self and other match."""
@@ -92,6 +94,14 @@ class SerializableObject(object):
                 return True
 
             # XXX: Gross hack takes OTIO->JSON String->Python Dictionaries
+            #
+            # using the serializer ensures that we only compare fields that are
+            # serializable, which is how we define equivalence.
+            #
+            # we use json.loads() to turn the string back into dictionaries
+            # so we can use python's equivalence for things like floating 
+            # point numbers (ie 5.0 == 5) without having to do string 
+            # processing.
 
             from . import json_serializer
             import json
@@ -105,9 +115,6 @@ class SerializableObject(object):
             return (lhs == rhs)
         except AttributeError:
             return False
-
-    def __hash__(self):
-        return hash(id(self))
     # @}
 
     def update(self, d):

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -99,8 +99,8 @@ class SerializableObject(object):
             # serializable, which is how we define equivalence.
             #
             # we use json.loads() to turn the string back into dictionaries
-            # so we can use python's equivalence for things like floating 
-            # point numbers (ie 5.0 == 5) without having to do string 
+            # so we can use python's equivalence for things like floating
+            # point numbers (ie 5.0 == 5) without having to do string
             # processing.
 
             from . import json_serializer

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -76,25 +76,39 @@ class SerializableObject(object):
     def __init__(self):
         self.data = {}
 
+    # @{ "Reference Type" semantics for SerializableObject
+    # We think of the SerializableObject as a reference type - by default
+    # comparison is pointer comparison, but you can use 'is_equivalent_to' to
+    # check if the contents of the SerializableObject are the same as some
+    # other SerializableObject's contents.
     def __eq__(self, other):
+        return self is other
+
+    def is_equivalent_to(self, other):
+        """Returns true if the contents of self and other match."""
+
         try:
-            return (self.data == other.data)
+            if self.data == other.data:
+                return True
+
+            # XXX: Gross hack takes OTIO->JSON String->Python Dictionaries
+
+            from . import json_serializer
+            import json
+
+            lhs_str = json_serializer.serialize_json_to_string(self)
+            lhs = json.loads(lhs_str)
+
+            rhs_str = json_serializer.serialize_json_to_string(other)
+            rhs = json.loads(rhs_str)
+
+            return (lhs == rhs)
         except AttributeError:
             return False
 
     def __hash__(self):
-        # Because the children of this class should implement their own
-        # versions of __eq__ and __hash__, this is really meant to be a
-        # "reasonable default" to get things up and running until that is
-        # possible.
-        #
-        # As such it is using the simple ugly hack implementation of
-        # stringifying.
-        #
-        # If this is ever a problem it should be replaced with a more robust
-        # implementation.
-
-        return hash(str(self.data))
+        return hash(id(self))
+    # @}
 
     def update(self, d):
         """Like the dictionary .update() method.

--- a/opentimelineio/schema/external_reference.py
+++ b/opentimelineio/schema/external_reference.py
@@ -67,12 +67,3 @@ class ExternalReference(core.MediaReference):
         return 'otio.schema.ExternalReference(target_url={})'.format(
             repr(self.target_url)
         )
-
-    def __hash__(self, other):
-        return hash(
-            self.name,
-            self._name,
-            self.available_range,
-            self.target_url,
-            self.metadata
-        )

--- a/opentimelineio/schema/marker.py
+++ b/opentimelineio/schema/marker.py
@@ -102,15 +102,6 @@ class Marker(core.SerializableObject):
         except (KeyError, AttributeError):
             return False
 
-    def __hash__(self):
-        return hash(
-            (
-                self.name,
-                self.marked_range,
-                tuple(self.metadata.items())
-            )
-        )
-
     def __repr__(self):
         return (
             "otio.schema.Marker("

--- a/opentimelineio/schema/marker.py
+++ b/opentimelineio/schema/marker.py
@@ -93,15 +93,6 @@ class Marker(core.SerializableObject):
         "Metadata dictionary."
     )
 
-    def __eq__(self, other):
-        try:
-            return (
-                (self.name, self.marked_range, self.metadata) ==
-                (other.name, other.marked_range, other.metadata)
-            )
-        except (KeyError, AttributeError):
-            return False
-
     def __repr__(self):
         return (
             "otio.schema.Marker("

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -164,7 +164,7 @@ class Track(core.Composition):
         """
 
         try:
-            index = self.index_of_child(item)
+            index = self.index(item)
         except ValueError:
             raise ValueError(
                 "item: {} is not in composition: {}".format(

--- a/opentimelineio/test_utils.py
+++ b/opentimelineio/test_utils.py
@@ -1,5 +1,6 @@
+#!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright 2018 Pixar Animation Studios
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in
@@ -22,23 +23,30 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-"""An editorial interchange format and library.
+"""Utility assertions for OTIO Unit tests."""
 
-see: http://opentimeline.io
+import re
 
-.. moduleauthor:: Pixar Animation Studios <opentimelineio@pixar.com>
-"""
+import opentimelineio as otio
 
-# flake8: noqa
 
-# in dependency hierarchy
-from . import (
-    opentime,
-    exceptions,
-    core,
-    schema,
-    plugins,
-    adapters,
-    algorithms,
-    test_utils,
-)
+class OTIOAssertions(object):
+    def assertJsonEqual(self, known, test_result):
+        """Convert to json and compare that (more readable)."""
+        self.maxDiff = None
+
+        known_str = otio.adapters.write_to_string(known, 'otio_json')
+        test_str = otio.adapters.write_to_string(test_result, 'otio_json')
+
+        def strip_trailing_decimal_zero(s):
+            return re.sub(r'"(value|rate)": (\d+)\.0', r'"\1": \2', s)
+
+        self.assertMultiLineEqual(
+            strip_trailing_decimal_zero(known_str),
+            strip_trailing_decimal_zero(test_str)
+        )
+
+    def assertIsOTIOEquivalentTo(self, known, test_result):
+        """Test using the 'is equivalent to' method on SerializableObject"""
+
+        self.assertTrue(known.is_equivalent_to(test_result))

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -47,7 +47,7 @@ class TestAdapterSuffixes(unittest.TestCase):
 class TestPluginAdapters(unittest.TestCase):
     def setUp(self):
         self.jsn = baseline_reader.json_baseline_as_string(ADAPTER_PATH)
-        self.adp = otio.adapters.otio_json.read_from_string(self.jsn)
+        self.adp = otio.adapters.read_from_string(self.jsn, 'otio_json')
         self.adp._json_path = os.path.join(
             baseline_reader.MODPATH,
             "baselines",

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -38,7 +38,7 @@ SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
 
 
-class BuiltInAdapterTest(unittest.TestCase):
+class BuiltInAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_disk_io(self):
         edl_path = SCREENING_EXAMPLE_PATH
@@ -46,7 +46,7 @@ class BuiltInAdapterTest(unittest.TestCase):
         otiotmp = tempfile.mkstemp(suffix=".otio", text=True)[1]
         otio.adapters.write_to_file(timeline, otiotmp)
         decoded = otio.adapters.read_from_file(otiotmp)
-        self.assertEqual(timeline, decoded)
+        self.assertJsonEqual(timeline, decoded)
 
     def test_otio_round_trip(self):
         tl = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
@@ -58,13 +58,12 @@ class BuiltInAdapterTest(unittest.TestCase):
         temp_dir = tempfile.mkdtemp(prefix='test_otio_adapter')
         temp_file = os.path.join(temp_dir, 'test.otio')
         otio.adapters.otio_json.write_to_file(tl, temp_file)
-        new = otio.adapters.otio_json.read_from_file(
-            temp_file)
+        new = otio.adapters.otio_json.read_from_file(temp_file)
 
         new_json = otio.adapters.otio_json.write_to_string(new)
 
         self.assertMultiLineEqual(baseline_json, new_json)
-        self.assertEqual(tl, new)
+        self.assertIsOTIOEquivalentTo(tl, new)
         # Clean up the temporary file when you're finished.
         os.remove(temp_file)
 
@@ -97,7 +96,7 @@ class BuiltInAdapterTest(unittest.TestCase):
         )
 
         test_str = otio.adapters.write_to_string(tl)
-        self.assertEqual(tl, otio.adapters.read_from_string(test_str))
+        self.assertJsonEqual(tl, otio.adapters.read_from_string(test_str))
 
 
 if __name__ == '__main__':

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -27,7 +27,7 @@ import unittest
 import opentimelineio as otio
 
 
-class ClipTests(unittest.TestCase):
+class ClipTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):
         name = "test"
@@ -55,7 +55,7 @@ class ClipTests(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(cl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(cl, decoded)
+        self.assertIsOTIOEquivalentTo(cl, decoded)
 
     def test_each_clip(self):
         cl = otio.schema.Clip(name="test_clip")
@@ -141,19 +141,19 @@ class ClipTests(unittest.TestCase):
 
     def test_ref_default(self):
         cl = otio.schema.Clip()
-        self.assertEqual(
+        self.assertIsOTIOEquivalentTo(
             cl.media_reference,
             otio.schema.MissingReference()
         )
 
         cl.media_reference = None
-        self.assertEqual(
+        self.assertIsOTIOEquivalentTo(
             cl.media_reference,
             otio.schema.MissingReference()
         )
 
         cl.media_reference = otio.schema.ExternalReference()
-        self.assertEqual(
+        self.assertIsOTIOEquivalentTo(
             cl.media_reference,
             otio.schema.ExternalReference()
         )

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -33,8 +33,6 @@ import unittest
 import opentimelineio as otio
 from opentimelineio.adapters import cmx_3600
 
-import test_filter_algorithms
-
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
 NUCODA_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "nucoda_example.edl")
@@ -51,7 +49,7 @@ SPEED_EFFECTS_TEST_SMALL = os.path.join(
 )
 
 
-class EDLAdapterTest(unittest.TestCase, test_filter_algorithms.OTIOAssertions):
+class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
     maxDiff = None
 
     def test_edl_read(self):
@@ -261,7 +259,7 @@ class EDLAdapterTest(unittest.TestCase, test_filter_algorithms.OTIOAssertions):
         self.assertMultiLineEqual(original_json, output_json)
 
         # The in-memory OTIO representation should be the same
-        self.assertEqual(timeline, result)
+        self.assertIsOTIOEquivalentTo(timeline, result)
 
         # When debugging, use this to see the difference in the EDLs on disk
         # os.system("opendiff {} {}".format(SCREENING_EXAMPLE_PATH, tmp_path))
@@ -274,7 +272,7 @@ class EDLAdapterTest(unittest.TestCase, test_filter_algorithms.OTIOAssertions):
     def test_regex_flexibility(self):
         timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
         no_spaces = otio.adapters.read_from_file(NO_SPACES_PATH)
-        self.assertEqual(timeline, no_spaces)
+        self.assertIsOTIOEquivalentTo(timeline, no_spaces)
 
     def test_clip_with_tab_and_space_delimiters(self):
         timeline = otio.adapters.read_from_string(
@@ -436,7 +434,7 @@ class EDLAdapterTest(unittest.TestCase, test_filter_algorithms.OTIOAssertions):
             timeline.tracks[0][0].source_range.duration,
             otio.opentime.from_timecode("00:00:01:07", fps)
         )
-        self.assertEqual(
+        self.assertIsOTIOEquivalentTo(
             timeline.tracks[0][0].media_reference,
             otio.schema.ExternalReference(
                 target_url=r"S:\path\to\ZZ100_501.take_1.0001.exr"
@@ -450,7 +448,7 @@ class EDLAdapterTest(unittest.TestCase, test_filter_algorithms.OTIOAssertions):
             timeline.tracks[0][1].source_range.duration,
             otio.opentime.from_timecode("00:00:02:02", fps)
         )
-        self.assertEqual(
+        self.assertIsOTIOEquivalentTo(
             timeline.tracks[0][1].media_reference,
             otio.schema.ExternalReference(
                 target_url=r"S:\path\to\ZZ100_502A.take_2.0101.exr"

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -29,7 +29,7 @@ import unittest
 import opentimelineio as otio
 
 
-class ComposableTests(unittest.TestCase):
+class ComposableTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def test_constructor(self):
         seqi = otio.core.Composable(
             name="test",
@@ -45,7 +45,7 @@ class ComposableTests(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(seqi)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(seqi, decoded)
+        self.assertIsOTIOEquivalentTo(seqi, decoded)
 
     def test_stringify(self):
         seqi = otio.core.Composable()
@@ -76,7 +76,7 @@ class ComposableTests(unittest.TestCase):
         seqi.metadata["foo"] = "bar"
         encoded = otio.adapters.otio_json.write_to_string(seqi)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(seqi, decoded)
+        self.assertIsOTIOEquivalentTo(seqi, decoded)
         self.assertEqual(decoded.metadata["foo"], seqi.metadata["foo"])
 
     def test_set_parent(self):

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -614,13 +614,38 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         sq = otio.schema.Track(children=[it])
         self.assertEqual(sq.range_of_child_at_index(0), tr)
 
-        # TODO: Do we really want to support this case?
-        # It makes the whole _parent pointer thing really problematic...
-        sq = otio.schema.Track(children=[it, it, it])
-        self.assertEqual(len(sq), 3)
+        # Instancing is not allowed
+        with self.assertRaises(ValueError):
+            otio.schema.Track(children=[it, it, it])
 
-        # del sq[1]
-        # self.assertEqual(len(sq), 2) -> you actually get 0
+        # inserting duplicates should raise and have no
+        # side effects
+        self.assertEqual(len(sq), 1)
+        with self.assertRaises(ValueError):
+            sq.append(it)
+        self.assertEqual(len(sq), 1)
+
+        self.assertEqual(len(sq), 1)
+        with self.assertRaises(ValueError):
+            sq[:] = [it, it]
+        self.assertEqual(len(sq), 1)
+
+        self.assertEqual(len(sq), 1)
+        with self.assertRaises(ValueError):
+            sq.insert(1, it)
+        self.assertEqual(len(sq), 1)
+
+        sq[0] = it
+        self.assertEqual(len(sq), 1)
+
+        sq[:] = [it]
+        self.assertEqual(len(sq), 1)
+
+        sq.append(copy.deepcopy(it))
+        self.assertEqual(len(sq), 2)
+        with self.assertRaises(ValueError):
+            sq[1:] = [it, copy.deepcopy(it)]
+        self.assertEqual(len(sq), 2)
 
     def test_range(self):
         length = otio.opentime.RationalTime(5, 1)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -33,7 +33,7 @@ SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 TRANSITION_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "transition_test.otio")
 
 
-class CompositionTests(unittest.TestCase):
+class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):
         it = otio.core.Item()
@@ -58,7 +58,7 @@ class CompositionTests(unittest.TestCase):
     def test_equality(self):
         co0 = otio.core.Composition()
         co00 = otio.core.Composition()
-        self.assertEqual(co0, co00)
+        self.assertIsOTIOEquivalentTo(co0, co00)
 
         a = otio.core.Item(name="A")
         b = otio.core.Item(name="B")
@@ -79,7 +79,7 @@ class CompositionTests(unittest.TestCase):
         self.assertNotEqual(co1, co2)
 
         self.assertTrue(co1 is not co3)
-        self.assertEqual(co1, co3)
+        self.assertIsOTIOEquivalentTo(co1, co3)
 
     def test_truthiness(self):
         # An empty Composition is False (since it behaves like a list)
@@ -187,7 +187,7 @@ class CompositionTests(unittest.TestCase):
         )
 
 
-class StackTest(unittest.TestCase):
+class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):
         st = otio.schema.Stack(name="test")
@@ -201,7 +201,7 @@ class StackTest(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(st)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(st, decoded)
+        self.assertIsOTIOEquivalentTo(st, decoded)
 
         self.assertIsNotNone(decoded[0]._parent)
 
@@ -574,14 +574,14 @@ class StackTest(unittest.TestCase):
         )
 
 
-class TrackTest(unittest.TestCase):
+class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_serialize(self):
         sq = otio.schema.Track(name="foo", children=[])
 
         encoded = otio.adapters.otio_json.write_to_string(sq)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(sq, decoded)
+        self.assertIsOTIOEquivalentTo(sq, decoded)
 
     def test_str(self):
         sq = otio.schema.Track(name="foo", children=[])
@@ -1109,7 +1109,7 @@ class TrackTest(unittest.TestCase):
                 duration=trans.in_offset
             )
         )
-        self.assertEqual(neighbors, (fill, fill))
+        self.assertJsonEqual(neighbors, (fill, fill))
 
     def test_neighbors_of_no_expand(self):
         seq = otio.schema.Track()
@@ -1145,7 +1145,7 @@ class TrackTest(unittest.TestCase):
             seq[0],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, (fill, seq[1]))
+        self.assertJsonEqual(neighbors, (fill, seq[1]))
 
         # neighbor around second transition
         neighbors = seq.neighbors_of(
@@ -1178,7 +1178,7 @@ class TrackTest(unittest.TestCase):
             seq[5],
             otio.schema.NeighborGapPolicy.around_transitions
         )
-        self.assertEqual(neighbors, (seq[4], fill))
+        self.assertJsonEqual(neighbors, (seq[4], fill))
 
 
 class EdgeCases(unittest.TestCase):
@@ -1342,7 +1342,7 @@ class NestingTest(unittest.TestCase):
             self.assertIsNotNone(item.parent())
 
             parent = item.parent()
-            index = parent.index_of_child(item)
+            index = parent.index(item)
             wrapper = otio.schema.Stack()
 
             self.assertIs(parent[index], item)

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -27,7 +27,7 @@ import unittest
 import opentimelineio as otio
 
 
-class EffectTest(unittest.TestCase):
+class EffectTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):
         ef = otio.schema.Effect(
@@ -37,7 +37,7 @@ class EffectTest(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(ef)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(ef, decoded)
+        self.assertIsOTIOEquivalentTo(ef, decoded)
         self.assertEqual(decoded.name, "blur it")
         self.assertEqual(decoded.effect_name, "blur")
         self.assertEqual(decoded.metadata['foo'], 'bar')
@@ -53,7 +53,7 @@ class EffectTest(unittest.TestCase):
             effect_name="blur",
             metadata={"foo": "bar"}
         )
-        self.assertEqual(ef, ef2)
+        self.assertIsOTIOEquivalentTo(ef, ef2)
 
     def test_str(self):
         ef = otio.schema.Effect(

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -38,7 +38,7 @@ FCP7_XML_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")
 SIMPLE_XML_PATH = os.path.join(SAMPLE_DATA_DIR, "sample_just_track.xml")
 
 
-class AdaptersFcp7XmlTest(unittest.TestCase):
+class AdaptersFcp7XmlTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def __init__(self, *args, **kwargs):
         super(AdaptersFcp7XmlTest, self).__init__(*args, **kwargs)
@@ -348,18 +348,7 @@ class AdaptersFcp7XmlTest(unittest.TestCase):
             adapter_name='fcp_xml'
         )
 
-        self.assertMultiLineEqual(
-            otio.adapters.write_to_string(
-                new_timeline,
-                adapter_name="otio_json"
-            ),
-            otio.adapters.write_to_string(
-                timeline,
-                adapter_name="otio_json"
-            )
-        )
-
-        self.assertEqual(new_timeline, timeline)
+        self.assertJsonEqual(new_timeline, timeline)
 
     def test_roundtrip_disk2mem2disk(self):
         timeline = otio.adapters.read_from_file(FCP7_XML_EXAMPLE_PATH)
@@ -372,7 +361,7 @@ class AdaptersFcp7XmlTest(unittest.TestCase):
         output_json = otio.adapters.write_to_string(result, 'otio_json')
         self.assertMultiLineEqual(original_json, output_json)
 
-        self.assertEqual(timeline, result)
+        self.assertIsOTIOEquivalentTo(timeline, result)
 
         # But the xml text on disk is not identical because otio has a subset
         # of features to xml and we drop all the nle specific preferences.

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -27,29 +27,11 @@
 
 import unittest
 import copy
-import re
 
 import opentimelineio as otio
 
 
-class OTIOAssertions(object):
-    def assertJsonEqual(self, known, test_result):
-        """Convert to json and compare that (more readable)."""
-        self.maxDiff = None
-
-        known_str = otio.adapters.write_to_string(known, 'otio_json')
-        test_str = otio.adapters.write_to_string(test_result, 'otio_json')
-
-        def strip_trailing_decimal_zero(s):
-            return re.sub(r'"(value|rate)": (\d+)\.0', r'"\1": \2', s)
-
-        self.assertMultiLineEqual(
-            strip_trailing_decimal_zero(known_str),
-            strip_trailing_decimal_zero(test_str)
-        )
-
-
-class FilterTest(unittest.TestCase, OTIOAssertions):
+class FilterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
     maxDiff = None
 
     def test_copy_track(self):
@@ -127,7 +109,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
         # emptying the track should have the same effect
         del tr[:]
-        self.assertEqual(tr, result)
+        self.assertIsOTIOEquivalentTo(tr, result)
 
     def test_prune_by_type_args(self):
         """Test pruning using the types_to_prune list"""
@@ -146,7 +128,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
 
         # emptying the track should have the same effect
         del tr[:]
-        self.assertEqual(tr, result)
+        self.assertIsOTIOEquivalentTo(tr, result)
 
     def test_copy(self):
         md = {'test': 'bar'}
@@ -182,7 +164,7 @@ class FilterTest(unittest.TestCase, OTIOAssertions):
         self.assertJsonEqual(tr, result)
 
 
-class ReduceTest(unittest.TestCase, OTIOAssertions):
+class ReduceTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
     maxDiff = None
 
     def test_copy_track(self):
@@ -232,7 +214,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         # emptying the track should have the same effect
         del tr[:]
-        self.assertEqual(tr, result)
+        self.assertIsOTIOEquivalentTo(tr, result)
 
     def test_prune_clips_using_types_to_prune(self):
         """Test pruning otio.schema.clip using the types_to_prune argument"""
@@ -253,7 +235,7 @@ class ReduceTest(unittest.TestCase, OTIOAssertions):
 
         # emptying the track should have the same effect
         del tr[:]
-        self.assertEqual(tr, result)
+        self.assertIsOTIOEquivalentTo(tr, result)
 
     def test_insert_tuple(self):
         """test a reduce that takes each clip in a sequence and triples it"""

--- a/tests/test_generator_reference.py
+++ b/tests/test_generator_reference.py
@@ -9,7 +9,7 @@ SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 GEN_REF_TEST = os.path.join(SAMPLE_DATA_DIR, "generator_reference_test.otio")
 
 
-class GeneratorReferenceTests(unittest.TestCase):
+class GeneratorRefTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def setUp(self):
         self.gen = otio.schema.GeneratorReference(
             name="SMPTEBars",
@@ -42,7 +42,7 @@ class GeneratorReferenceTests(unittest.TestCase):
     def test_serialize(self):
         encoded = otio.adapters.otio_json.write_to_string(self.gen)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(self.gen, decoded)
+        self.assertIsOTIOEquivalentTo(self.gen, decoded)
 
     def test_read_file(self):
         self.assertTrue(os.path.exists(GEN_REF_TEST))

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -33,7 +33,7 @@ import opentimelineio as otio
 otio.core.register_type(otio.core.Item)
 
 
-class GapTester(unittest.TestCase):
+class GapTester(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_str_gap(self):
         gp = otio.schema.Gap()
@@ -66,7 +66,7 @@ class GapTester(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(gp)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(gp, decoded)
+        self.assertJsonEqual(gp, decoded)
 
     def test_convert_from_filler(self):
         gp = otio.schema.Gap()
@@ -76,7 +76,7 @@ class GapTester(unittest.TestCase):
         isinstance(decoded, otio.schema.Gap)
 
 
-class ItemTests(unittest.TestCase):
+class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_constructor(self):
         tr = otio.opentime.TimeRange(
@@ -89,7 +89,7 @@ class ItemTests(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(it, decoded)
+        self.assertIsOTIOEquivalentTo(it, decoded)
 
     def test_is_parent_of(self):
         it = otio.core.Item()
@@ -154,7 +154,7 @@ class ItemTests(unittest.TestCase):
         it = otio.core.Item(source_range=tr)
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(it, decoded)
+        self.assertIsOTIOEquivalentTo(it, decoded)
 
     def test_stringify(self):
         tr = otio.opentime.TimeRange(
@@ -202,7 +202,7 @@ class ItemTests(unittest.TestCase):
         it.metadata["foo"] = "bar"
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(it, decoded)
+        self.assertIsOTIOEquivalentTo(it, decoded)
         self.assertEqual(decoded.metadata["foo"], it.metadata["foo"])
 
     def test_add_effect(self):
@@ -220,8 +220,8 @@ class ItemTests(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(it, decoded)
-        self.assertEqual(it.effects, decoded.effects)
+        self.assertIsOTIOEquivalentTo(it, decoded)
+        self.assertJsonEqual(it.effects, decoded.effects)
 
     def test_add_marker(self):
         tr = otio.opentime.TimeRange(
@@ -239,8 +239,8 @@ class ItemTests(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(it, decoded)
-        self.assertEqual(it.markers, decoded.markers)
+        self.assertIsOTIOEquivalentTo(it, decoded)
+        self.assertJsonEqual(it.markers, decoded.markers)
 
     def test_copy(self):
         tr = otio.opentime.TimeRange(
@@ -266,7 +266,7 @@ class ItemTests(unittest.TestCase):
         )
 
         it_copy = it.copy()
-        self.assertEqual(it, it_copy)
+        self.assertIsOTIOEquivalentTo(it, it_copy)
         it.metadata["foo"] = "bar2"
         # shallow copy, should change both dictionaries
         self.assertEqual(it_copy.metadata["foo"], "bar2")
@@ -306,7 +306,7 @@ class ItemTests(unittest.TestCase):
         # shallow test
         import copy
         it_copy = copy.copy(it)
-        self.assertEqual(it, it_copy)
+        self.assertIsOTIOEquivalentTo(it, it_copy)
         it.metadata["foo"] = "bar2"
         # shallow copy, should change both dictionaries
         self.assertEqual(it_copy.metadata["foo"], "bar2")

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -33,7 +33,7 @@ import opentimelineio as otio
 import baseline_reader
 
 
-class TestJsonFormat(unittest.TestCase):
+class TestJsonFormat(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def setUp(self):
         self.maxDiff = None
@@ -51,7 +51,7 @@ class TestJsonFormat(unittest.TestCase):
         )
         if isinstance(baseline_data, dict):
             raise TypeError("did not deserialize correctly")
-        self.assertEqual(obj, baseline_data)
+        self.assertJsonEqual(obj, baseline_data)
 
     def test_rationaltime(self):
         rt = otio.opentime.RationalTime()

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -27,7 +27,7 @@ import unittest
 import opentimelineio as otio
 
 
-class MarkerTest(unittest.TestCase):
+class MarkerTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):
         tr = otio.opentime.TimeRange(
@@ -47,7 +47,7 @@ class MarkerTest(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(m)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(m, decoded)
+        self.assertIsOTIOEquivalentTo(m, decoded)
 
     def test_upgrade(self):
         src = """

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -44,7 +44,6 @@ class MarkerTest(unittest.TestCase):
         self.assertEqual(m.metadata['foo'], 'bar')
         self.assertEqual(m.marked_range, tr)
         self.assertEqual(m.color, otio.schema.MarkerColor.GREEN)
-        self.assertNotEqual(hash(m), hash(otio.schema.Marker()))
 
         encoded = otio.adapters.otio_json.write_to_string(m)
         decoded = otio.adapters.otio_json.read_from_string(encoded)

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -29,7 +29,7 @@ import opentimelineio as otio
 import unittest
 
 
-class MediaReferenceTests(unittest.TestCase):
+class MediaReferenceTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):
         tr = otio.opentime.TimeRange(
@@ -61,7 +61,7 @@ class MediaReferenceTests(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(missing)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(missing, decoded)
+        self.assertIsOTIOEquivalentTo(missing, decoded)
 
     def test_filepath(self):
         filepath = otio.schema.ExternalReference("/var/tmp/foo.mov")
@@ -79,14 +79,14 @@ class MediaReferenceTests(unittest.TestCase):
         # round trip serialize
         encoded = otio.adapters.otio_json.write_to_string(filepath)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(filepath, decoded)
+        self.assertIsOTIOEquivalentTo(filepath, decoded)
 
     def test_equality(self):
         filepath = otio.schema.ExternalReference(target_url="/var/tmp/foo.mov")
         filepath2 = otio.schema.ExternalReference(
             target_url="/var/tmp/foo.mov"
         )
-        self.assertEqual(filepath, filepath2)
+        self.assertIsOTIOEquivalentTo(filepath, filepath2)
 
         bl = otio.schema.MissingReference()
         self.assertNotEqual(filepath, bl)

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -27,7 +27,7 @@ import unittest
 import opentimelineio as otio
 
 
-class SerializableCollectionTests(unittest.TestCase):
+class SerializableColTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def setUp(self):
         self.children = [
             otio.schema.Clip(name="testClip"),
@@ -53,7 +53,7 @@ class SerializableCollectionTests(unittest.TestCase):
     def test_serialize(self):
         encoded = otio.adapters.otio_json.write_to_string(self.sc)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(self.sc, decoded)
+        self.assertIsOTIOEquivalentTo(self.sc, decoded)
 
     def test_str(self):
         self.assertMultiLineEqual(

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # Copyright 2017 Pixar Animation Studios
 #
@@ -47,8 +48,7 @@ class OpenTimeTypeSerializerTest(unittest.TestCase):
         self.assertEqual(tt, decoded)
 
 
-class SerializableObjectTest(unittest.TestCase):
-
+class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def test_cons(self):
         so = otio.core.SerializableObject()
         so.data['foo'] = 'bar'
@@ -56,10 +56,9 @@ class SerializableObjectTest(unittest.TestCase):
 
     def test_hash(self):
         so = otio.core.SerializableObject()
-        so.data['foo'] = 'bar'
         so_2 = otio.core.SerializableObject()
-        so_2.data['foo'] = 'bar'
-        self.assertEqual(hash(so), hash(so_2))
+        self.assertNotEqual(hash(so), hash(so_2))
+        self.assertEqual(hash(so), hash(so))
 
     def test_update(self):
         so = otio.core.SerializableObject()
@@ -85,7 +84,7 @@ class SerializableObjectTest(unittest.TestCase):
         # shallow copy
         so_cp = copy.copy(so)
         so_cp.data["metadata"]["foo"] = "not bar"
-        self.assertEqual(so, so_cp)
+        self.assertEqual(so.data, so_cp.data)
 
         so.foo = "bar"
         so_cp = copy.copy(so)
@@ -95,7 +94,7 @@ class SerializableObjectTest(unittest.TestCase):
 
         # deep copy
         so_cp = copy.deepcopy(so)
-        self.assertEqual(so, so_cp)
+        self.assertIsOTIOEquivalentTo(so, so_cp)
 
         so_cp.data["foo"] = "bar"
         self.assertNotEqual(so, so_cp)
@@ -160,8 +159,8 @@ class SerializableObjectTest(unittest.TestCase):
         o1 = otio.core.SerializableObject()
         o2 = otio.core.SerializableObject()
         self.assertTrue(o1 is not o2)
-        self.assertTrue(o1 == o2)
-        self.assertEqual(o1, o2)
+        self.assertTrue(o1.is_equivalent_to(o2))
+        self.assertIsOTIOEquivalentTo(o1, o2)
 
     def test_truthiness(self):
         o = otio.core.SerializableObject()

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -54,12 +54,6 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         so.data['foo'] = 'bar'
         self.assertEqual(so.data['foo'], 'bar')
 
-    def test_hash(self):
-        so = otio.core.SerializableObject()
-        so_2 = otio.core.SerializableObject()
-        self.assertNotEqual(hash(so), hash(so_2))
-        self.assertEqual(hash(so), hash(so))
-
     def test_update(self):
         so = otio.core.SerializableObject()
         so.update({"foo": "bar"})

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -34,7 +34,7 @@ MULTITRACK_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "multitrack.otio")
 PREFLATTENED_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "preflattened.otio")
 
 
-class StackAlgoTests(unittest.TestCase):
+class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     """ test harness for stack algo functions """
 
     def setUp(self):
@@ -310,7 +310,7 @@ class StackAlgoTests(unittest.TestCase):
         ])
         flat_track = otio.algorithms.flatten_stack(stack)
         # the result should be equivalent
-        self.assertListEqual(
+        self.assertJsonEqual(
             flat_track[:],
             self.trackABC[:]
         )
@@ -334,7 +334,7 @@ class StackAlgoTests(unittest.TestCase):
             self.trackZ
         ])
         flat_track = otio.algorithms.flatten_stack(stack)
-        self.assertEqual(
+        self.assertJsonEqual(
             flat_track[:],
             self.trackZ[:]
         )
@@ -344,7 +344,7 @@ class StackAlgoTests(unittest.TestCase):
             self.trackABC
         ])
         flat_track = otio.algorithms.flatten_stack(stack)
-        self.assertEqual(
+        self.assertJsonEqual(
             flat_track[:],
             self.trackABC[:]
         )
@@ -355,9 +355,9 @@ class StackAlgoTests(unittest.TestCase):
             self.trackDgE
         ])
         flat_track = otio.algorithms.flatten_stack(stack)
-        self.assertEqual(flat_track[0], self.trackDgE[0])
-        self.assertEqual(flat_track[1], self.trackABC[1])
-        self.assertEqual(flat_track[2], self.trackDgE[2])
+        self.assertIsOTIOEquivalentTo(flat_track[0], self.trackDgE[0])
+        self.assertIsOTIOEquivalentTo(flat_track[1], self.trackABC[1])
+        self.assertIsOTIOEquivalentTo(flat_track[2], self.trackDgE[2])
         self.assertIsNot(flat_track[0], self.trackDgE[0])
         self.assertIsNot(flat_track[1], self.trackABC[1])
         self.assertIsNot(flat_track[2], self.trackDgE[2])
@@ -367,9 +367,9 @@ class StackAlgoTests(unittest.TestCase):
             self.trackgFg
         ])
         flat_track = otio.algorithms.flatten_stack(stack)
-        self.assertEqual(flat_track[0], self.trackABC[0])
-        self.assertEqual(flat_track[1], self.trackgFg[1])
-        self.assertEqual(flat_track[2], self.trackABC[2])
+        self.assertIsOTIOEquivalentTo(flat_track[0], self.trackABC[0])
+        self.assertIsOTIOEquivalentTo(flat_track[1], self.trackgFg[1])
+        self.assertIsOTIOEquivalentTo(flat_track[2], self.trackABC[2])
         self.assertIsNot(flat_track[0], self.trackABC[0])
         self.assertIsNot(flat_track[1], self.trackgFg[1])
         self.assertIsNot(flat_track[2], self.trackABC[2])
@@ -380,7 +380,7 @@ class StackAlgoTests(unittest.TestCase):
             self.trackDgE
         ])
         flat_track = otio.algorithms.flatten_stack(stack)
-        self.assertEqual(flat_track[0], self.trackDgE[0])
+        self.assertIsOTIOEquivalentTo(flat_track[0], self.trackDgE[0])
         self.assertEqual(flat_track[1].name, "Z")
         self.assertEqual(
             flat_track[1].source_range,
@@ -389,7 +389,7 @@ class StackAlgoTests(unittest.TestCase):
                 otio.opentime.RationalTime(50, 24)
             )
         )
-        self.assertEqual(flat_track[2], self.trackDgE[2])
+        self.assertIsOTIOEquivalentTo(flat_track[2], self.trackDgE[2])
 
         stack = otio.schema.Stack(children=[
             self.trackZ,
@@ -404,7 +404,7 @@ class StackAlgoTests(unittest.TestCase):
                 otio.opentime.RationalTime(50, 24)
             )
         )
-        self.assertEqual(flat_track[1], self.trackgFg[1])
+        self.assertIsOTIOEquivalentTo(flat_track[1], self.trackgFg[1])
         self.assertEqual(flat_track[2].name, "Z")
         self.assertEqual(
             flat_track[2].source_range,
@@ -420,18 +420,18 @@ class StackAlgoTests(unittest.TestCase):
             self.trackDgE
         ]
         flat_track = otio.algorithms.flatten_stack(tracks)
-        self.assertEqual(flat_track[0], self.trackDgE[0])
-        self.assertEqual(flat_track[1], self.trackABC[1])
-        self.assertEqual(flat_track[2], self.trackDgE[2])
+        self.assertIsOTIOEquivalentTo(flat_track[0], self.trackDgE[0])
+        self.assertIsOTIOEquivalentTo(flat_track[1], self.trackABC[1])
+        self.assertIsOTIOEquivalentTo(flat_track[2], self.trackDgE[2])
 
         tracks = [
             self.trackABC,
             self.trackgFg
         ]
         flat_track = otio.algorithms.flatten_stack(tracks)
-        self.assertEqual(flat_track[0], self.trackABC[0])
-        self.assertEqual(flat_track[1], self.trackgFg[1])
-        self.assertEqual(flat_track[2], self.trackABC[2])
+        self.assertIsOTIOEquivalentTo(flat_track[0], self.trackABC[0])
+        self.assertIsOTIOEquivalentTo(flat_track[1], self.trackgFg[1])
+        self.assertIsOTIOEquivalentTo(flat_track[2], self.trackABC[2])
 
     def test_flatten_example_code(self):
         timeline = otio.adapters.read_from_file(MULTITRACK_EXAMPLE_PATH)

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -27,7 +27,7 @@ import unittest
 import opentimelineio as otio
 
 
-class TimelineTests(unittest.TestCase):
+class TimelineTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_init(self):
         rt = otio.opentime.RationalTime(12, 24)
@@ -43,7 +43,7 @@ class TimelineTests(unittest.TestCase):
 
         encoded = otio.adapters.otio_json.write_to_string(tl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(tl, decoded)
+        self.assertIsOTIOEquivalentTo(tl, decoded)
         self.assertEqual(tl.metadata, decoded.metadata)
 
     def test_range(self):
@@ -160,7 +160,7 @@ class TimelineTests(unittest.TestCase):
         tl = otio.schema.timeline_from_clips([clip])
         encoded = otio.adapters.otio_json.write_to_string(tl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(tl, decoded)
+        self.assertIsOTIOEquivalentTo(tl, decoded)
 
         string2 = otio.adapters.otio_json.write_to_string(decoded)
         self.assertEqual(encoded, string2)

--- a/tests/test_track_algo.py
+++ b/tests/test_track_algo.py
@@ -237,7 +237,7 @@ class TransitionExpansionTests(unittest.TestCase):
         )
 
 
-class TrackTrimmingTests(unittest.TestCase):
+class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     """ test harness for track trimming function """
 
     def make_sample_track(self):
@@ -337,7 +337,7 @@ class TrackTrimmingTests(unittest.TestCase):
             )
         )
         # it shouldn't have changed at all
-        self.assertEqual(original_track, trimmed)
+        self.assertIsOTIOEquivalentTo(original_track, trimmed)
 
     def test_trim_to_longer_range(self):
         original_track = self.make_sample_track()
@@ -350,7 +350,7 @@ class TrackTrimmingTests(unittest.TestCase):
             )
         )
         # it shouldn't have changed at all
-        self.assertEqual(original_track, trimmed)
+        self.assertJsonEqual(original_track, trimmed)
 
     def test_trim_front(self):
         original_track = self.make_sample_track()
@@ -381,7 +381,7 @@ class TrackTrimmingTests(unittest.TestCase):
             )
         )
         # clip C should have been left alone
-        self.assertEqual(trimmed[1], original_track[2])
+        self.assertIsOTIOEquivalentTo(trimmed[1], original_track[2])
 
     def test_trim_end(self):
         original_track = self.make_sample_track()
@@ -403,7 +403,7 @@ class TrackTrimmingTests(unittest.TestCase):
             )
         )
         # clip A should have been left alone
-        self.assertEqual(trimmed[0], original_track[0])
+        self.assertIsOTIOEquivalentTo(trimmed[0], original_track[0])
         # did clip B get trimmed?
         self.assertEqual(trimmed[1].name, "B")
         self.assertEqual(
@@ -531,4 +531,4 @@ class TrackTrimmingTests(unittest.TestCase):
         }
         """, "otio_json")
 
-        self.assertEqual(expected, trimmed)
+        self.assertJsonEqual(expected, trimmed)

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -29,7 +29,7 @@ import unittest
 import opentimelineio as otio
 
 
-class TransitionTests(unittest.TestCase):
+class TransitionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def test_constructor(self):
         trx = otio.schema.Transition(
             name="AtoB",
@@ -52,7 +52,7 @@ class TransitionTests(unittest.TestCase):
         )
         encoded = otio.adapters.otio_json.write_to_string(trx)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
-        self.assertEqual(trx, decoded)
+        self.assertIsOTIOEquivalentTo(trx, decoded)
 
     def test_stringify(self):
         trx = otio.schema.Transition("SMPTE.Dissolve")


### PR DESCRIPTION
Changes the equality of `SerializableObject` to use `id()` (`is` style equality) instead of the contents of the `.data` dictionary.  This clarifies that OTIO `SerializableObjects` are 'reference type' objects rather than 'value type' objects.
- removes implementation of `__hash__` and `__eq__` on `SerializableObject`
- adds cbb implementation of `is_equivalent_to` on `SerializableObject`
- adds explicit instance insertion prevention in `Composition`
- removes `index_of_child` and replaces with calls to `index`
- adds the `test_utils` module, which has assertions that use the `is_equivalent_to` method instead of equality, and a handy method that compares json output (which is much more readable)