### PR TITLE
Fix subtle bug with several unit tests

### DIFF
--- a/opentimelineio/adapters/__init__.py
+++ b/opentimelineio/adapters/__init__.py
@@ -46,7 +46,7 @@ from .. import (
 from .adapter import Adapter  # noqa
 
 # OTIO Json adapter is always available
-import otio_json # noqa
+from . import otio_json # noqa
 
 
 def suffixes_with_defined_adapters(read=False, write=False):

--- a/opentimelineio/adapters/__init__.py
+++ b/opentimelineio/adapters/__init__.py
@@ -45,6 +45,9 @@ from .. import (
 
 from .adapter import Adapter  # noqa
 
+# OTIO Json adapter is always available
+import otio_json # noqa
+
 
 def suffixes_with_defined_adapters(read=False, write=False):
     """Return a set of all the suffixes that have adapters defined for them."""

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -208,8 +208,11 @@ class TestPluginManifest(unittest.TestCase):
             os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = fpath.name + ':foo'
             result = otio.plugins.manifest.load_manifest()
 
-            self.assertEqual(len(result.media_linkers), 1)
-            self.assertEqual(result.media_linkers[0].name, "example")
+            # Rather than try and remove any other setuptools based plugins
+            # that might be installed, this check is made more permissive to
+            # see if the known unit test linker is being loaded by the manifest
+            self.assertTrue(len(result.media_linkers) > 0)
+            self.assertIn("example", (ml.name for ml in result.media_linkers))
 
         otio.plugins.manifest._MANIFEST = bak
         if bak_env:

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -217,6 +217,8 @@ class TestPluginManifest(unittest.TestCase):
         otio.plugins.manifest._MANIFEST = bak
         if bak_env:
             os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
+        else:
+            del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
 
 
 if __name__ == '__main__':

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -36,7 +36,9 @@ MANIFEST_PATH = "adapter_plugin_manifest.plugin_manifest"
 
 class TestPluginMediaLinker(unittest.TestCase):
     def setUp(self):
+        self.bak = otio.plugins.ActiveManifest()
         self.man = utils.create_manifest()
+        otio.plugins.manifest._MANIFEST = self.man
         self.jsn = baseline_reader.json_baseline_as_string(LINKER_PATH)
         self.mln = otio.adapters.otio_json.read_from_string(self.jsn)
         self.mln._json_path = os.path.join(
@@ -46,6 +48,7 @@ class TestPluginMediaLinker(unittest.TestCase):
         )
 
     def tearDown(self):
+        otio.plugins.manifest._MANIFEST = self.bak
         utils.remove_manifest(self.man)
 
     def test_plugin_adapter(self):
@@ -96,7 +99,7 @@ class TestPluginMediaLinker(unittest.TestCase):
         )
 
     def test_available_media_linker_names(self):
-        # for not just assert that it returns a non-empty list
+        # for now just assert that it returns a non-empty list
         self.assertTrue(otio.media_linker.available_media_linker_names())
 
     def test_default_media_linker(self):
@@ -109,3 +112,8 @@ class TestPluginMediaLinker(unittest.TestCase):
     def test_from_name_fail(self):
         with self.assertRaises(otio.exceptions.NotSupportedError):
             otio.media_linker.from_name("should not exist")
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -114,6 +114,5 @@ class TestPluginMediaLinker(unittest.TestCase):
             otio.media_linker.from_name("should not exist")
 
 
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -476,4 +476,4 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertEqual(3, len(self.trackABC))
         self.assertEqual(4, len(stack[1]))
         self.assertEqual(4, len(flat_track))
-        self.assertEquals(flat_track[1].name, "test_transition")
+        self.assertEqual(flat_track[1].name, "test_transition")


### PR DESCRIPTION
There was a bug in a couple of the tests that was causing test failures in certain environments where the OTIO environment variables were set but plugins were loaded via pip.  The tests weren't doing a good enough job of bookkeeping the state of the central `ActiveManifest`.