### PR TITLE
Add zip_safe = false flag to address #270.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,6 @@ setup(
     test_suite='setup.test_otio',
 
     # because we need to open() the adapters manifest, we aren't zip-safe
-    zip_safe = False,
+    zip_safe=False,
 
 )

--- a/setup.py
+++ b/setup.py
@@ -141,4 +141,7 @@ setup(
 
     test_suite='setup.test_otio',
 
+    # because we need to open() the adapters manifest, we aren't zip-safe
+    zip_safe = False,
+
 )


### PR DESCRIPTION
Sets the `zip_safe = False` because we use open() to fetch files from OTIO - which means OTIO can't be used with compressed eggs.