### PR TITLE
Better dependency reporting for `pip` and `setuptools`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -239,7 +239,7 @@ setup(
             'tox>=3.0',
         ],
         'view': [
-            'PySide2>=5.11'
+            'PySide2~=5.11'
         ]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if (
     print(
         "Your setuptools version is: '{}', OpenTimelineIO requires at least "
         "version '{}'.  Please update setuptools by running: "
-        "pip install -u setuptools".format(
+        "pip install -U setuptools".format(
             SETUPTOOLS_VERSION,
             REQUIRED_SETUPTOOLS_VERSION,
         )

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,10 @@ if (
         distutils.version.StrictVersion(PIP_VERSION)
         <= distutils.version.StrictVersion(REQUIRED_PIP_VERSION)
 ):
-    print(
+    sys.stderr.write(
         "Your pip version is: '{}', OpenTimelineIO requires at least "
-        "version '{}'.  Please update setuptools by running: "
-        "pip install -U pip".format(
+        "version '{}'.  Please update pip by running:\n"
+        "pip install -U pip\n".format(
             PIP_VERSION,
             REQUIRED_PIP_VERSION,
         )
@@ -64,10 +64,10 @@ if (
     distutils.version.StrictVersion(SETUPTOOLS_VERSION)
     <= distutils.version.StrictVersion(REQUIRED_SETUPTOOLS_VERSION)
 ):
-    print(
+    sys.stderr.write(
         "Your setuptools version is: '{}', OpenTimelineIO requires at least "
-        "version '{}'.  Please update setuptools by running: "
-        "pip install -U setuptools".format(
+        "version '{}'.  Please update setuptools by running:\n"
+        "pip install -U setuptools\n".format(
             SETUPTOOLS_VERSION,
             REQUIRED_SETUPTOOLS_VERSION,
         )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ try:
 except ImportError:
     SETUPTOOLS_VERSION = setuptools.__version__
 
-REQUIRED_SETUPTOOLS_VERSION = '38.3.0'
+REQUIRED_SETUPTOOLS_VERSION = '20.5.0'
 if (
     distutils.version.StrictVersion(SETUPTOOLS_VERSION)
     <= distutils.version.StrictVersion(REQUIRED_SETUPTOOLS_VERSION)

--- a/setup.py
+++ b/setup.py
@@ -218,18 +218,20 @@ setup(
     },
     extras_require={
         'dev': [
-            'flake8==3.5',
-            'coverage==4.5',
-            'tox==3.0',
+            'flake8>=3.5',
+            'coverage>=4.5',
+            'tox>=3.0',
         ],
         'view': [
-            'PySide2==5.11'
+            'PySide2>=5.11'
         ]
     },
 
     test_suite='setup.test_otio',
 
-    tests_require=['mock;python_version<"3.3"'],
+    tests_require=[
+            'mock;python_version<"3.3"',
+    ],
 
     # because we need to open() the adapters manifest, we aren't zip-safe
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,25 @@ import unittest
 from setuptools import setup
 import setuptools.command.build_py
 import distutils.version
+import pip
+
+
+# Make sure the environment contains an up to date enough version of pip.
+PIP_VERSION = pip.__version__
+REQUIRED_PIP_VERSION = "6.0.0"
+if (
+        distutils.version.StrictVersion(PIP_VERSION)
+        <= distutils.version.StrictVersion(REQUIRED_PIP_VERSION)
+):
+    print(
+        "Your pip version is: '{}', OpenTimelineIO requires at least "
+        "version '{}'.  Please update setuptools by running: "
+        "pip install -U pip".format(
+            PIP_VERSION,
+            REQUIRED_PIP_VERSION,
+        )
+    )
+    sys.exit(1)
 
 
 # Make sure the environment contains an up to date enough version of setuptools.
@@ -54,9 +73,6 @@ if (
         )
     )
     sys.exit(1)
-
-
-
 
 
 # check the python version first

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,33 @@ import sys
 import unittest
 from setuptools import setup
 import setuptools.command.build_py
+import distutils.version
+
+
+# Make sure the environment contains an up to date enough version of setuptools.
+try:
+    import setuptools.version
+    SETUPTOOLS_VERSION = setuptools.version.__version__
+except ImportError:
+    SETUPTOOLS_VERSION = setuptools.__version__
+
+REQUIRED_SETUPTOOLS_VERSION = '38.3.0'
+if (
+    distutils.version.StrictVersion(SETUPTOOLS_VERSION)
+    <= distutils.version.StrictVersion(REQUIRED_SETUPTOOLS_VERSION)
+):
+    print(
+        "Your setuptools version is: '{}', OpenTimelineIO requires at least "
+        "version '{}'.  Please update setuptools by running: "
+        "pip install -u setuptools".format(
+            SETUPTOOLS_VERSION,
+            REQUIRED_SETUPTOOLS_VERSION,
+        )
+    )
+    sys.exit(1)
+
+
+
 
 
 # check the python version first


### PR DESCRIPTION
We depend on relatively modern features inside the pip and setuptools libraries.  Ironically, `pip` and `setuptools` don't provide great tools for catching this and reporting this.  

- Require `pip` version of at least 6.0
- Require `setuptools` version of at least 20.5.0
- Also make the dev dependencies floating (`>=` rather than pinned to a specific version `==`)

Definitely open to comments on this.  Is this a harsh requirement on folks?  VFX Platform doesn't specify a `pip` or `setuptools` version, but it probably should.