### PR TITLE
Fixing misspelling typo in docs

### DIFF
--- a/docs/tutorials/architecture.md
+++ b/docs/tutorials/architecture.md
@@ -31,7 +31,7 @@ Additionally, for developers integrating OTIO into a studio pipeline:
 
 ## otio.schema
 
-The in-memory OTIO representation data model is rooted at an `otio.shema.Timeline` which has a member `.tracks` which is a `otio.schema.Stack` of `otio.schema.Sequences`, which contain either `otio.schema.Clip` or `otio.shema.Gap`.  The `otio.schema.Clip` objects can reference media through a `otio.media_reference.External` or indicate that they are missing a reference to real media with a `otio.media_reference.MissingReference`.  All objects have a metadata dictionary for blind data.
+The in-memory OTIO representation data model is rooted at an `otio.schema.Timeline` which has a member `.tracks` which is a `otio.schema.Stack` of `otio.schema.Sequences`, which contain either `otio.schema.Clip` or `otio.schema.Gap`.  The `otio.schema.Clip` objects can reference media through a `otio.media_reference.External` or indicate that they are missing a reference to real media with a `otio.media_reference.MissingReference`.  All objects have a metadata dictionary for blind data.
 
 Schema composition objects (`otio.schema.Stack` and `otio.schema.Sequence`) implement the python mutable sequence API.  A simple script that prints out each shot might look like:
 


### PR DESCRIPTION
Was reading the help guide (https://opentimelineio.readthedocs.io/en/latest/index.html) and there was a misspelling of the word "schema" as "shema".