### PR TITLE
Add support for AAF unit tests in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,19 @@ python:
     - "3.5"
     - "3.6"
 
-env:
-    global:
-        - PYAAF27=PyAAF-1.0.0-cp27-cp27mu-manylinux1_x86_64.whl
-        - PYAAF35=PyAAF-1.0.0-cp35-cp35m-manylinux1_x86_64.whl
-        - PYAAF36=PyAAF-1.0.0-cp36-cp36m-manylinux1_x86_64.whl
-
 before_install:
     # Note that pyaaf is only needed for the AAF adapter
     # We need to get a wheel that matches our Python version
-    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export PYAAF=$PYAAF27 ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then export PYAAF=$PYAAF35 ; fi
-    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then export PYAAF=$PYAAF36 ; fi
-    - wget -qO /tmp/${PYAAF} "https://github.com/markreidvfx/pyaaf/releases/download/v1.0.0/${PYAAF}"
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then export TOX_ENV=py27 ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then export TOX_ENV=py35 ; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then export TOX_ENV=py36 ; fi
 
 install:
     # tox-travis installs tox and also makes working with travis better.
     - pip install tox-travis coverage
-    - pip install /tmp/${PYAAF}
 
 script:
-    - tox
+    - tox -e $TOX_ENV
 
 after_success:
     # Documentation for codecov uploader

--- a/opentimelineio_contrib/adapters/tests/test_burnins.py
+++ b/opentimelineio_contrib/adapters/tests/test_burnins.py
@@ -140,7 +140,7 @@ TIMECODE = ('ffmpeg -loglevel panic -i TEST.MOV -vf "drawtext=timecode='
 
 try:
     import PIL # noqa
-    from PIL import imaging # noqa
+    from PIL.Image import core as imaging # noqa
     could_import_pillow = True
 except (ImportError):
     could_import_pillow = False

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,13 @@ deps =
     check-manifest
     flake8
     Pillow
+    mock
+; TODO: This will ONLY work on linux systems.  If we could get this from PyPI,
+;       then the platform resolution could be handled by pip instead of here.
+    py27: https://github.com/markreidvfx/pyaaf/releases/download/v1.0.0/PyAAF-1.0.0-cp27-cp27mu-manylinux1_x86_64.whl
+    py35: https://github.com/markreidvfx/pyaaf/releases/download/v1.0.0/PyAAF-1.0.0-cp35-cp35m-manylinux1_x86_64.whl
+    py36: https://github.com/markreidvfx/pyaaf/releases/download/v1.0.0/PyAAF-1.0.0-cp36-cp36m-manylinux1_x86_64.whl
+
 commands =
     check-manifest --ignore tox.ini,tests*,requirements* --ignore-bad-ideas *.egg-info,*egg-info/*
     flake8 opentimelineio

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean,py27,py35,py36,py37,stats
+envlist = clean,py27,py35,py36,stats
 skip_missing_interpreters = true
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ deps =
 commands =
     check-manifest --ignore tox.ini,tests*,requirements* --ignore-bad-ideas *.egg-info,*egg-info/*
     flake8 opentimelineio
-    python -m unittest discover -s tests
-    python -m unittest discover -s opentimelineio_contrib/adapters/tests
+    python -m unittest discover -s tests -vvv
+    python -m unittest discover -s opentimelineio_contrib/adapters/tests -vvv
     coverage run -a --source=opentimelineio -m unittest discover tests
     coverage run -a --source=opentimelineio_contrib/adapters -m unittest discover opentimelineio_contrib/adapters/tests
     coverage report --include=* -m

--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,8 @@ deps =
 commands =
     check-manifest --ignore tox.ini,tests*,requirements* --ignore-bad-ideas *.egg-info,*egg-info/*
     flake8 opentimelineio
-    python -m unittest discover -s tests -vvv
-    python -m unittest discover -s opentimelineio_contrib/adapters/tests -vvv
-    coverage run -a --source=opentimelineio -m unittest discover tests
-    coverage run -a --source=opentimelineio_contrib/adapters -m unittest discover opentimelineio_contrib/adapters/tests
+    coverage run -a --source=opentimelineio -m unittest discover tests -vvv
+    coverage run -a --source=opentimelineio_contrib/adapters -m unittest discover opentimelineio_contrib/adapters/tests -vvv
     coverage report --include=* -m
 
 [testenv:clean]


### PR DESCRIPTION
Rejiggered the travis/tox configuration:

- PyAAF installation happens in tox now, rather than travis.  Because tox builds itself a virtualenv, this makes it easier for tox to do the right thing.  Note that this only works for linux, because it has explicit paths to released files from github.   If we could get PyAAF from pip, this would be simpler.
- Travis tells tox which environment to run
- Adjusted the import name on Pillow, which seems to have changed in recent versions of the library.
- Added the mock library as a dependency (needed for several unit tests in core).
- Makes tests run with verbose printout so that its easier to see what/why things get skipped.
- Removed Python 3.7 testing from Tox (it wasn't in Travis anyways). If someone wants this, we should add it to both.