### PR TITLE
192 code coverage badge

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,4 @@
 codecov:
-  branch: 192-code-coverage-badge
   notify:
     require_ci_to_pass: yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,6 @@ script:
     - make lint
     - make test
     - make coverage
+
+after_success:
+    - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,10 @@ install:
 script:
     - make lint
     - make test
+    # Build coverage which will get uploaded to codecov
     - make coverage
 
 after_success:
+    # Documentation for codecov uploader
+    # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
     - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Discussion Group: https://groups.google.com/forum/#!forum/open-timeline-io
 
 ![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.5-blue.svg)
 [![Build Status](https://travis-ci.org/PixarAnimationStudios/OpenTimelineIO.svg?branch=master)](https://travis-ci.org/PixarAnimationStudios/OpenTimelineIO)
-[![codecov](https://codecov.io/gh/alexwidener/OpenTimelineIO/branch/master/graph/badge.svg)](https://codecov.io/gh/alexwidener/OpenTimelineIO)
+[![codecov](https://codecov.io/gh/alexwidener/OpenTimelineIO/branch/192-code-coverage-badge/graph/badge.svg)](https://codecov.io/gh/alexwidener/OpenTimelineIO)
 
 PUBLIC BETA NOTICE
 ------------------

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Discussion Group: https://groups.google.com/forum/#!forum/open-timeline-io
 
 ![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.5-blue.svg)
 [![Build Status](https://travis-ci.org/PixarAnimationStudios/OpenTimelineIO.svg?branch=master)](https://travis-ci.org/PixarAnimationStudios/OpenTimelineIO)
+[![codecov](https://codecov.io/gh/alexwidener/OpenTimelineIO/branch/master/graph/badge.svg)](https://codecov.io/gh/alexwidener/OpenTimelineIO)
 
 PUBLIC BETA NOTICE
 ------------------

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Discussion Group: https://groups.google.com/forum/#!forum/open-timeline-io
 
 ![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.5-blue.svg)
 [![Build Status](https://travis-ci.org/PixarAnimationStudios/OpenTimelineIO.svg?branch=master)](https://travis-ci.org/PixarAnimationStudios/OpenTimelineIO)
-[![codecov](https://codecov.io/gh/alexwidener/OpenTimelineIO/branch/192-code-coverage-badge/graph/badge.svg)](https://codecov.io/gh/alexwidener/OpenTimelineIO)
+[![codecov](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO/branch/master/graph/badge.svg)](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO)
 
 PUBLIC BETA NOTICE
 ------------------

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  branch: 192-code-coverage-badge
   notify:
     require_ci_to_pass: yes
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+comment:
+  layout: "reach, diff, flags, files, footer"
+  behavior: default
+require_changes: no


### PR DESCRIPTION
Closes #192 

Process:

1 ) Connect the PixarAnimationStudios Github account to codecov.io (ignore the token stuff on the Overview page after you sign in, it's not necessary since OTIO is OSS)
2 ) Select the OpenTimelineIO repository - you can see the reports after I connected it [here](https://codecov.io/gh/alexwidener/OpenTimelineIO/commits)
3 ) Run a build for Travis, which causes a coverage report to get kicked off which updates the badge (for the master branch).
4) [There's a Github integration for Codecov if you want to check it out](https://github.com/integration/codecov)

Final result:

![screen shot 2018-06-19 at 8 10 56 pm](https://user-images.githubusercontent.com/3489076/41635431-8f355d0a-73fd-11e8-939c-a2747bb74c2e.png)

Additionally, check out the cool graphs: https://docs.codecov.io/docs/graphs#section-sunburst

Sorry for a bunch of dumb commits, I was just testing stuff - you can squash the commits into one commit whenever you merge it. 