### PR TITLE
Add development requirements to package and instructions to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,24 @@
 .PHONY: coverage test test_first_fail clean autopep8 lint doc-html \
 	python-version
 
+# Special definition to handle Make from stripping newlines
+define newline
+
+
+endef
+
+# Color highlighting for the shell
+ccred = $(shell echo "\033[0;31m")
+ccgreen = $(shell echo "\033[0;32m")
+ccblue = $(shell echo "\033[0;34m")
+ccend = $(shell echo "\033[0m")
+
+# Helpful link to install development dependencies declared in setup.py
+define dev_deps_message
+$(ccred)You can install this and other development dependencies with$(newline)$(ccend)\
+$(ccblue)	pip install -e .[dev]$(newline)$(ccend)
+endef
+
 COV_PROG := $(shell command -v coverage 2> /dev/null)
 PEP8_PROG := $(shell command -v pep8 2> /dev/null)
 PYFLAKES_PROG := $(shell command -v pyflakes 2> /dev/null)
@@ -19,11 +37,11 @@ OTIO_DEFAULT_MEDIA_LINKER =
 test: test-core test-contrib
 
 test-core: python-version
-	@echo "Running Core tests..."
+	@echo "$(ccgreen)Running Core tests...$(ccend)"
 	@python -m unittest discover tests $(TEST_ARGS)
 
 test-contrib: python-version
-	@echo "Running Contrib tests..."
+	@echo "$(ccgreen)Running Contrib tests...$(ccend)"
 	@make -C opentimelineio_contrib/adapters test VERBOSE=$(VERBOSE)
 
 python-version:
@@ -33,8 +51,9 @@ coverage: coverage-core coverage-contrib
 
 coverage-core: python-version
 ifndef COV_PROG
-	$(error "coverage is not available please see: "\
-		"https://coverage.readthedocs.io/en/coverage-4.2/install.html")
+	$(error $(newline)$(ccred) Coverage is not available please see:$(newline)$(ccend)\
+	$(ccblue)	https://coverage.readthedocs.io/en/coverage-4.2/install.html $(newline)$(ccend)\
+	$(dev_deps_message))
 endif
 	@${COV_PROG} run --source=opentimelineio -m unittest discover tests
 	@${COV_PROG} report -m
@@ -61,18 +80,22 @@ clean:
 # run the codebase through flake8.  pep8 and pyflakes are called by flake8.
 lint:
 ifndef PEP8_PROG
-	$(error "pep8 is not available on $$PATH please see: "\
-		"https://pypi.python.org/pypi/pep8#installation")
+	$(error $(newline)$(ccred)pep8 is not available on $$PATH please see:$(newline)$(ccend)\
+	$(ccblue)	https://pypi.python.org/pypi/pep8#installation$(newline)$(ccend)\
+	$(dev_deps_message))
 endif
 ifndef PYFLAKES_PROG
-	$(error "pyflakes is not available on $$PATH please see: "\
-		"https://pypi.python.org/pypi/pyflakes#installation")
+	$(error $(newline)$(ccred)pyflakes is not available on $$PATH please see:$(newline)$(ccend)\
+	$(ccblue)	https://pypi.python.org/pypi/pyflakes#installation$(newline)$(ccend)\
+	$(dev_deps_message))
 endif
 ifndef FLAKE8_PROG
-	$(error "flake8 is not available on $$PATH please see: "\
-		"http://flake8.pycqa.org/en/latest/index.html#installation")
+	$(error $(newline)$(ccred)flake8 is not available on $$PATH please see:$(newline)$(ccend)\
+	$(ccblue)	http://flake8.pycqa.org/en/latest/index.html#installation$(newline)$(ccend)\
+	$(dev_deps_message))
 endif
 	@python -m flake8 --exclude build
+
 
 # generate documentation in html
 doc-html:

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ with the pep8 style.  We ask that before you submit a pull request, you:
 
 PEP8: https://www.python.org/dev/peps/pep-0008/
 
+You can install development dependencies with `pip install -e .[dev]`
+
 Contact
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -138,7 +138,12 @@ setup(
     install_requires=[
         # PyAAF2 to go here eventually
     ],
-
+    extras_require={
+        'dev': [
+            'flake8==3.5',
+            'coverage==4.5',
+        ]
+    },
     test_suite='setup.test_otio',
 
 )


### PR DESCRIPTION
This does _not_ add PySide2 or PySide1, but it does add the dependencies for flake8 and coverage, as well as documentation for how to install the dependencies to the README.

PySide2 Snapshot wheels are available through the following: 

`pip install --index-url=http://download.qt.io/snapshots/ci/pyside/5.9/latest/ pyside2 --trusted-host download.qt.io` 

and are hosted at http://download.qt.io/snapshots/ci/pyside/5.9/latest/pyside2/

Since you may be about to merge in #160 I chose not to add PySide2 for 2 reasons. 

1 ) To not get out of date immediately :)
2 ) The above are _snapshots_ and therefore not versioned. I think until PySide2 enters into versioned tagging, it should be up to the person managing the distribution of OTIO in their facility to handle which PySide2 version they have available. 

Something to ponder about once they do enter into a versioned tag schema is whether to actually add PySide2 as an installation dependency. I know that in my facility (Laika) we would have to fork and block this requirement in the setup.py as we build our own PySide/PyQt. 