### PR TITLE
new SchemaDef plugin type to define site-specific schemas

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.md CHANGELOG.md LICENSE.txt NOTICE.txt
 recursive-include examples *
+recursive-include opentimelineio *
 
 recursive-exclude docs *
 prune docs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ Tutorials
    tutorials/wrapping-otio
    tutorials/write-an-adapter
    tutorials/write-a-media-linker
+   tutorials/write-a-schemadef
 
 Use Cases
 ------------
@@ -71,4 +72,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docs/tutorials/write-a-schemadef.md
+++ b/docs/tutorials/write-a-schemadef.md
@@ -1,0 +1,118 @@
+# Writing an OTIO SchemaDef Plugin
+
+OpenTimelineIO SchemaDef plugins are plugins that define new schemas within the
+otio type registry system.
+You might want to do this to add new schemas that are specific to your own
+internal studio workflow and shouldn't be part of the generic OpenTimelineIO
+package.
+
+To write a new SchemaDef plugin, you create a Python source file that
+defines and registers one or more new classes subclassed from
+``otio.core.SerializeableObject``.  Multiple schema classes can be defined
+and registered in one plugin, or you can use a separate plugin for each of them.
+
+Here's an example of defining a very simple class called ``MyThing``:
+
+```
+import opentimelineio as otio
+
+@otio.core.register_type
+class MyThing(otio.core.SerializableObject):
+    """A schema for my thing."""
+
+    _serializable_label = "MyThing.1"
+    _name = "MyThing"
+
+    def __init__(
+        self,
+        arg1=None,
+        argN=None
+    ):
+        otio.core.SerializableObject.__init__(self)
+        self.arg1 = arg1
+        self.argN = argN
+
+    arg1 = otio.core.serializable_field(
+        "arg1",
+        doc = ( "arg1's doc string")
+    )
+
+    argN = otio.core.serializable_field(
+        "argN",
+        doc = ( "argN's doc string")
+    )
+
+    def __str__(self):
+        return "MyThing({}, {})".format(
+            repr(self.arg1),
+            repr(self.argN)
+        )
+
+    def __repr__(self):
+        return "otio.schema.MyThing(arg1={}, argN={})".format(
+            repr(self.arg1),
+            repr(self.argN)
+        )
+```
+
+In the example, the ``MyThing`` class has two parameters ``arg1`` and ``argN``,
+but your schema class could have any number of parameters as needed to
+contain the data fields you want to have in your class.
+
+One or more class definitions like this one can be included in a plugin
+source file, which must then be added to the plugin manifest as shown below:
+
+
+## Registering Your SchemaDef Plugin
+
+To create a new SchemaDef plugin, you need to create a Python source file
+as shown in the example above.  Let's call it ``mything.py``.
+Then you must add it to a plugin manifest:
+
+```
+{
+    "OTIO_SCHEMA" : "PluginManifest.1",
+    "schemadefs" : [
+        {
+            "OTIO_SCHEMA" : "MyThing.1",
+            "name" : "mything",
+            "execution_scope" : "in process",
+            "filepath" : "mything.py"
+         }
+    ]
+}
+```
+
+The same plugin manifest may also include adapters and media linkers, if desired.
+
+Then you need to add this manifest to your `$OTIO_PLUGIN_MANIFEST_PATH` environment variable (which is "`:`" separated).
+
+## Using the New Schema in Your Code
+
+Now that we've defined a new otio schema, how can we create an instance of the
+schema class in our code (for instance, in an adapter or media linker)?
+SchemaDef plugins are magically loaded into a namespace called ``otio.schemadef``,
+so you can create a class instance just like this:
+
+```
+import opentimelineio as otio
+
+mine = otio.schemadef.my_thing.MyThing(arg1, argN)
+```
+
+An alternative approach is to use the ``instance_from_schema``
+mechanism, which requires that you create and provide a dict of the parameters:
+
+```
+    mything = otio.core.instance_from_schema("MyThing", 1, {
+        "arg1": arg1,
+        "argN": argN
+    })
+```
+
+This ``instance_from_schema`` approach has the added benefit of calling the
+schema upgrade function to upgrade the parameters in the case where the requested
+schema version is earlier than the current version defined by the schemadef plugin.
+This seems rather unlikely to occur in practice if you keep your code up-to-date,
+so the first technique of creating the class instance directly from
+``otio.schemadef`` is usually preferred.

