### PR TITLE
Add console entry points for application

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,13 @@ setup(
     install_requires=[
         # PyAAF2 to go here eventually
     ],
-
+    entry_points={
+        'console_scripts': [
+            'otioview = bin.otioview:main',
+            'otiocat = bin.otiocat:main',
+            'otioconvert = bin.otioconvert:main',
+        ],
+    },
     test_suite='setup.test_otio',
 
 )


### PR DESCRIPTION
```
(venv) ~/dev/OpenTimelineIO  (pyside2-updates)
└─ ▶ otioconvert
usage: otioconvert [-h] -i INPUT -o OUTPUT [-I INPUT_ADAPTER]
                   [-O OUTPUT_ADAPTER] [-T TRACKS] [-m MEDIA_LINKER]
otioconvert: error: the following arguments are required: -i/--input, -o/--output
```
```
(venv) ~/dev/OpenTimelineIO  (pyside2-updates)
└─ ▶ otiocat
usage: otiocat [-h] filepath [filepath ...]
otiocat: error: the following arguments are required: filepath
```
```
(venv) ~/dev/OpenTimelineIO  (pyside2-updates)
└─ ▶ otioview tests/sample_data/clip_example.otio
```