### PR TITLE
Optimizations for flatten (range_of_all_children)

### DIFF
--- a/opentimelineio/algorithms/stack_algo.py
+++ b/opentimelineio/algorithms/stack_algo.py
@@ -27,7 +27,7 @@ __doc__ = """ Algorithms for stack objects. """
 import copy
 
 from .. import (
-    schema
+    schema,
 )
 from . import (
     track_algo
@@ -41,6 +41,9 @@ def flatten_stack(in_stack):
 
     flat_track = schema.Track()
     flat_track.name = "Flattened"
+
+    # map of track to track.range_of_all_children
+    range_track_map = {}
 
     def _get_next_item(
             in_stack,
@@ -57,6 +60,12 @@ def flatten_stack(in_stack):
         track = in_stack[track_index]
         if trim_range is not None:
             track = track_algo.track_trimmed_to_range(track, trim_range)
+
+        track_map = range_track_map.get(track)
+        if track_map is None:
+            track_map = track.child_range_map()
+            range_track_map[track] = track_map
+
         for item in track:
             if (
                     item.visible()
@@ -65,7 +74,7 @@ def flatten_stack(in_stack):
             ):
                 yield item
             else:
-                trim = item.range_in_parent()
+                trim = track_map[item]
                 if trim_range is not None:
                     trim.start_time += trim_range.start_time
                 for more in _get_next_item(in_stack, track_index - 1, trim):

--- a/opentimelineio/algorithms/stack_algo.py
+++ b/opentimelineio/algorithms/stack_algo.py
@@ -63,7 +63,7 @@ def flatten_stack(in_stack):
 
         track_map = range_track_map.get(track)
         if track_map is None:
-            track_map = track.child_range_map()
+            track_map = track.range_of_all_children()
             range_track_map[track] = track_map
 
         for item in track:

--- a/opentimelineio/algorithms/track_algo.py
+++ b/opentimelineio/algorithms/track_algo.py
@@ -41,9 +41,11 @@ def track_trimmed_to_range(in_track, trim_range):
     away the stuff outside and that's what this function is meant for."""
     new_track = copy.deepcopy(in_track)
 
+    track_map = new_track.child_range_map()
+
     # iterate backwards so we can delete items
     for c, child in reversed(list(enumerate(new_track))):
-        child_range = child.range_in_parent()
+        child_range = track_map[child]
         if not trim_range.overlaps(child_range):
             # completely outside the trim range, so we discard it
             del new_track[c]

--- a/opentimelineio/algorithms/track_algo.py
+++ b/opentimelineio/algorithms/track_algo.py
@@ -41,7 +41,7 @@ def track_trimmed_to_range(in_track, trim_range):
     away the stuff outside and that's what this function is meant for."""
     new_track = copy.deepcopy(in_track)
 
-    track_map = new_track.child_range_map()
+    track_map = new_track.range_of_all_children()
 
     # iterate backwards so we can delete items
     for c, child in reversed(list(enumerate(new_track))):

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -198,8 +198,8 @@ class Track(core.Composition):
             next_item
         )
 
-    def child_range_map(self):
-        """Build a dict mapping children to their range in this track."""
+    def range_of_all_children(self):
+        """Return a dict mapping children to their range in this track."""
 
         if not self._children:
             return {}

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1205,11 +1205,11 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
         self.assertJsonEqual(neighbors, (seq[4], fill))
 
-    def test_track_child_range_map(self):
+    def test_track_range_of_all_children(self):
         edl_path = TRANSITION_EXAMPLE_PATH
         timeline = otio.adapters.read_from_file(edl_path)
         tr = timeline.tracks[0]
-        mp = tr.child_range_map()
+        mp = tr.range_of_all_children()
 
         # fetch all the valid children that should be in the map
         vc = list(tr.each_clip())

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1221,6 +1221,9 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             for child in track:
                 self.assertEqual(child.range_in_parent(), mp[child])
 
+        track = otio.schema.Track()
+        self.assertEqual(track.range_of_all_children(), {})
+
 
 class EdgeCases(unittest.TestCase):
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1205,6 +1205,22 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
         self.assertJsonEqual(neighbors, (seq[4], fill))
 
+    def test_track_child_range_map(self):
+        edl_path = TRANSITION_EXAMPLE_PATH
+        timeline = otio.adapters.read_from_file(edl_path)
+        tr = timeline.tracks[0]
+        mp = tr.child_range_map()
+
+        # fetch all the valid children that should be in the map
+        vc = list(tr.each_clip())
+
+        self.assertEqual(mp[vc[0]].start_time.value, 0)
+        self.assertEqual(mp[vc[1]].start_time, mp[vc[0]].duration)
+
+        for track in timeline.tracks:
+            for child in track:
+                self.assertEqual(child.range_in_parent(), mp[child])
+
 
 class EdgeCases(unittest.TestCase):
 


### PR DESCRIPTION
Flattening for timelines with many tracks/items was slow because `range_in_parent` was computed by walking through all previous items and summing their times.  This adds a function (`range_of_all_children`) that computes a map of item to range_in_parent, so you can do a look up rather than a compute to get the value.  This speeds up one particular case from 1600s to flatten down to 6s.