### PR TITLE
Simplify AAF clip nesting when effects are found

### DIFF
--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -663,7 +663,7 @@ def _simplify(thing):
             c = len(thing) - 1
             while c >= 0:
                 child = thing[c]
-                # Is my child a Stack also?
+                # Is my child a Stack also? (with no effects)
                 if (
                     isinstance(child, otio.schema.Stack)
                     and not _has_effects(child)
@@ -709,15 +709,10 @@ def _has_effects(thing):
 
 
 def _is_redundant_container(thing):
+    # A container with only one thing in it?
     return (
         isinstance(thing, otio.core.Composition) and
-        (
-            # A container with length of one
-            len(thing) == 1 and
-
-            # ...which contains a container
-            isinstance(thing[0], otio.core.Composition)
-        )
+        len(thing) == 1
     )
 
 

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -689,6 +689,9 @@ def _simplify(thing):
             result.markers.extend(thing.markers)
             # TODO: The order of the effects is probably important...
             # should they be added to the end or the front?
+            # Intuitively it seems like the child's effects should come before
+            # the parent's effects. This will need to be solidified when we
+            # add more effects support.
             result.effects.extend(thing.effects)
             # Keep the parent's length, if it has one
             if thing.source_range:
@@ -711,8 +714,8 @@ def _has_effects(thing):
 def _is_redundant_container(thing):
     # A container with only one thing in it?
     return (
-        isinstance(thing, otio.core.Composition) and
-        len(thing) == 1
+        isinstance(thing, otio.core.Composition)
+        and len(thing) == 1
     )
 
 

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -621,6 +621,7 @@ class AAFAdapterTest(unittest.TestCase):
         self.assertEqual(0, len(clip.effects))
 
         for clip in track[1:]:
+            self.assertIsInstance(clip, otio.schema.Clip)
             self.assertEqual(1, len(clip.effects))
             effect = clip.effects[0]
             self.assertEqual(otio.schema.LinearTimeWarp, type(effect))


### PR DESCRIPTION
In AAF, effects are represented as a wrapper object around the clip. When we turn this into an OTIO, we attempt to simplify the structure to remove this extra level of nesting (the effects are a list on the Clip, not a wrapper). This PR adds a unit test to check for this, and modifies the simplify logic to un-nest any Composition that has only 1 child.
