### PR TITLE
otioview's --adapter_arg can now handle Python literals, 

### DIFF
--- a/bin/otioview.py
+++ b/bin/otioview.py
@@ -28,6 +28,7 @@
 import os
 import sys
 import argparse
+import ast
 from PySide import QtGui
 
 import opentimelineio as otio
@@ -181,8 +182,14 @@ def main():
     argument_map = {}
     for pair in args.adapter_arg:
         if '=' in pair:
-            key, val = pair.split('=')
-            argument_map[key] = val
+            key, val = pair.split('=', 1)  # only split on the 1st '='
+            try:
+                # Sometimes we need to pass a bool, int, list, etc.
+                parsed_value = ast.literal_eval(val)
+            except:
+                # Fall back to a simple string
+                parsed_value = val
+            argument_map[key] = parsed_value
         else:
             print(
                 "error: adapter arguments must be in the form key=value"

--- a/bin/otioview.py
+++ b/bin/otioview.py
@@ -186,7 +186,7 @@ def main():
             try:
                 # Sometimes we need to pass a bool, int, list, etc.
                 parsed_value = ast.literal_eval(val)
-            except:
+            except (ValueError, SyntaxError):
                 # Fall back to a simple string
                 parsed_value = val
             argument_map[key] = parsed_value

--- a/bin/otioview.py
+++ b/bin/otioview.py
@@ -52,8 +52,9 @@ def _parsed_args():
         type=str,
         default=[],
         action='append',
-        help='Extra arguments to be passed to adapter in the form of a=b.  Can'
-        ' be used multiple times eg: -a burrito="bar" -a taco=12.'
+        help='Extra arguments to be passed to adapter in the form of '
+        'key=value. Values are strings, numbers or Python literals: True, '
+        'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
     )
 
     return parser.parse_args()


### PR DESCRIPTION
You can pass True, False, etc. as real values, instead of everything coming in as a string.