### PR TITLE
Hide deserialization methods of SerizableObject

### DIFF
--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -424,7 +424,7 @@ class Composition(item.Item, collections.MutableSequence):
         return child_range
 
     # @{ SerializableObject override.
-    def update(self, d):
+    def _update(self, d):
         """Like the dictionary .update() method.
 
         Update the data dictionary of this SerializableObject with the .data
@@ -432,7 +432,7 @@ class Composition(item.Item, collections.MutableSequence):
         """
 
         # use the parent update function
-        super(Composition, self).update(d)
+        super(Composition, self)._update(d)
 
         # ...except for the 'children' field, which needs to run through the
         # insert method so that _parent pointers are correctly set on children.

--- a/opentimelineio/core/json_serializer.py
+++ b/opentimelineio/core/json_serializer.py
@@ -92,7 +92,7 @@ def _encoded_serializable_object(input_otio):
     result = {
         "OTIO_SCHEMA": input_otio._serializable_label,
     }
-    result.update(input_otio.data)
+    result.update(input_otio._data)
     return result
 
 

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -60,8 +60,8 @@ class SerializableObject(object):
     >>>         old_child_data_name = otio.core.deprecated_field()
 
     >>>    @otio.core.upgrade_function_for(ExampleChild, 3)
-    ...    def upgrade_child_to_three(data):
-    ...        return {"child_data" : data["old_child_data_name"]}
+    ...    def upgrade_child_to_three(_data):
+    ...        return {"child_data" : _data["old_child_data_name"]}
     """
 
     # Every child must define a _serializable_label attribute.
@@ -73,7 +73,7 @@ class SerializableObject(object):
     _class_path = "core.SerializableObject"
 
     def __init__(self):
-        self.data = {}
+        self._data = {}
 
     # @{ "Reference Type" semantics for SerializableObject
     # We think of the SerializableObject as a reference type - by default
@@ -89,7 +89,7 @@ class SerializableObject(object):
         """Returns true if the contents of self and other match."""
 
         try:
-            if self.data == other.data:
+            if self._data == other._data:
                 return True
 
             # XXX: Gross hack takes OTIO->JSON String->Python Dictionaries
@@ -119,14 +119,14 @@ class SerializableObject(object):
     def update(self, d):
         """Like the dictionary .update() method.
 
-        Update the data dictionary of this SerializableObject with the .data
+        Update the _data dictionary of this SerializableObject with the ._data
         of d if d is a SerializableObject or if d is a dictionary, d itself.
         """
 
         if isinstance(d, SerializableObject):
-            self.data.update(d.data)
+            self._data.update(d._data)
         else:
-            self.data.update(d)
+            self._data.update(d)
 
     @classmethod
     def schema_name(cls):
@@ -148,7 +148,7 @@ class SerializableObject(object):
 
     def __copy__(self):
         result = self.__class__()
-        result.data = copy.copy(self.data)
+        result._data = copy.copy(self._data)
 
         return result
 
@@ -157,7 +157,7 @@ class SerializableObject(object):
 
     def __deepcopy__(self, md):
         result = type(self)()
-        result.data = copy.deepcopy(self.data, md)
+        result._data = copy.deepcopy(self._data, md)
 
         return result
 
@@ -192,7 +192,7 @@ def serializable_field(name, required_type=None, doc=None):
     """
 
     def getter(self):
-        return self.data[name]
+        return self._data[name]
 
     def setter(self, val):
         # always allow None values regardless of value of required_type
@@ -206,7 +206,7 @@ def serializable_field(name, required_type=None, doc=None):
                     )
                 )
 
-        self.data[name] = val
+        self._data[name] = val
 
     return property(getter, setter, doc=doc)
 

--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -116,7 +116,7 @@ class SerializableObject(object):
             return False
     # @}
 
