### PR TITLE
Bugfixes: Issue 320, 338, and 349 (biggest feature: constructors copy values)

### DIFF
--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -60,7 +60,7 @@ class Composable(serializable_object.SerializableObject):
 
         # initialize the serializable fields
         self.name = name
-        self.metadata = copy.deepcopy(metadata) or {}
+        self.metadata = copy.deepcopy(metadata) if metadata else {}
 
     @staticmethod
     def visible():

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -30,6 +30,8 @@ An object that can be composed by tracks.
 from . import serializable_object
 from . import type_registry
 
+import copy
+
 
 @type_registry.register_type
 class Composable(serializable_object.SerializableObject):
@@ -58,7 +60,7 @@ class Composable(serializable_object.SerializableObject):
 
         # initialize the serializable fields
         self.name = name
-        self.metadata = metadata or {}
+        self.metadata = copy.deepcopy(metadata) or {}
 
     @staticmethod
     def visible():

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -57,12 +57,16 @@ class Composition(item.Item, collections.MutableSequence):
         name=None,
         children=None,
         source_range=None,
+        markers=None,
+        effects=None,
         metadata=None
     ):
         item.Item.__init__(
             self,
             name=name,
             source_range=source_range,
+            markers=markers,
+            effects=effects,
             metadata=metadata
         )
         collections.MutableSequence.__init__(self)

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -64,8 +64,8 @@ class Item(composable.Composable):
         super(Item, self).__init__(name=name, metadata=metadata)
 
         self.source_range = copy.deepcopy(source_range)
-        self.effects = copy.deepcopy(effects or [])
-        self.markers = copy.deepcopy(markers or [])
+        self.effects = copy.deepcopy(effects) if effects else []
+        self.markers = copy.deepcopy(markers) if markers else []
 
     name = serializable_object.serializable_field("name", doc="Item name.")
     source_range = serializable_object.serializable_field(

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -63,11 +63,11 @@ class Item(composable.Composable):
     ):
         serializable_object.SerializableObject.__init__(self)
 
-        self.name = name
-        self.source_range = source_range
-        self.effects = effects or []
-        self.markers = markers or []
-        self.metadata = metadata or {}
+        self.name = copy.deepcopy(name)
+        self.source_range = copy.deepcopy(source_range)
+        self.effects = copy.deepcopy(effects or [])
+        self.markers = copy.deepcopy(markers or [])
+        self.metadata = copy.deepcopy(metadata or {})
         self._parent = None
 
     name = serializable_object.serializable_field("name", doc="Item name.")

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -61,14 +61,11 @@ class Item(composable.Composable):
         markers=None,
         metadata=None,
     ):
-        serializable_object.SerializableObject.__init__(self)
+        super(Item, self).__init__(name=name, metadata=metadata)
 
-        self.name = copy.deepcopy(name)
         self.source_range = copy.deepcopy(source_range)
         self.effects = copy.deepcopy(effects or [])
         self.markers = copy.deepcopy(markers or [])
-        self.metadata = copy.deepcopy(metadata) or {}
-        self._parent = None
 
     name = serializable_object.serializable_field("name", doc="Item name.")
     source_range = serializable_object.serializable_field(

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -67,7 +67,7 @@ class Item(composable.Composable):
         self.source_range = copy.deepcopy(source_range)
         self.effects = copy.deepcopy(effects or [])
         self.markers = copy.deepcopy(markers or [])
-        self.metadata = copy.deepcopy(metadata or {})
+        self.metadata = copy.deepcopy(metadata) or {}
         self._parent = None
 
     name = serializable_object.serializable_field("name", doc="Item name.")

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -206,12 +206,7 @@ def _as_otio(dct):
 def deserialize_json_from_string(otio_string):
     """ Deserialize a string containing JSON to OTIO objects. """
 
-    json_data = json.loads(otio_string, object_hook=_as_otio)
-
-    if json_data is {}:
-        raise exceptions.CouldNotReadFileError
-
-    return json_data
+    return json.loads(otio_string, object_hook=_as_otio)
 
 
 def deserialize_json_from_file(otio_filepath):

--- a/opentimelineio/core/media_reference.py
+++ b/opentimelineio/core/media_reference.py
@@ -54,7 +54,7 @@ class MediaReference(serializable_object.SerializableObject):
         available_range=None,
         metadata=None
     ):
