### PR TITLE
Use a weakref for _parent to prevent cycles.

### DIFF
--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -27,6 +27,8 @@
 An object that can be composed by tracks.
 """
 
+import weakref
+
 from . import serializable_object
 from . import type_registry
 
@@ -81,28 +83,28 @@ class Composable(serializable_object.SerializableObject):
     def _ancestors(self):
         ancestors = []
         seqi = self
-        while seqi._parent is not None:
-            seqi = seqi._parent
+        while seqi.parent() is not None:
+            seqi = seqi.parent()
             ancestors.append(seqi)
         return ancestors
 
     def parent(self):
         """Return the parent Composable, or None if self has no parent."""
 
-        return self._parent
+        return self._parent() if self._parent is not None else None
 
     def _set_parent(self, new_parent):
-        self._parent = new_parent
+        self._parent = weakref.ref(new_parent) if new_parent is not None else None
 
     def is_parent_of(self, other):
         """Returns true if self is a parent or ancestor of other."""
 
         visited = set([])
-        while other._parent is not None and other._parent not in visited:
-            if other._parent is self:
+        while other.parent() is not None and other.parent() not in visited:
+            if other.parent() is self:
                 return True
             visited.add(other)
-            other = other._parent
+            other = other.parent()
 
         return False
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -225,7 +225,7 @@ class Composition(item.Item, collections.MutableSequence):
 
         while(current is not self):
             try:
-                current = current._parent
+                current = current.parent()
             except AttributeError:
                 raise exceptions.NotAChildError(
                     "Item '{}' is not a child of '{}'.".format(child, self)

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -159,7 +159,7 @@ class Item(composable.Composable):
         item = self
         while item != root and item != to_item:
 
-            parent = item._parent
+            parent = item.parent()
             result -= item.trimmed_range().start_time
             result += parent.range_of_child(item).start_time
 
@@ -171,7 +171,7 @@ class Item(composable.Composable):
         item = to_item
         while item != root and item != ancestor:
 
-            parent = item._parent
+            parent = item.parent()
             result += item.trimmed_range().start_time
             result -= parent.range_of_child(item).start_time
 

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -85,9 +85,9 @@ class ComposableTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         # set seqi from none
         seqi_2._set_parent(seqi)
-        self.assertEqual(seqi, seqi_2._parent)
+        self.assertEqual(seqi, seqi_2.parent())
 
         # change seqi
         seqi_3 = otio.core.Composable()
         seqi_2._set_parent(seqi_3)
-        self.assertEqual(seqi_3, seqi_2._parent)
+        self.assertEqual(seqi_3, seqi_2.parent())

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -120,7 +120,7 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def test_parent_manip(self):
         it = otio.core.Item()
         co = otio.core.Composition(children=[it])
-        self.assertIs(it._parent, co)
+        self.assertIs(it.parent(), co)
 
     def test_each_child_recursion(self):
         tl = otio.schema.Timeline(name="TL")
@@ -203,7 +203,7 @@ class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         self.assertIsOTIOEquivalentTo(st, decoded)
 
-        self.assertIsNotNone(decoded[0]._parent)
+        self.assertIsNotNone(decoded[0].parent())
 
     def test_str(self):
         st = otio.schema.Stack(name="foo", children=[])


### PR DESCRIPTION
The _parent pointer should be a weakref.  This also enforces that nothing outside of item should use the _parent pointer directly, things should go through `.parent()`