-    def update(self, d):
+    def _update(self, d):
         """Like the dictionary .update() method.
 
         Update the _data dictionary of this SerializableObject with the ._data

--- a/opentimelineio/core/type_registry.py
+++ b/opentimelineio/core/type_registry.py
@@ -147,6 +147,6 @@ def instance_from_schema(schema_name, schema_version, data_dict):
             data_dict = upgrade_func(data_dict)
 
     obj = cls()
-    obj.update(data_dict)
+    obj._update(data_dict)
 
     return obj

--- a/opentimelineio/core/unknown_schema.py
+++ b/opentimelineio/core/unknown_schema.py
@@ -41,3 +41,10 @@ class UnknownSchema(SerializableObject):
     @property
     def is_unknown_schema(self):
         return True
+
+    @property
+    def data(self):
+        """Exposes the data dictionary of the underlying SerializableObject
+        directly.
+        """
+        return self._data

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -56,11 +56,11 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_update(self):
         so = otio.core.SerializableObject()
-        so.update({"foo": "bar"})
+        so._update({"foo": "bar"})
         self.assertEqual(so._data["foo"], "bar")
         so_2 = otio.core.SerializableObject()
         so_2._data["foo"] = "not bar"
-        so.update(so_2)
+        so._update(so_2)
         self.assertEqual(so._data["foo"], "not bar")
 
     def test_serialize_to_error(self):

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -51,38 +51,38 @@ class OpenTimeTypeSerializerTest(unittest.TestCase):
 class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
     def test_cons(self):
         so = otio.core.SerializableObject()
-        so.data['foo'] = 'bar'
-        self.assertEqual(so.data['foo'], 'bar')
+        so._data['foo'] = 'bar'
+        self.assertEqual(so._data['foo'], 'bar')
 
     def test_update(self):
         so = otio.core.SerializableObject()
         so.update({"foo": "bar"})
-        self.assertEqual(so.data["foo"], "bar")
+        self.assertEqual(so._data["foo"], "bar")
         so_2 = otio.core.SerializableObject()
-        so_2.data["foo"] = "not bar"
+        so_2._data["foo"] = "not bar"
         so.update(so_2)
-        self.assertEqual(so.data["foo"], "not bar")
+        self.assertEqual(so._data["foo"], "not bar")
 
     def test_serialize_to_error(self):
         so = otio.core.SerializableObject()
-        so.data['foo'] = 'bar'
+        so._data['foo'] = 'bar'
         with self.assertRaises(otio.exceptions.InvalidSerializableLabelError):
             otio.adapters.otio_json.write_to_string(so)
 
     def test_copy_lib(self):
         so = otio.core.SerializableObject()
-        so.data["metadata"] = {"foo": "bar"}
+        so._data["meta_data"] = {"foo": "bar"}
 
         import copy
 
         # shallow copy
         so_cp = copy.copy(so)
-        so_cp.data["metadata"]["foo"] = "not bar"
-        self.assertEqual(so.data, so_cp.data)
+        so_cp._data["meta_data"]["foo"] = "not bar"
+        self.assertEqual(so._data, so_cp._data)
 
         so.foo = "bar"
         so_cp = copy.copy(so)
-        # copy only copies members of the data dictionary, *not* other attrs.
+        # copy only copies members of the _data dictionary, *not* other attrs.
         with self.assertRaises(AttributeError):
             so_cp.foo
 
@@ -90,7 +90,7 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         so_cp = copy.deepcopy(so)
         self.assertIsOTIOEquivalentTo(so, so_cp)
 
-        so_cp.data["foo"] = "bar"
+        so_cp._data["foo"] = "bar"
         self.assertNotEqual(so, so_cp)
 
     def test_copy_subclass(self):
@@ -99,7 +99,7 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             _serializable_label = "Foo.1"
 
         foo = Foo()
-        foo.data["metadata"] = {"foo": "bar"}
+        foo._data["meta_data"] = {"foo": "bar"}
 
         import copy
 
@@ -125,7 +125,7 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             )
 
         ft = otio.core.instance_from_schema("Stuff", "1", {"foo": "bar"})
-        self.assertEqual(ft.data['foo'], "bar")
+        self.assertEqual(ft._data['foo'], "bar")
 
         @otio.core.register_type
         class FakeThing(otio.core.SerializableObject):
@@ -133,21 +133,21 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             foo_two = otio.core.serializable_field("foo_2")
 
         @otio.core.upgrade_function_for(FakeThing, 2)
-        def upgrade_one_to_two(data_dict):
-            return {"foo_2": data_dict["foo"]}
+        def upgrade_one_to_two(_data_dict):
+            return {"foo_2": _data_dict["foo"]}
 
         @otio.core.upgrade_function_for(FakeThing, 3)
-        def upgrade_one_to_two_three(data_dict):
-            return {"foo_3": data_dict["foo_2"]}
+        def upgrade_one_to_two_three(_data_dict):
+            return {"foo_3": _data_dict["foo_2"]}
 
         ft = otio.core.instance_from_schema("Stuff", "1", {"foo": "bar"})
-        self.assertEqual(ft.data['foo_3'], "bar")
+        self.assertEqual(ft._data['foo_3'], "bar")
 
         ft = otio.core.instance_from_schema("Stuff", "3", {"foo_2": "bar"})
-        self.assertEqual(ft.data['foo_3'], "bar")
+        self.assertEqual(ft._data['foo_3'], "bar")
 
         ft = otio.core.instance_from_schema("Stuff", "4", {"foo_3": "bar"})
-        self.assertEqual(ft.data['foo_3'], "bar")
+        self.assertEqual(ft._data['foo_3'], "bar")
 
     def test_equality(self):
         o1 = otio.core.SerializableObject()


### PR DESCRIPTION
We exposed the `data` dictionary (really the backing of `SerializableObject`), but since that is likely to change in the C++ version, this hides that.  We're also hiding the `.update()` method, since it only seems to be used by internal implementation details that are also likely to change in the C++ version.