### PR TITLE
Stamp metadata into top level __init__ files on build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@
 
 import os
 from setuptools import setup
+import setuptools.command.build_py
 import sys
 import unittest
 
@@ -43,6 +44,55 @@ if (
             sys.version_info[1]
         )
     )
+
+# Metadata that gets stamped into the __init__ files during the build phase.
+PROJECT_METADATA = {
+    "version": "0.8.0.dev1",
+    "author": 'Pixar Animation Studios',
+    "author_email": 'opentimelineio@pixar.com',
+    "license": 'Modified Apache 2.0 License',
+}
+
+METADATA_TEMPLATE = """
+__version__ = "{version}"
+__author__ = "{author}"
+__author_email__ = "{author_email}"
+__license__ = "{license}"
+"""
+
+
+def _append_version_info_to_init_scripts(build_lib):
+    """Stamp PROJECT_METADATA into __init__ files."""
+
+    for module in [
+            "opentimelineio",
+            "opentimelineio_contrib",
+            "opentimelineview",
+    ]:
+        target_file = os.path.join(build_lib, module, "__init__.py")
+        source_file = os.path.join(
+            os.path.dirname(__file__),
+            module, "__init__.py"
+        )
+
+        # get the base data from the original file
+        with open(source_file, 'r') as fi:
+            src_data = fi.read()
+
+        # write that + the suffix to the target file
+        with open(target_file, 'w') as fo:
+            fo.write(src_data)
+            fo.write(METADATA_TEMPLATE.format(**PROJECT_METADATA))
+
+
+class AddMetadataToInits(setuptools.command.build_py.build_py):
+    """Stamps PROJECT_METADATA into __init__ files."""
+
+    def run(self):
+        if not self.dry_run:
+            _append_version_info_to_init_scripts(self.build_lib)
+
+        setuptools.command.build_py.build_py.run(self)
 
 
 def test_otio():
@@ -72,11 +122,8 @@ OpenTimelineIO format."""
 
 setup(
     name='OpenTimelineIO',
-    version='0.8.0.dev1',
     description='Editorial interchange format and API',
     long_description=LONG_DESCRIPTION,
-    author='Pixar Animation Studios',
-    author_email='opentimelineio@pixar.com',
     url='http://opentimeline.io',
     project_urls={
         'Source':
@@ -86,7 +133,6 @@ setup(
         'Issues':
             'https://github.com/PixarAnimationStudios/OpenTimelineIO/issues',
     },
-    license='Modified Apache 2.0 License',
 
     classifiers=[
         'Development Status :: 4 - Beta',
@@ -156,4 +202,9 @@ setup(
     # because we need to open() the adapters manifest, we aren't zip-safe
     zip_safe=False,
 
+    # Use the code that wires the PROJECT_METADATA into the __init__ files.
+    cmdclass={'build_py': AddMetadataToInits},
+
+    # expand the project metadata dictionary to fill in those values
+    **PROJECT_METADATA
 )


### PR DESCRIPTION
Addresses #242 

- Adds some code in the setup.py file that stamps the `__version__` and `__author__` metadata into the  top level __init__.py files.