--- a/opentimelineio/__init__.py
+++ b/opentimelineio/__init__.py
@@ -37,6 +37,7 @@ from . import (
     exceptions,
     core,
     schema,
+    schemadef,
     plugins,
     adapters,
     algorithms,

--- a/opentimelineio/core/__init__.py
+++ b/opentimelineio/core/__init__.py
@@ -27,7 +27,7 @@
 # flake8: noqa
 
 from . import (
-    serializable_object,
+    serializable_object
 )
 from .serializable_object import (
     SerializableObject,
@@ -60,4 +60,8 @@ from .json_serializer import (
 )
 from .media_reference import (
     MediaReference,
+)
+from . import unknown_schema
+from .unknown_schema import (
+    UnknownSchema
 )

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -34,6 +34,8 @@ from . import (
     type_registry,
 )
 
+from .unknown_schema import UnknownSchema
+
 from .. import (
     exceptions,
     opentime,
@@ -94,6 +96,20 @@ def _encoded_serializable_object(input_otio):
     return result
 
 
+def _encoded_unknown_schema_object(input_otio):
+    orig_label = input_otio.data.get(UnknownSchema._original_label)
+    if not orig_label:
+        raise exceptions.InvalidSerializableLabelError(
+            orig_label
+        )
+    # result is just a dict, not a SerializableObject
+    result = {}
+    result.update(input_otio.data)
+    result["OTIO_SCHEMA"] = orig_label  # override the UnknownSchema label
+    del result[UnknownSchema._original_label]
+    return result
+
+
 def _encoded_time(input_otio):
     return {
         "OTIO_SCHEMA": "RationalTime.1",
@@ -125,6 +141,7 @@ _ENCODER_MAP = {
     opentime.RationalTime: _encoded_time,
     opentime.TimeRange: _encoded_time_range,
     opentime.TimeTransform: _encoded_transform,
+    UnknownSchema: _encoded_unknown_schema_object,
     SerializableObject: _encoded_serializable_object,
 }
 

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -140,6 +140,12 @@ class SerializableObject(object):
             cls._serializable_label
         )
 
+    @property
+    def is_unknown_schema(self):
+        # in general, SerializableObject will have a known schema
+        # but UnknownSchema subclass will redefine this property to be True
+        return False
+
     def __copy__(self):
         result = self.__class__()
         result.data = copy.copy(self.data)

--- a/opentimelineio/core/type_registry.py
+++ b/opentimelineio/core/type_registry.py
@@ -48,6 +48,12 @@ def schema_version_from_label(label):
     return int(label.split(".")[1])
 
 
+def schema_label_from_name_version(schema_name, schema_version):
+    """Return the serializeable object schema label given the name and version."""
+
+    return "{}.{}".format(schema_name, schema_version)
+
+
 def register_type(classobj, schemaname=None):
     """ Register a class to a Schema Label.
 
@@ -106,9 +112,14 @@ def instance_from_schema(schema_name, schema_version, data_dict):
     """Return an instance, of the schema from data in the data_dict."""
 
     if schema_name not in _OTIO_TYPES:
-        raise exceptions.NotSupportedError(
-            "OTIO_SCHEMA: '{}' not in type registry.".format(schema_name)
-        )
+        from .unknown_schema import UnknownSchema
+
+        # create an object of UnknownSchema type to represent the data
+        schema_label = schema_label_from_name_version(schema_name, schema_version)
+        data_dict[UnknownSchema._original_label] = schema_label
+        unknown_label = UnknownSchema._serializable_label
+        schema_name = schema_name_from_label(unknown_label)
+        schema_version = schema_version_from_label(unknown_label)
 
     cls = _OTIO_TYPES[schema_name]
 

--- a/opentimelineio/core/unknown_schema.py
+++ b/opentimelineio/core/unknown_schema.py
@@ -23,21 +23,21 @@
 #
 
 """
-Implementation of the MissingReference media reference schema.
+Implementation of the UnknownSchema schema.
 """
 
-from .. import (
-    core,
-)
+from .serializable_object import SerializableObject
+from .type_registry import register_type
 
 
-@core.register_type
-class MissingReference(core.MediaReference):
-    """Represents media for which a concrete reference is missing."""
+@register_type
+class UnknownSchema(SerializableObject):
+    """Represents an object whose schema is unknown to us."""
 
-    _serializable_label = "MissingReference.1"
-    _name = "MissingReference"
+    _serializable_label = "UnknownSchema.1"
+    _name = "UnknownSchema"
+    _original_label = "UnknownSchemaOriginalLabel"
 
     @property
-    def is_missing_reference(self):
+    def is_unknown_schema(self):
         return True

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -104,6 +104,16 @@ class Manifest(core.SerializableObject):
         "Media Linkers this manifest describes."
     )
 
+    def extend(self, another_manifest):
+        """
+        Extend the adapters, schemadefs, and media_linkers lists of this manifest
+        by appending the contents of the corresponding lists of another_manifest.
+        """
+        if another_manifest:
+            self.adapters.extend(another_manifest.adapters)
+            self.schemadefs.extend(another_manifest.schemadefs)
+            self.media_linkers.extend(another_manifest.media_linkers)
+
     def _update_plugin_source(self, path):
         """Track the source .json for a given adapter."""
 
@@ -177,9 +187,7 @@ def load_manifest():
                 "contrib_adapters.plugin_manifest.json"
             )
         )
-        result.adapters.extend(contrib_manifest.adapters)
-        result.schemadefs.extend(contrib_manifest.schemadefs)
-        result.media_linkers.extend(contrib_manifest.media_linkers)
+        result.extend(contrib_manifest)
     except ImportError:
         pass
 
@@ -219,9 +227,7 @@ def load_manifest():
                 )
                 continue
 
-            result.adapters.extend(plugin_manifest.adapters)
-            result.schemadefs.extend(plugin_manifest.schemadefs)
-            result.media_linkers.extend(plugin_manifest.media_linkers)
+            result.extend(plugin_manifest)
     else:
         # XXX: Should we print some kind of warning that pkg_resources isn't
         #        available?
@@ -240,9 +246,7 @@ def load_manifest():
                 continue
 
             LOCAL_MANIFEST = manifest_from_file(json_path)
-            result.adapters.extend(LOCAL_MANIFEST.adapters)
-            result.schemadefs.extend(LOCAL_MANIFEST.schemadefs)
-            result.media_linkers.extend(LOCAL_MANIFEST.media_linkers)
+            result.extend(LOCAL_MANIFEST)
 
     # force the schemadefs to load
     for s in result.schemadefs:

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -84,6 +84,7 @@ class Manifest(core.SerializableObject):
     def __init__(self):
         core.SerializableObject.__init__(self)
         self.adapters = []
+        self.schemadefs = []
         self.media_linkers = []
         self.source_files = []
 
@@ -91,6 +92,11 @@ class Manifest(core.SerializableObject):
         "adapters",
         type([]),
         "Adapters this manifest describes."
+    )
+    schemadefs = core.serializable_field(
+        "schemadefs",
+        type([]),
+        "Schemadefs this manifest describes."
     )
     media_linkers = core.serializable_field(
         "media_linkers",
@@ -101,7 +107,7 @@ class Manifest(core.SerializableObject):
     def _update_plugin_source(self, path):
         """Track the source .json for a given adapter."""
 
-        for thing in (self.adapters + self.media_linkers):
+        for thing in (self.adapters + self.schemadefs + self.media_linkers):
             thing._json_path = path
 
     def from_filepath(self, suffix):
@@ -140,6 +146,12 @@ class Manifest(core.SerializableObject):
         adp = self.from_name(name)
         return adp.module()
 
+    def schemadef_module_from_name(self, name):
+        """Return the schemadef module associated with a given schemadef name."""
+
+        adp = self.from_name(name, kind_list="schemadefs")
+        return adp.module()
+
 
 _MANIFEST = None
 
@@ -166,6 +178,7 @@ def load_manifest():
             )
         )
         result.adapters.extend(contrib_manifest.adapters)
+        result.schemadefs.extend(contrib_manifest.schemadefs)
         result.media_linkers.extend(contrib_manifest.media_linkers)
     except ImportError:
         pass
@@ -202,6 +215,7 @@ def load_manifest():
                 continue
 
             result.adapters.extend(plugin_manifest.adapters)
+            result.schemadefs.extend(plugin_manifest.schemadefs)
             result.media_linkers.extend(plugin_manifest.media_linkers)
     else:
         # XXX: Should we print some kind of warning that pkg_resources isn't
@@ -222,6 +236,7 @@ def load_manifest():
 
             LOCAL_MANIFEST = manifest_from_file(json_path)
             result.adapters.extend(LOCAL_MANIFEST.adapters)
+            result.schemadefs.extend(LOCAL_MANIFEST.schemadefs)
             result.media_linkers.extend(LOCAL_MANIFEST.media_linkers)
 
     return result

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -248,7 +248,7 @@ def load_manifest():
             LOCAL_MANIFEST = manifest_from_file(json_path)
             result.extend(LOCAL_MANIFEST)
 
-    # force the schemadefs to load
+    # force the schemadefs to load and add to schemadef module namespace
     for s in result.schemadefs:
         s.module()
     return result

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -207,6 +207,11 @@ def load_manifest():
                         manifest_stream.read().decode('utf-8')
                     )
                     manifest_stream.close()
+                    filepath = pkg_resources.resource_filename(
+                        plugin.module_name,
+                        'plugin_manifest.json'
+                    )
+                    plugin_manifest._update_plugin_source(filepath)
 
             except Exception:
                 logging.exception(
@@ -239,6 +244,9 @@ def load_manifest():
             result.schemadefs.extend(LOCAL_MANIFEST.schemadefs)
             result.media_linkers.extend(LOCAL_MANIFEST.media_linkers)
 
+    # force the schemadefs to load
+    for s in result.schemadefs:
+        s.module()
     return result
 
 

--- a/opentimelineio/plugins/python_plugin.py
+++ b/opentimelineio/plugins/python_plugin.py
@@ -90,8 +90,8 @@ class PythonPlugin(core.SerializableObject):
 
         return filepath
 
-    def _imported_module(self):
-        """Load the module this adapter points at."""
+    def _imported_module(self, namespace):
+        """Load the module this plugin points at."""
 
         pyname = os.path.splitext(os.path.basename(self.module_abs_path()))[0]
         pydir = os.path.dirname(self.module_abs_path())
@@ -101,7 +101,7 @@ class PythonPlugin(core.SerializableObject):
         with file_obj:
             # this will reload the module if it has already been loaded.
             mod = imp.load_module(
-                "opentimelineio.adapters.{}".format(self.name),
+                "opentimelineio.{}.{}".format(namespace, self.name),
                 file_obj,
                 pathname,
                 description
@@ -113,7 +113,7 @@ class PythonPlugin(core.SerializableObject):
         """Return the module object for this adapter. """
 
         if not self._module:
-            self._module = self._imported_module()
+            self._module = self._imported_module("adapters")
 
         return self._module
 

--- a/opentimelineio/schema/__init__.py
+++ b/opentimelineio/schema/__init__.py
@@ -34,7 +34,7 @@ from .external_reference import (
 )
 from .clip import (
     Clip,
-) 
+)
 from .track import (
     Track,
     TrackKind,
@@ -69,4 +69,7 @@ from .serializable_collection import (
 )
 from .generator_reference import (
     GeneratorReference
+)
+from .schema_def import (
+    SchemaDef
 )

--- a/opentimelineio/schema/__init__.py
+++ b/opentimelineio/schema/__init__.py
@@ -70,6 +70,6 @@ from .serializable_collection import (
 from .generator_reference import (
     GeneratorReference
 )
-from .schema_def import (
+from .schemadef import (
     SchemaDef
 )

--- a/opentimelineio/schema/schema_def.py
+++ b/opentimelineio/schema/schema_def.py
@@ -1,0 +1,38 @@
+
+from .. import (
+    core,
+    exceptions,
+    plugins
+)
+
+@core.register_type
+class SchemaDef(plugins.PythonPlugin):
+    _serializable_label = "SchemaDef.1"
+
+    def __init__(
+        self,
+        name=None,
+        execution_scope=None,
+        filepath=None,
+    ):
+        plugins.PythonPlugin.__init__(self, name, execution_scope, filepath)
+
+
+def available_schemadef_names():
+    """Return a string list of the available schemadefs."""
+
+    return [str(sd.name) for sd in plugins.ActiveManifest().schemadefs]
+
+
+def from_name(name):
+    """Fetch the schemadef object by the name of the schema directly."""
+
+    try:
+        return plugins.ActiveManifest().from_name(name, kind_list="schemadefs")
+    except exceptions.NotSupportedError:
+        raise exceptions.NotSupportedError(
+            "schemadef not supported: {}, available: {}".format(
+                name,
+                available_schemadef_names()
+            )
+        )

--- a/opentimelineio/schema/schema_def.py
+++ b/opentimelineio/schema/schema_def.py
@@ -5,6 +5,7 @@ from .. import (
     plugins
 )
 
+
 @core.register_type
 class SchemaDef(plugins.PythonPlugin):
     _serializable_label = "SchemaDef.1"

--- a/opentimelineio/schema/schemadef.py
+++ b/opentimelineio/schema/schemadef.py
@@ -2,7 +2,8 @@
 from .. import (
     core,
     exceptions,
-    plugins
+    plugins,
+    schemadef
 )
 
 
@@ -17,6 +18,19 @@ class SchemaDef(plugins.PythonPlugin):
         filepath=None,
     ):
         plugins.PythonPlugin.__init__(self, name, execution_scope, filepath)
+
+    def module(self):
+        """
+        Return the module object for this schemadef plugin.
+        (redefines PythonPlugin.module())
+        """
+
+        if not self._module:
+            self._module = self._imported_module("schemadef")
+            if self.name:
+                schemadef._add_schemadef_module(self.name, self._module)
+
+        return self._module
 
 
 def available_schemadef_names():

--- a/opentimelineio/schema/schemadef.py
+++ b/opentimelineio/schema/schemadef.py
@@ -22,6 +22,8 @@ class SchemaDef(plugins.PythonPlugin):
     def module(self):
         """
         Return the module object for this schemadef plugin.
+        If the module hasn't already been imported, it is imported and
+        injected into the otio.schemadefs namespace as a side-effect.
         (redefines PythonPlugin.module())
         """
 

--- a/opentimelineio/schemadef/__init__.py
+++ b/opentimelineio/schemadef/__init__.py
@@ -1,0 +1,5 @@
+
+def _add_schemadef_module(name, mod):
+    """Insert a new module name and module object into schemadef namespace."""
+    ns = globals()  # the namespace dict of the schemadef package
+    ns[name] = mod

--- a/tests/baselines/exampleSchemaDef.py
+++ b/tests/baselines/exampleSchemaDef.py
@@ -1,0 +1,62 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""This file is here to support the test_schemadef_plugin unittest.
+If you want to learn how to write your own SchemaDef plugin, please read:
+https://opentimelineio.readthedocs.io/en/latest/tutorials/write-a-schemadef.html
+"""
+
+import opentimelineio as otio
+
+
+@otio.core.register_type
+class exampleSchemaDef(otio.core.SerializableObject):
+    """Example of a SchemaDef plugin class for testing."""
+
+    _serializable_label = "exampleSchemaDef.1"
+    _name = "exampleSchemaDef"
+
+    def __init__(
+        self,
+        exampleArg=None,
+    ):
+        otio.core.SerializableObject.__init__(self)
+        self.exampleArg = exampleArg
+
+    exampleArg = otio.core.serializable_field(
+        "exampleArg",
+        doc=(
+            "example of an arg passed to the exampleSchemaDef"
+        )
+    )
+
+    def __str__(self):
+        return 'exampleSchemaDef({})'.format(
+            repr(self.exampleArg)
+        )
+
+    def __repr__(self):
+        return 'otio.schema.PixarMetadata(exampleArg={})'.format(
+            repr(self.exampleArg)
+        )

--- a/tests/baselines/example_schemadef.py
+++ b/tests/baselines/example_schemadef.py
@@ -57,6 +57,7 @@ class exampleSchemaDef(otio.core.SerializableObject):
         )
 
     def __repr__(self):
-        return 'otio.schemadef.example_schemadef.exampleSchemaDef(exampleArg={})'.format(
-            repr(self.exampleArg)
-        )
+        return \
+            'otio.schemadef.example_schemadef.exampleSchemaDef(exampleArg={})'.format(
+                repr(self.exampleArg)
+            )

--- a/tests/baselines/example_schemadef.py
+++ b/tests/baselines/example_schemadef.py
@@ -57,6 +57,6 @@ class exampleSchemaDef(otio.core.SerializableObject):
         )
 
     def __repr__(self):
-        return 'otio.schema.PixarMetadata(exampleArg={})'.format(
+        return 'otio.schemadef.example_schemadef.exampleSchemaDef(exampleArg={})'.format(
             repr(self.exampleArg)
         )

--- a/tests/baselines/schemadef_example.json
+++ b/tests/baselines/schemadef_example.json
@@ -3,9 +3,9 @@
     "schemadefs": [
         {
             "OTIO_SCHEMA" : "SchemaDef.1",
-            "name" : "exampleSchemaDef",
+            "name" : "example_schemadef",
             "execution_scope" : "in process",
-            "filepath" : "exampleSchemaDef.py"
+            "filepath" : "example_schemadef.py"
         }
     ]
 }

--- a/tests/baselines/schemadef_example.json
+++ b/tests/baselines/schemadef_example.json
@@ -1,0 +1,11 @@
+{
+    "OTIO_SCHEMA" : "PluginManifest.1",
+    "schemadefs": [
+        {
+            "OTIO_SCHEMA" : "SchemaDef.1",
+            "name" : "exampleSchemaDef",
+            "execution_scope" : "in process",
+            "filepath" : "exampleSchemaDef.py"
+        }
+    ]
+}

--- a/tests/test_schemadef_plugin.py
+++ b/tests/test_schemadef_plugin.py
@@ -55,18 +55,17 @@ class TestPluginSchemadefs(unittest.TestCase):
     def test_plugin_schemadef(self):
         # Our test manifest should have been loaded, including
         # the example_schemadef.
+        # Try creating a schema object using the instance_from_schema method.
         peculiar_value = "something One-derful"
-        try:
-            example = otio.core.instance_from_schema("exampleSchemaDef", 1, {
-                EXAMPLE_ARG: peculiar_value
-            })
-        except otio.exceptions.NotSupportedError:
-            self.fail("raised NotSupportedError (new schema type was undefined)")
+        example = otio.core.instance_from_schema("exampleSchemaDef", 1, {
+            EXAMPLE_ARG: peculiar_value
+        })
 
         self.assertEqual(str(type(example)), EXCLASS)
         self.assertEqual(example.exampleArg, peculiar_value)
 
-        # Repeat test using the direct class definition method:
+    def test_plugin_schemadef_namespace(self):
+        # Try creating schema object with the direct class definition method:
         peculiar_value = "something Two-derful"
         example = otio.schemadef.example_schemadef.exampleSchemaDef(peculiar_value)
         self.assertEqual(str(type(example)), EXCLASS)

--- a/tests/test_schemadef_plugin.py
+++ b/tests/test_schemadef_plugin.py
@@ -1,0 +1,69 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+import unittest
+import os
+
+import opentimelineio as otio
+from tests import baseline_reader
+
+"""Unit tests for the schemadef plugin system."""
+
+
+SCHEMADEF_NAME = "schemadef_example"
+EXAMPLE_SCHEMADEF = "exampleSchemaDef"
+EXAMPLE_ARG = "exampleArg"
+
+
+class TestPluginSchemadefs(unittest.TestCase):
+    def setUp(self):
+        self.save_manifest_path = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
+        # find the path to the baselines/schemadef_example.json
+        self.manifest_path = baseline_reader.path_to_baseline(SCHEMADEF_NAME)
+        os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = self.manifest_path
+        otio.plugins.manifest.ActiveManifest(force_reload=True)
+
+    def tearDown(self):
+        # restore original state
+        if self.save_manifest_path:
+            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = self.save_manifest_path
+        else:
+            del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
+        otio.plugins.manifest.ActiveManifest(force_reload=True)
+
+    def test_plugin_schemadef(self):
+        # Our test manifest should have been loaded, including
+        # the exampleSchemaDef.
+        peculiar_value = "something One-derful"
+        try:
+            example = otio.core.instance_from_schema(EXAMPLE_SCHEMADEF, 1, {
+                EXAMPLE_ARG: peculiar_value
+            })
+        except otio.exceptions.NotSupportedError:
+            self.fail("raised NotSupportedError (new schema type was undefined)")
+
+        self.assertEqual(example.exampleArg, peculiar_value)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_schemadef_plugin.py
+++ b/tests/test_schemadef_plugin.py
@@ -37,6 +37,7 @@ EXAMPLE_ARG = "exampleArg"
 
 class TestPluginSchemadefs(unittest.TestCase):
     def setUp(self):
+        self.save_manifest = otio.plugins.manifest._MANIFEST
         self.save_manifest_path = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
         # find the path to the baselines/schemadef_example.json
         self.manifest_path = baseline_reader.path_to_baseline(SCHEMADEF_NAME)
@@ -49,7 +50,7 @@ class TestPluginSchemadefs(unittest.TestCase):
             os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = self.save_manifest_path
         else:
             del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
-        otio.plugins.manifest.ActiveManifest(force_reload=True)
+        otio.plugins.manifest._MANIFEST = self.save_manifest
 
     def test_plugin_schemadef(self):
         # Our test manifest should have been loaded, including

--- a/tests/test_schemadef_plugin.py
+++ b/tests/test_schemadef_plugin.py
@@ -31,8 +31,8 @@ from tests import baseline_reader
 
 
 SCHEMADEF_NAME = "schemadef_example"
-EXAMPLE_SCHEMADEF = "exampleSchemaDef"
 EXAMPLE_ARG = "exampleArg"
+EXCLASS = "<class 'opentimelineio.schemadef.example_schemadef.exampleSchemaDef'>"
 
 
 class TestPluginSchemadefs(unittest.TestCase):
@@ -54,15 +54,22 @@ class TestPluginSchemadefs(unittest.TestCase):
 
     def test_plugin_schemadef(self):
         # Our test manifest should have been loaded, including
-        # the exampleSchemaDef.
+        # the example_schemadef.
         peculiar_value = "something One-derful"
         try:
-            example = otio.core.instance_from_schema(EXAMPLE_SCHEMADEF, 1, {
+            example = otio.core.instance_from_schema("exampleSchemaDef", 1, {
                 EXAMPLE_ARG: peculiar_value
             })
         except otio.exceptions.NotSupportedError:
             self.fail("raised NotSupportedError (new schema type was undefined)")
 
+        self.assertEqual(str(type(example)), EXCLASS)
+        self.assertEqual(example.exampleArg, peculiar_value)
+
+        # Repeat test using the direct class definition method:
+        peculiar_value = "something Two-derful"
+        example = otio.schemadef.example_schemadef.exampleSchemaDef(peculiar_value)
+        self.assertEqual(str(type(example)), EXCLASS)
         self.assertEqual(example.exampleArg, peculiar_value)
 
 

--- a/tests/test_unknown_schema.py
+++ b/tests/test_unknown_schema.py
@@ -64,6 +64,7 @@ has_undefined_schema = """
 }
 """
 
+
 class UnknownSchemaTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def setUp(self):
         # make an OTIO data structure containing an undefined schema object

--- a/tests/test_unknown_schema.py
+++ b/tests/test_unknown_schema.py
@@ -1,0 +1,81 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import unittest
+
+import opentimelineio as otio
+
+has_undefined_schema = """
+{
+    "OTIO_SCHEMA": "Clip.1",
+    "effects": [],
+    "markers": [],
+    "media_reference": {
+        "OTIO_SCHEMA": "ExternalReference.1",
+        "available_range": {
+            "OTIO_SCHEMA": "TimeRange.1",
+            "duration": {
+                "OTIO_SCHEMA": "RationalTime.1",
+                "rate": 24,
+                "value": 140
+            },
+            "start_time": {
+                "OTIO_SCHEMA": "RationalTime.1",
+                "rate": 24,
+                "value": 91
+            }
+        },
+        "metadata": {
+            "OTIO_SCHEMA": "MyOwnDangSchema.3",
+            "some_data": 895,
+            "howlongami": {
+                "OTIO_SCHEMA": "RationalTime.1",
+                "rate": 30,
+                "value": 100
+            }
+        },
+        "name": null,
+        "target_url": "/usr/tmp/some_media.mov"
+    },
+    "metadata": {},
+    "name": null,
+    "source_range": null
+}
+"""
+
+class UnknownSchemaTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+    def setUp(self):
+        # make an OTIO data structure containing an undefined schema object
+        self.orig = otio.adapters.otio_json.read_from_string(has_undefined_schema)
+
+    def test_serialize_deserialize(self):
+        serialized = otio.adapters.otio_json.write_to_string(self.orig)
+        test_otio = otio.adapters.otio_json.read_from_string(serialized)
+
+        self.assertIsOTIOEquivalentTo(self.orig, test_otio)
+
+    def test_is_unknown_schema(self):
+        self.assertFalse(self.orig.is_unknown_schema)
+        unknown = self.orig.media_reference.metadata
+        self.assertTrue(unknown.is_unknown_schema)


### PR DESCRIPTION
This PR adds a new SchemaDef plugin type.  A SchemaDef plugin can define one or more new OTIO schemas (or schemata if you prefer) which define first-class serializable OTIO objects and can be upgraded based on changes to the schema version number just like other OTIO schema-based objects.  

One possible use case is to define new schemas for studio-specific metadata objects which can be included in the clip "metadata" field.  For instance, our internal media linker plugin uses a few Pixar-specific schemas to provide metadata values which can be automatically upgraded when the schema version number increases.  Those Pixar-specific metadata schemas are defined in a single SchemaDef Python plugin and included by our plugin_manifest.json.
