### PR TITLE
Remove sort_keys argument to json serializer to adapter.

### DIFF
--- a/opentimelineio/adapters/otio_json.py
+++ b/opentimelineio/adapters/otio_json.py
@@ -40,9 +40,9 @@ def read_from_string(input_str):
     return core.deserialize_json_from_string(input_str)
 
 
-def write_to_string(input_otio):
-    return core.serialize_json_to_string(input_otio)
+def write_to_string(input_otio, sort_keys=True):
+    return core.serialize_json_to_string(input_otio, sort_keys)
 
 
-def write_to_file(input_otio, filepath):
-    return core.serialize_json_to_file(input_otio, filepath)
+def write_to_file(input_otio, filepath, sort_keys=True):
+    return core.serialize_json_to_file(input_otio, filepath, sort_keys)

--- a/opentimelineio/adapters/otio_json.py
+++ b/opentimelineio/adapters/otio_json.py
@@ -40,9 +40,9 @@ def read_from_string(input_str):
     return core.deserialize_json_from_string(input_str)
 
 
-def write_to_string(input_otio, sort_keys=True):
-    return core.serialize_json_to_string(input_otio, sort_keys)
+def write_to_string(input_otio):
+    return core.serialize_json_to_string(input_otio)
 
 
-def write_to_file(input_otio, filepath, sort_keys=True):
-    return core.serialize_json_to_file(input_otio, filepath, sort_keys)
+def write_to_file(input_otio, filepath):
+    return core.serialize_json_to_file(input_otio, filepath)

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -69,14 +69,14 @@ def serialize_json_to_string(root, sort_keys=True, indent=4):
     ).encode(root)
 
 
-def serialize_json_to_file(root, to_file):
+def serialize_json_to_file(root, to_file, sort_keys=True):
     """
     Serialize a tree of SerializableObject to JSON.
 
     Writes the result to the given file path.
     """
 
-    content = serialize_json_to_string(root)
+    content = serialize_json_to_string(root, sort_keys=sort_keys)
 
     with open(to_file, 'w') as file_contents:
         file_contents.write(content)

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -57,26 +57,26 @@ class _SerializableObjectEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def serialize_json_to_string(root, sort_keys=True, indent=4):
+def serialize_json_to_string(root, indent=4):
     """Serialize a tree of SerializableObject to JSON.
 
     Returns a JSON string.
     """
 
     return _SerializableObjectEncoder(
-        sort_keys=sort_keys,
+        sort_keys=True,
         indent=indent
     ).encode(root)
 
 
-def serialize_json_to_file(root, to_file, sort_keys=True):
+def serialize_json_to_file(root, to_file):
     """
     Serialize a tree of SerializableObject to JSON.
 
     Writes the result to the given file path.
     """
 
-    content = serialize_json_to_string(root, sort_keys=sort_keys)
+    content = serialize_json_to_string(root)
 
     with open(to_file, 'w') as file_contents:
         file_contents.write(content)


### PR DESCRIPTION
The `sort_keys` argument was vestigial from when we were iterating on the development.  It won't be present in the C++ api, so I'm removing it from the API with this PR.