### PR TITLE
all children of EDL are outside of track range

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -325,10 +325,8 @@ class EDLParser(object):
                 raise EDLParseError('Unknown event type')
 
         for track in self.timeline.tracks:
-            # if the source_range is the same as the available_range
-            # then we don't need to set it at all.
-            if track.source_range == track.available_range():
-                track.source_range = None
+            # EDL doesn't have a top level range, so strip it.
+            track.source_range = None
 
 
 class ClipHandler(object):
@@ -737,6 +735,7 @@ def write_to_string(input_otio, rate=None, style='avid'):
         raise otio.exceptions.NotSupportedError(
             "No more than 2 audio tracks are supported."
         )
+
     # if audio_tracks:
     #     raise otio.exceptions.NotSupportedError(
     #         "No audio tracks are currently supported."

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -313,7 +313,8 @@ class Composition(item.Item, collections.MutableSequence):
 
     def trimmed_range_of_child(self, child, reference_space=None):
         """Get range of the child in reference_space coordinates, after the
-        self.source_range is applied.
+        self.source_range is applied, or None, if the child is outside the
+        self.source_range.
 
         Example
         |     [-----]     | seq
@@ -351,6 +352,10 @@ class Composition(item.Item, collections.MutableSequence):
             index = parent.index(current)
             parent_range = parent.trimmed_range_of_child_at_index(index)
 
+            # trimmed out entirely
+            if not parent_range:
+                return None
+
             if not result_range:
                 result_range = parent_range
                 current = parent
@@ -366,10 +371,6 @@ class Composition(item.Item, collections.MutableSequence):
             self.source_range.start_time,
             result_range.start_time
         )
-
-        # trimmed out
-        if new_start_time >= result_range.end_time_exclusive():
-            return None
 
         # compute duration
         new_duration = min(

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -312,7 +312,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         trck = tl.tracks[0]
         self.assertEqual(trck[0].duration().value, 10)
-        self.assertEqual(trck[2].source_range.start_time.value, 86400+201)
+        self.assertEqual(trck[2].source_range.start_time.value, 86400 + 201)
         self.assertEqual(trck[2].duration().value, 10)
 
     def test_dissolve_with_odd_frame_count_maintains_length(self):
@@ -326,7 +326,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         # VALIDATE
-        self.assertEqual(tl.duration().value, (11*24)+12)
+        self.assertEqual(tl.duration().value, (11 * 24) + 12)
 
     def test_fade_to_black_ends_with_gap(self):
         # EXERCISE
@@ -360,7 +360,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         timeline = otio.adapters.read_from_file(edl_path)
         track = timeline.tracks[0]
         self.assertEqual(len(track), 5)
-        self.assertEqual(track.duration().value, 5*24+6)
+        self.assertEqual(track.duration().value, 5 * 24 + 6)
         clip1, gapA, clip2, gapB, clip3 = track[:]
         self.assertEqual(clip1.source_range.duration.value, 24)
         self.assertEqual(clip2.source_range.duration.value, 24)
@@ -738,10 +738,10 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_invalid_edl_style_raises_exception(self):
         tl = otio.adapters.read_from_string(
-                '001  AX       V     C        '
-                '00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05\n',
-                adapter_name="cmx_3600"
-            )
+            '001  AX       V     C        '
+            '00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05\n',
+            adapter_name="cmx_3600"
+        )
         with self.assertRaises(otio.exceptions.NotSupportedError):
             otio.adapters.write_to_string(
                 tl,

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -855,6 +855,20 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             )
         )
 
+    def test_children_inside_track(self):
+        """Test for issue 346 -- EDL adapter was creating massively negative
+        start time source ranges on tracks, which caused all children to be
+        trimmed (so trimmed_range_in_parent() always returned None).
+        """
+
+        edl_path = SCREENING_EXAMPLE_PATH
+        timeline = otio.adapters.read_from_file(edl_path)
+        for cl in timeline.each_clip():
+            self.assertIsNotNone(cl.trimmed_range_in_parent())
+        self.assertFalse(
+            timeline.tracks[0].trimmed_range().start_time.value < 0
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The source range of a track coming from the EDL adapter has a negative start time, so all children are out of trimmed out of range. This was an attempt at fixing #346.