-        serializable_object.SerializableObject.__init__(self)
+        super(MediaReference, self).__init__()
 
         self.name = name
         self.available_range = copy.deepcopy(available_range)

--- a/opentimelineio/core/media_reference.py
+++ b/opentimelineio/core/media_reference.py
@@ -32,6 +32,8 @@ from . import (
     serializable_object,
 )
 
+import copy
+
 
 @type_registry.register_type
 class MediaReference(serializable_object.SerializableObject):
@@ -55,8 +57,8 @@ class MediaReference(serializable_object.SerializableObject):
         serializable_object.SerializableObject.__init__(self)
 
         self.name = name
-        self.available_range = available_range
-        self.metadata = metadata or {}
+        self.available_range = copy.deepcopy(available_range)
+        self.metadata = copy.deepcopy(metadata) or {}
 
     name = serializable_object.serializable_field(
         "name",

--- a/opentimelineio/core/type_registry.py
+++ b/opentimelineio/core/type_registry.py
@@ -135,7 +135,7 @@ def instance_from_schema(schema_name, schema_version, data_dict):
         )
 
     if cls.schema_version() != schema_version:
-        # since the keys are the versions to upgrade to, sorting the keys 
+        # since the keys are the versions to upgrade to, sorting the keys
         # before iterating through them should ensure that upgrade functions
         # are called in order.
         for version, upgrade_func in sorted(

--- a/opentimelineio/core/type_registry.py
+++ b/opentimelineio/core/type_registry.py
@@ -135,7 +135,10 @@ def instance_from_schema(schema_name, schema_version, data_dict):
         )
 
     if cls.schema_version() != schema_version:
-        for version, upgrade_func in (
+        # since the keys are the versions to upgrade to, sorting the keys 
+        # before iterating through them should ensure that upgrade functions
+        # are called in order.
+        for version, upgrade_func in sorted(
             _UPGRADE_FUNCTIONS[cls].items()
         ):
             if version < schema_version:

--- a/opentimelineio/hooks.py
+++ b/opentimelineio/hooks.py
@@ -97,7 +97,7 @@ class HookScript(plugins.PythonPlugin):
     ):
         """HookScript plugin constructor."""
 
-        plugins.PythonPlugin.__init__(self, name, execution_scope, filepath)
+        super(HookScript, self).__init__(name, execution_scope, filepath)
 
     def run(self, in_timeline, argument_map={}):
         """Run the hook_function associated with this plugin."""

--- a/opentimelineio/media_linker.py
+++ b/opentimelineio/media_linker.py
@@ -137,7 +137,7 @@ class MediaLinker(plugins.PythonPlugin):
         execution_scope=None,
         filepath=None,
     ):
-        plugins.PythonPlugin.__init__(self, name, execution_scope, filepath)
+        super(MediaLinker, self).__init__(name, execution_scope, filepath)
 
     def link_media_reference(self, in_clip, media_linker_argument_map=None):
         media_linker_argument_map = media_linker_argument_map or {}

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -235,8 +235,8 @@ class TimeTransform(object):
 
     def __init__(self, offset=RationalTime(), scale=1.0, rate=None):
         self.offset = copy.copy(offset)
-        self.scale = copy.copy(scale)
-        self.rate = copy.copy(rate)
+        self.scale = scale
+        self.rate = rate
 
     def applied_to(self, other):
         if isinstance(other, TimeRange):

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -235,8 +235,8 @@ class TimeTransform(object):
 
     def __init__(self, offset=RationalTime(), scale=1.0, rate=None):
         self.offset = copy.copy(offset)
-        self.scale  = copy.copy(scale)
-        self.rate   = copy.copy(rate)
+        self.scale = copy.copy(scale)
+        self.rate = copy.copy(rate)
 
     def applied_to(self, other):
         if isinstance(other, TimeRange):
@@ -317,7 +317,7 @@ class TimeRange(object):
 
     def __init__(self, start_time=RationalTime(), duration=RationalTime()):
         self.start_time = copy.copy(start_time)
-        self.duration   = copy.copy(duration)
+        self.duration = copy.copy(duration)
 
     def __copy__(self, memodict=None):
         # Construct a new one directly to avoid the overhead of deepcopy

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -386,24 +386,21 @@ class TimeRange(object):
     def extended_by(self, other):
         """Construct a new TimeRange that is this one extended by another."""
 
