### PR TITLE
Add PySide2 to setup.py under view key

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ PEP8: https://www.python.org/dev/peps/pep-0008/
 
 You can install development dependencies with `pip install -e .[dev]`
 
+You can also install the PySide2 dependency with `pip install -e .[view]`
+
 Contact
 -------
 

--- a/setup.py
+++ b/setup.py
@@ -195,6 +195,9 @@ setup(
         'dev': [
             'flake8==3.5',
             'coverage==4.5',
+        ],
+        'view': [
+            'PySide2==5.11'
         ]
     },
 


### PR DESCRIPTION
PySide2 is on PyPi as of a week ago.

This adds the PySide2 dependency underneath the 'view' key in extra_requires, as discussed in https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/269#issuecomment-398248375

Updated the README with instructions as well.