### PR TITLE
Composition: Optimize internal membership tracking for searches

### DIFF
--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -530,7 +530,7 @@ class Composition(item.Item, collections.MutableSequence):
         # set the item's parent and add it to our membership tracking and list
         # of children
         item._set_parent(self)
-        self._children_set.add(item)
+        self._child_lookup.add(item)
         self._children.insert(index, item)
 
     def __contains__(self, item):

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -69,7 +69,7 @@ class Composition(item.Item, collections.MutableSequence):
 
         # Because we know that all children are unique, we store a set
         # of all the children as well to speed up __contain__ checks.
-        self._children_set = set()
+        self._child_lookup = set()
 
         self._children = []
         if children:

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -68,13 +68,13 @@ class Composition(item.Item, collections.MutableSequence):
         collections.MutableSequence.__init__(self)
 
         # used to optimize membership checks on children.
-        self._children_hashes = set()
+        self._children_set = set()
 
         self._children = []
         if children:
             # cannot simply set ._children to children since __setitem__ runs
             # extra logic (assigning ._parent pointers) and populates the
-            # internal membership set _children_hashes.
+            # internal membership set _children_set.
             self.extend(children)
 
     _children = serializable_object.serializable_field(
@@ -201,8 +201,8 @@ class Composition(item.Item, collections.MutableSequence):
         # pointers need to be updated.
         [c._set_parent(result) for c in result._children]
 
-        # we also need to reconstruct the membership set of _children_hashes.
-        [result._children_hashes.add(c) for c in result._children]
+        # we also need to reconstruct the membership set of _children_set.
+        result._children_set.update(result._children)
 
         return result
 
@@ -494,10 +494,10 @@ class Composition(item.Item, collections.MutableSequence):
         # unset the old child's parent and delete the membership entry.
         if old is not None:
             old._set_parent(None)
-            self._children_hashes.remove(old)
+            self._children_set.remove(old)
 
         # put it into our membership tracking set
-        self._children_hashes.add(value)
+        self._children_set.add(value)
 
         # put it into our list of children
         self._children[key] = value
@@ -529,12 +529,12 @@ class Composition(item.Item, collections.MutableSequence):
         # set the item's parent and add it to our membership tracking and list
         # of children
         item._set_parent(self)
-        self._children_hashes.add(item)
+        self._children_set.add(item)
         self._children.insert(index, item)
 
     def __contains__(self, item):
         """Use our internal membership tracking set to speed up searches."""
-        return item in self._children_hashes
+        return item in self._children_set
 
     def __len__(self):
         """The len() of a Composition is the # of children in it.
@@ -551,9 +551,9 @@ class Composition(item.Item, collections.MutableSequence):
         if old is not None:
             if isinstance(key, slice):
                 for val in old:
-                    self._children_hashes.remove(val)
+                    self._children_set.remove(val)
             else:
-                self._children_hashes.remove(old)
+                self._children_set.remove(old)
 
         # remove it from our list of children
         del self._children[key]

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -203,7 +203,7 @@ class Composition(item.Item, collections.MutableSequence):
         [c._set_parent(result) for c in result._children]
 
         # we also need to reconstruct the membership set of _child_lookup.
-        result._children_set.update(result._children)
+        result._child_lookup.update(result._children)
 
         return result
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -202,7 +202,7 @@ class Composition(item.Item, collections.MutableSequence):
         [c._set_parent(result) for c in result._children]
 
         # we also need to reconstruct the membership set of _children_hashes.
-        [result._children_hashes.add(c.__hash__()) for c in result._children]
+        [result._children_hashes.add(c) for c in result._children]
 
         return result
 
@@ -494,10 +494,10 @@ class Composition(item.Item, collections.MutableSequence):
         # unset the old child's parent and delete the membership entry.
         if old is not None:
             old._set_parent(None)
-            self._children_hashes.remove(old.__hash__())
+            self._children_hashes.remove(old)
 
         # put it into our membership tracking set
-        self._children_hashes.add(value.__hash__())
+        self._children_hashes.add(value)
 
         # put it into our list of children
         self._children[key] = value
@@ -529,12 +529,12 @@ class Composition(item.Item, collections.MutableSequence):
         # set the item's parent and add it to our membership tracking and list
         # of children
         item._set_parent(self)
-        self._children_hashes.add(item.__hash__())
+        self._children_hashes.add(item)
         self._children.insert(index, item)
 
     def __contains__(self, item):
         """Use our internal membership tracking set to speed up searches."""
-        return item.__hash__() in self._children_hashes
+        return item in self._children_hashes
 
     def __len__(self):
         """The len() of a Composition is the # of children in it.
@@ -551,9 +551,9 @@ class Composition(item.Item, collections.MutableSequence):
         if old is not None:
             if isinstance(key, slice):
                 for val in old:
-                    self._children_hashes.remove(val.__hash__())
+                    self._children_hashes.remove(val)
             else:
-                self._children_hashes.remove(old.__hash__())
+                self._children_hashes.remove(old)
 
         # remove it from our list of children
         del self._children[key]

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -535,7 +535,7 @@ class Composition(item.Item, collections.MutableSequence):
 
     def __contains__(self, item):
         """Use our internal membership tracking set to speed up searches."""
-        return item in self._children_set
+        return item in self._child_lookup
 
     def __len__(self):
         """The len() of a Composition is the # of children in it.

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -495,7 +495,7 @@ class Composition(item.Item, collections.MutableSequence):
         # unset the old child's parent and delete the membership entry.
         if old is not None:
             old._set_parent(None)
-            self._children_set.remove(old)
+            self._child_lookup.remove(old)
 
         # put it into our membership tracking set
         self._children_set.add(value)

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -202,7 +202,7 @@ class Composition(item.Item, collections.MutableSequence):
         # pointers need to be updated.
         [c._set_parent(result) for c in result._children]
 
-        # we also need to reconstruct the membership set of _children_set.
+        # we also need to reconstruct the membership set of _child_lookup.
         result._children_set.update(result._children)
 
         return result

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -552,7 +552,7 @@ class Composition(item.Item, collections.MutableSequence):
         if old is not None:
             if isinstance(key, slice):
                 for val in old:
-                    self._children_set.remove(val)
+                    self._child_lookup.remove(val)
             else:
                 self._children_set.remove(old)
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -67,7 +67,8 @@ class Composition(item.Item, collections.MutableSequence):
         )
         collections.MutableSequence.__init__(self)
 
-        # used to optimize membership checks on children.
+        # Because we know that all children are unique, we store a set
+        # of all the children as well to speed up __contain__ checks.
         self._children_set = set()
 
         self._children = []

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -75,7 +75,7 @@ class Composition(item.Item, collections.MutableSequence):
         if children:
             # cannot simply set ._children to children since __setitem__ runs
             # extra logic (assigning ._parent pointers) and populates the
-            # internal membership set _children_set.
+            # internal membership set _child_lookup.
             self.extend(children)
 
     _children = serializable_object.serializable_field(

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -498,7 +498,7 @@ class Composition(item.Item, collections.MutableSequence):
             self._child_lookup.remove(old)
 
         # put it into our membership tracking set
-        self._children_set.add(value)
+        self._child_lookup.add(value)
 
         # put it into our list of children
         self._children[key] = value

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -554,7 +554,7 @@ class Composition(item.Item, collections.MutableSequence):
                 for val in old:
                     self._child_lookup.remove(val)
             else:
-                self._children_set.remove(old)
+                self._child_lookup.remove(old)
 
         # remove it from our list of children
         del self._children[key]

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1593,5 +1593,40 @@ class NestingTest(unittest.TestCase):
             )
 
 
+class MembershipTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+
+    def test_remove_actually_removes(self):
+        """Test that removed item is no longer 'in' composition."""
+        tr = otio.schema.Track()
+        cl = otio.schema.Clip()
+
+        # test inclusion
+        tr.append(cl)
+        self.assertIn(cl, tr)
+
+        # delete by index
+        del tr[0]
+        self.assertNotIn(cl, tr)
+
+        # delete by slice
+        tr = otio.schema.Track()
+        tr.append(cl)
+        del tr[:]
+        self.assertNotIn(cl, tr)
+
+        # delete by setting over item
+        tr = otio.schema.Track()
+        tr.append(cl)
+        cl2 = otio.schema.Clip()
+        tr[0] = cl2
+        self.assertNotIn(cl, tr)
+
+        # delete by pop
+        tr = otio.schema.Track()
+        tr.insert(0, cl)
+        tr.pop()
+        self.assertNotIn(cl, tr)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add an internal children membership set for tracking as well as a new
__contains__ method to use the set when checking for membership.

(NOTE: This is mostly to encourage discussion. Feelings will not be hurt if this is not the preferred solution.)