-        result = TimeRange(self.start_time, self.duration)
-        if isinstance(other, TimeRange):
-            result.start_time = min(self.start_time, other.start_time)
-            new_end_time = max(
-                self.end_time_exclusive(),
-                other.end_time_exclusive()
-            )
-            result.duration = duration_from_start_end_time(
-                result.start_time,
-                new_end_time
-            )
-        else:
+        if not isinstance(other, TimeRange):
             raise TypeError(
                 "extended_by requires rtime be a TimeRange, not a '{}'".format(
                     type(other)
                 )
             )
-        return result
+
+        start_time = min(self.start_time, other.start_time)
+        new_end_time = max(
+            self.end_time_exclusive(),
+            other.end_time_exclusive()
+        )
+        duration = duration_from_start_end_time(start_time, new_end_time)
+        return TimeRange(start_time, duration)
+
 
     # @TODO: remove?
     def clamped(

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -368,7 +368,7 @@ class TimeRange(object):
 
             return result
         else:
-            return self.start_time
+            return copy.deepcopy(self.start_time)
 
     def end_time_exclusive(self):
         """"Time of the first sample outside the time range.

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -136,6 +136,7 @@ class RationalTime(object):
         self.value = value
         self.rate = scale
 
+        # @TODO: make this construct and return a new object
         return self
 
     def __add__(self, other):
@@ -233,9 +234,9 @@ class TimeTransform(object):
     """1D Transform for RationalTime.  Has offset and scale."""
 
     def __init__(self, offset=RationalTime(), scale=1.0, rate=None):
-        self.offset = offset
-        self.scale = scale
-        self.rate = rate
+        self.offset = copy.copy(offset)
+        self.scale  = copy.copy(scale)
+        self.rate   = copy.copy(rate)
 
     def applied_to(self, other):
         if isinstance(other, TimeRange):
@@ -315,8 +316,8 @@ class TimeRange(object):
     """
 
     def __init__(self, start_time=RationalTime(), duration=RationalTime()):
-        self.start_time = start_time
-        self.duration = duration
+        self.start_time = copy.copy(start_time)
+        self.duration   = copy.copy(duration)
 
     def __copy__(self, memodict=None):
         # Construct a new one directly to avoid the overhead of deepcopy
@@ -790,8 +791,12 @@ def duration_from_start_end_time(start_time, end_time_exclusive):
         )
     else:
         return RationalTime(
-            end_time_exclusive.value_rescaled_to(start_time) - start_time.value,
-            start_time.rate)
+            (
+                end_time_exclusive.value_rescaled_to(start_time)
+                - start_time.value
+            ),
+            start_time.rate
+        )
 
 
 # @TODO: create range from start/end [in,ex]clusive

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -401,7 +401,6 @@ class TimeRange(object):
         duration = duration_from_start_end_time(start_time, new_end_time)
         return TimeRange(start_time, duration)
 
-
     # @TODO: remove?
     def clamped(
         self,

--- a/opentimelineio/plugins/manifest.py
+++ b/opentimelineio/plugins/manifest.py
@@ -82,7 +82,7 @@ class Manifest(core.SerializableObject):
     _serializable_label = "PluginManifest.1"
 
     def __init__(self):
-        core.SerializableObject.__init__(self)
+        super(Manifest, self).__init__()
         self.adapters = []
         self.schemadefs = []
         self.media_linkers = []

--- a/opentimelineio/plugins/python_plugin.py
+++ b/opentimelineio/plugins/python_plugin.py
@@ -46,7 +46,7 @@ class PythonPlugin(core.SerializableObject):
         execution_scope=None,
         filepath=None,
     ):
-        core.SerializableObject.__init__(self)
+        super(PythonPlugin, self).__init__()
         self.name = name
         self.execution_scope = execution_scope
         self.filepath = filepath

--- a/opentimelineio/schema/clip.py
+++ b/opentimelineio/schema/clip.py
@@ -49,21 +49,22 @@ class Clip(core.Item):
         name=None,
         media_reference=None,
         source_range=None,
+        markers=[],
+        effects=[],
         metadata=None,
     ):
         core.Item.__init__(
             self,
             name=name,
             source_range=source_range,
+            markers=markers,
+            effects=effects,
             metadata=metadata
         )
