### PR TITLE
fix an error in the schemadef plugin tutorial

### DIFF
--- a/docs/tutorials/write-a-schemadef.md
+++ b/docs/tutorials/write-a-schemadef.md
@@ -74,7 +74,7 @@ Then you must add it to a plugin manifest:
     "OTIO_SCHEMA" : "PluginManifest.1",
     "schemadefs" : [
         {
-            "OTIO_SCHEMA" : "MyThing.1",
+            "OTIO_SCHEMA" : "SchemaDef.1",
             "name" : "mything",
             "execution_scope" : "in process",
             "filepath" : "mything.py"


### PR DESCRIPTION
This fixes issue #379.  A critical change to one string in the plugin manifest example.
