### PR TITLE
bug fix in json_serializer: use ordered list of encoders

### DIFF
--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -50,7 +50,7 @@ class _SerializableObjectEncoder(json.JSONEncoder):
     """ Encoder for the SerializableObject OTIO Class and its descendents. """
 
     def default(self, obj):
-        for typename, encfn in _ENCODER_MAP.items():
+        for typename, encfn in _ENCODER_LIST:
             if isinstance(obj, typename):
                 return encfn(obj)
 
@@ -136,14 +136,15 @@ def _encoded_transform(input_otio):
 # @}
 
 
-# Map of functions for encoding OTIO objects to JSON.
-_ENCODER_MAP = {
-    opentime.RationalTime: _encoded_time,
-    opentime.TimeRange: _encoded_time_range,
-    opentime.TimeTransform: _encoded_transform,
-    UnknownSchema: _encoded_unknown_schema_object,
-    SerializableObject: _encoded_serializable_object,
-}
+# Ordered list of functions for encoding OTIO objects to JSON.
+# More particular cases should precede more general cases.
+_ENCODER_LIST = [
+    (opentime.RationalTime, _encoded_time),
+    (opentime.TimeRange, _encoded_time_range),
+    (opentime.TimeTransform, _encoded_transform),
+    (UnknownSchema, _encoded_unknown_schema_object),
+    (SerializableObject, _encoded_serializable_object)
+]
 
 # @{ Decoders
 


### PR DESCRIPTION
This fixes a subtle bug.  Sometimes the unknown schema encoder would be called properly, but in other environments, it would not be.  The encoder map was being used like a list, but the order of the entries was random when iterated using _ENCODER_MAP.items().  Changed to be an actual list of pairs, which is the way we need to use it to be able to override a general case with a more specific case that precedes it in the list.