-        # init everything as None first, so that we will catch uninitialized
-        # values via exceptions
-        self.name = name
 
         if not media_reference:
             media_reference = missing_reference.MissingReference()
-        self._media_reference = media_reference
+        self._media_reference = copy.deepcopy(media_reference)
 
     name = core.serializable_field("name", doc="Name of this clip.")
     transform = core.deprecated_field()

--- a/opentimelineio/schema/effect.py
+++ b/opentimelineio/schema/effect.py
@@ -28,6 +28,8 @@ from .. import (
     core
 )
 
+import copy
+
 
 @core.register_type
 class Effect(core.SerializableObject):
@@ -39,10 +41,10 @@ class Effect(core.SerializableObject):
         effect_name=None,
         metadata=None
     ):
-        core.SerializableObject.__init__(self)
+        super(Effect, self).__init__()
         self.name = name
         self.effect_name = effect_name
-        self.metadata = metadata or {}
+        self.metadata = copy.deepcopy(metadata) or {}
 
     name = core.serializable_field(
         "name",

--- a/opentimelineio/schema/effect.py
+++ b/opentimelineio/schema/effect.py
@@ -44,7 +44,7 @@ class Effect(core.SerializableObject):
         super(Effect, self).__init__()
         self.name = name
         self.effect_name = effect_name
-        self.metadata = copy.deepcopy(metadata) or {}
+        self.metadata = copy.deepcopy(metadata) if metadata else {}
 
     name = core.serializable_field(
         "name",

--- a/opentimelineio/schema/schemadef.py
+++ b/opentimelineio/schema/schemadef.py
@@ -17,7 +17,7 @@ class SchemaDef(plugins.PythonPlugin):
         execution_scope=None,
         filepath=None,
     ):
-        plugins.PythonPlugin.__init__(self, name, execution_scope, filepath)
+        super(SchemaDef, self).__init__(name, execution_scope, filepath)
 
     def module(self):
         """

--- a/opentimelineio/schema/serializable_collection.py
+++ b/opentimelineio/schema/serializable_collection.py
@@ -61,7 +61,7 @@ class SerializableCollection(
 
         self.name = name
         self._children = children or []
-        self.metadata = copy.deepcopy(metadata) or {}
+        self.metadata = copy.deepcopy(metadata) if metadata else {}
 
     name = core.serializable_field(
         "name",

--- a/opentimelineio/schema/serializable_collection.py
+++ b/opentimelineio/schema/serializable_collection.py
@@ -25,6 +25,7 @@
 """A serializable collection of SerializableObjects."""
 
 import collections
+import copy
 
 from .. import (
     core
@@ -56,11 +57,11 @@ class SerializableCollection(
         children=None,
         metadata=None,
     ):
-        core.SerializableObject.__init__(self)
+        super(SerializableCollection, self).__init__()
 
         self.name = name
         self._children = children or []
-        self.metadata = metadata or {}
+        self.metadata = copy.deepcopy(metadata) or {}
 
     name = core.serializable_field(
         "name",

--- a/opentimelineio/schema/stack.py
+++ b/opentimelineio/schema/stack.py
@@ -46,6 +46,8 @@ class Stack(core.Composition):
         name=None,
         children=None,
         source_range=None,
+        markers=None,
+        effects=None,
         metadata=None
     ):
         core.Composition.__init__(
@@ -53,6 +55,8 @@ class Stack(core.Composition):
             name=name,
             children=children,
             source_range=source_range,
+            markers=markers,
+            effects=effects,
             metadata=metadata
         )
 

--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -24,6 +24,8 @@
 
 """Implementation of the OTIO built in schema, Timeline object."""
 
+import copy
+
 from .. import (
     core,
     opentime,
@@ -31,7 +33,6 @@ from .. import (
 
 from . import stack, track
 
-import copy
 
 @core.register_type
 class Timeline(core.SerializableObject):

--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -55,7 +55,7 @@ class Timeline(core.SerializableObject):
             tracks = []
         self.tracks = stack.Stack(name="tracks", children=tracks)
 
-        self.metadata = copy.deepcopy(metadata) or {}
+        self.metadata = copy.deepcopy(metadata) if metadata else {}
 
     name = core.serializable_field("name", doc="Name of this timeline.")
     tracks = core.serializable_field(

--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -31,6 +31,7 @@ from .. import (
 
 from . import stack, track
 
+import copy
 
 @core.register_type
 class Timeline(core.SerializableObject):
@@ -43,17 +44,17 @@ class Timeline(core.SerializableObject):
         global_start_time=None,
         metadata=None,
     ):
-        core.SerializableObject.__init__(self)
+        super(Timeline, self).__init__()
         self.name = name
         if global_start_time is None:
             global_start_time = opentime.RationalTime(0, 24)
-        self.global_start_time = global_start_time
+        self.global_start_time = copy.deepcopy(global_start_time)
 
         if tracks is None:
             tracks = []
         self.tracks = stack.Stack(name="tracks", children=tracks)
 
-        self.metadata = metadata or {}
+        self.metadata = copy.deepcopy(metadata) or {}
 
     name = core.serializable_field("name", doc="Name of this timeline.")
     tracks = core.serializable_field(

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -59,8 +59,10 @@ class Track(core.Composition):
         self,
         name=None,
         children=None,
-        source_range=None,
         kind=TrackKind.Video,
+        source_range=None,
+        markers=None,
+        effects=None,
         metadata=None,
     ):
         core.Composition.__init__(
@@ -68,6 +70,8 @@ class Track(core.Composition):
             name=name,
             children=children,
             source_range=source_range,
+            markers=markers,
+            effects=effects,
             metadata=metadata
         )
         self.kind = kind

--- a/opentimelineio/schema/transition.py
+++ b/opentimelineio/schema/transition.py
@@ -30,6 +30,8 @@ from .. import (
     exceptions,
 )
 
+import copy
+
 
 class TransitionTypes:
     """Enum encoding types of transitions.
@@ -78,8 +80,8 @@ class Transition(core.Composable):
         #     parameters = {}
         # self.parameters = parameters
         self.transition_type = transition_type
-        self.in_offset = in_offset
-        self.out_offset = out_offset
+        self.in_offset = copy.deepcopy(in_offset)
+        self.out_offset = copy.deepcopy(out_offset)
 
     transition_type = core.serializable_field(
         "transition_type",

--- a/opentimelineio_contrib/adapters/hls_playlist.py
+++ b/opentimelineio_contrib/adapters/hls_playlist.py
@@ -880,15 +880,15 @@ class MediaPlaylistParser(object):
 
     def _parse_entries(self, playlist_entries, playlist_version):
         """Interpret the entries through the lens of the schema"""
-        current_media_ref = otio.schema.ExternalReference(
-            metadata={
-                FORMAT_METADATA_KEY: {},
-                STREAMING_METADATA_KEY: {}
-            }
-        )
         current_clip = otio.schema.Clip(
-            media_reference=current_media_ref
+            media_reference=otio.schema.ExternalReference(
+                metadata={
+                    FORMAT_METADATA_KEY: {},
+                    STREAMING_METADATA_KEY: {}
+                }
+            )
         )
+        current_media_ref = current_clip.media_reference
         segment_metadata = {}
         current_map_data = {}
         # per section 4.3.3.2 of Pantos HLS, 0 is default start track
@@ -911,15 +911,15 @@ class MediaPlaylistParser(object):
                 current_track += 1
 
                 # Set up the next segment definition
-                current_media_ref = otio.schema.ExternalReference(
-                    metadata={
-                        FORMAT_METADATA_KEY: {},
-                        STREAMING_METADATA_KEY: {}
-                    }
-                )
                 current_clip = otio.schema.Clip(
-                    media_reference=current_media_ref
+                    media_reference=otio.schema.ExternalReference(
+                        metadata={
+                            FORMAT_METADATA_KEY: {},
+                            STREAMING_METADATA_KEY: {}
+                        }
+                    )
                 )
+                current_media_ref = current_clip.media_reference
                 continue
             elif entry.type != EntryType.tag:
                 # the rest of the code deals only with tags

--- a/opentimelineio_contrib/adapters/rv.py
+++ b/opentimelineio_contrib/adapters/rv.py
@@ -26,6 +26,7 @@
 
 import subprocess
 import os
+import copy
 
 from .. import adapters
 
@@ -45,10 +46,12 @@ def write_to_file(input_otio, filepath):
 
     input_data = adapters.write_to_string(input_otio, "otio_json")
 
-    os.environ['PYTHONPATH'] = (
+    base_environment = copy.deepcopy(os.environ)
+
+    base_environment['PYTHONPATH'] = (
         os.pathsep.join(
             [
-                os.environ.setdefault('PYTHONPATH', ''),
+                base_environment.setdefault('PYTHONPATH', ''),
                 os.path.dirname(__file__)
             ]
         )
@@ -56,7 +59,7 @@ def write_to_file(input_otio, filepath):
 
     proc = subprocess.Popen(
         [
-            os.environ["OTIO_RV_PYTHON_BIN"],
+            base_environment["OTIO_RV_PYTHON_BIN"],
             '-m',
             'extern_rv',
             filepath
@@ -64,7 +67,7 @@ def write_to_file(input_otio, filepath):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         stdin=subprocess.PIPE,
-        env=os.environ
+        env=base_environment
     )
     proc.stdin.write(input_data)
     out, err = proc.communicate()

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -50,7 +50,7 @@ class ClipTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
         self.assertEqual(cl.name, name)
         self.assertEqual(cl.source_range, tr)
-        self.assertEqual(cl.media_reference, mr)
+        self.assertIsOTIOEquivalentTo(cl.media_reference, mr)
         self.assertEqual(cl.source_range, tr)
 
         encoded = otio.adapters.otio_json.write_to_string(cl)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -121,8 +121,8 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
         name = "foobar"
         effects = []
-        markers=[]
-        metadata={}
+        markers = []
+        metadata = {}
         it = otio.core.Item(
             name=name,
             source_range=tr,
@@ -138,7 +138,6 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertNotEqual(it.markers, markers)
         metadata['foo'] = 'bar'
         self.assertNotEqual(it.metadata, metadata)
-
 
     def test_is_parent_of(self):
         it = otio.core.Item()

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -113,6 +113,33 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         self.assertIsOTIOEquivalentTo(it, decoded)
 
+    def test_copy_arguments(self):
+        # make sure all the arguments are copied and not referenced
+        tr = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(0, 24),
+            otio.opentime.RationalTime(10, 24),
+        )
+        name = "foobar"
+        effects = []
+        markers=[]
+        metadata={}
+        it = otio.core.Item(
+            name=name,
+            source_range=tr,
+            effects=effects,
+            markers=markers,
+            metadata=metadata,
+        )
+        name = 'foobaz'
+        self.assertNotEqual(it.name, name)
+        tr.start_time.value = 1
+        self.assertNotEqual(it.source_range.start_time, tr.start_time)
+        markers.append(otio.schema.Marker())
+        self.assertNotEqual(it.markers, markers)
+        metadata['foo'] = 'bar'
+        self.assertNotEqual(it.metadata, metadata)
+
+
     def test_is_parent_of(self):
         it = otio.core.Item()
         it_2 = otio.core.Item()

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -547,6 +547,17 @@ class TestTime(unittest.TestCase):
 
         self.assertEqual(tend, tdur)
 
+    def test_subtract_with_different_rates(self):
+        t1 = otio.opentime.RationalTime(12, 10)
+        t2 = otio.opentime.RationalTime(12, 5)
+
+        self.assertEqual((t1 - t2).value, -12)
+
+    def test_incomparable_floats(self):
+        t1 = otio.opentime.RationalTime(12, 10)
+        with self.assertRaises(TypeError):
+            t1 < -1
+
 
 class TestTimeTransform(unittest.TestCase):
 
@@ -876,6 +887,13 @@ class TestTimeRange(unittest.TestCase):
                 tr.start_time, tr.end_time_exclusive()
             )
         )
+
+    def test_fractional_end_time_inclusive(self):
+        t1 = otio.opentime.RationalTime(10, 1)
+        t2 = otio.opentime.RationalTime(0.5, 1)
+        tr = otio.opentime.TimeRange(start_time=t1, duration=t2)
+
+        self.assertEqual(tr.end_time_inclusive().value, 10)
 
     def test_adjacent_timeranges(self):
         d1 = 0.3


### PR DESCRIPTION
This PR should address:

- #320 -- constructors now copy arguments, and `TimeRange.end_time_inclusive` returns a copy
- #338 -- (partially addressed by #341) -- Upgrade functions are sorted to ensure that they run in the right order
- Removed some unnecessary code in the JSON deserializer
- #349 -- RV adapter creates a copy of the environment rather than directly modifying os.environ.

