### PR TITLE
Add adapter arg commandline argument to otiocat and otioconvert.

### DIFF
--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -27,6 +27,7 @@
 
 import argparse
 import ast
+import sys
 
 import opentimelineio as otio
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -65,7 +65,7 @@ class OTIOStatTest(ConsoleTester, unittest.TestCase):
 
 class OTIOCatTests(ConsoleTester, unittest.TestCase):
     def test_basic(self):
-        sys.argv = ['otiocat', SCREENING_EXAMPLE_PATH]
+        sys.argv = ['otiocat', SCREENING_EXAMPLE_PATH, "-a", "rate=24.0"]
         otio.console.otiocat.main()
         self.assertIn('"name": "Example_Screening.01",', sys.stdout.getvalue())
 
@@ -77,7 +77,8 @@ class OTIOConvertTests(unittest.TestCase):
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', tf.name,
-                '-O', 'otio_json'
+                '-O', 'otio_json',
+                "-a", "rate=24",
             ]
             otio.console.otioconvert.main()
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -69,6 +69,11 @@ class OTIOCatTests(ConsoleTester, unittest.TestCase):
         otio.console.otiocat.main()
         self.assertIn('"name": "Example_Screening.01",', sys.stdout.getvalue())
 
+    def test_no_media_linker(self):
+        sys.argv = ['otiocat', SCREENING_EXAMPLE_PATH, "-m", "none"]
+        otio.console.otiocat.main()
+        self.assertIn('"name": "Example_Screening.01",', sys.stdout.getvalue())
+
 
 class OTIOConvertTests(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
Turns out it was only added to otioview.  Now its present in `otiocat` and `otioconvert`.  You can use it like this:
```otiocat opentimelineio_contrib/adapters/tests/sample_data/simple.aaf -a simplify=False```