### PR TITLE
Moving already parented item is an error

### DIFF
--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -94,13 +94,13 @@ class Composable(serializable_object.SerializableObject):
         return self._parent() if self._parent is not None else None
 
     def _set_parent(self, new_parent):
-        if new_parent is not None and self._parent is not None:
+        if new_parent is not None and self.parent() is not None:
             raise ValueError(
                 "Composable named '{}' is already in a composition named '{}',"
                 " remove from previous parent before adding to new one."
                 " Composable: {}, Composition: {}".format(
                     self.name,
-                    self.parent().name,
+                    self.parent() is not None and self.parent().name or None,
                     self,
                     self.parent()
                 )

--- a/opentimelineio/core/composable.py
+++ b/opentimelineio/core/composable.py
@@ -94,6 +94,17 @@ class Composable(serializable_object.SerializableObject):
         return self._parent() if self._parent is not None else None
 
     def _set_parent(self, new_parent):
+        if new_parent is not None and self._parent is not None:
+            raise ValueError(
+                "Composable named '{}' is already in a composition named '{}',"
+                " remove from previous parent before adding to new one."
+                " Composable: {}, Composition: {}".format(
+                    self.name,
+                    self.parent().name,
+                    self,
+                    self.parent()
+                )
+            )
         self._parent = weakref.ref(new_parent) if new_parent is not None else None
 
     def is_parent_of(self, other):

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -371,7 +371,7 @@ class Composition(item.Item, collections.MutableSequence):
             result_range.start_time += parent_range.start_time
             current = parent
 
-        if not self.source_range or not result_range:
+        if not self.source_range:
             return result_range
 
         new_start_time = max(

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -88,17 +88,6 @@ class Composition(item.Item, collections.MutableSequence):
         "Items contained by this composition."
     )
 
-    def __del__(self):
-        # remove parent pointer on all the children
-        for c in self._children:
-            c._set_parent(None)
-            if c._parent is not None:
-                raise RuntimeError("Child still has a parent")
-            print c.parent()
-        del self._children[:]
-        print "here"
-
-
     @property
     def composition_kind(self):
         """Returns a label specifying the kind of composition."""

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -88,6 +88,17 @@ class Composition(item.Item, collections.MutableSequence):
         "Items contained by this composition."
     )
 
+    def __del__(self):
+        # remove parent pointer on all the children
+        for c in self._children:
+            c._set_parent(None)
+            if c._parent is not None:
+                raise RuntimeError("Child still has a parent")
+            print c.parent()
+        del self._children[:]
+        print "here"
+
+
     @property
     def composition_kind(self):
         """Returns a label specifying the kind of composition."""
@@ -371,7 +382,7 @@ class Composition(item.Item, collections.MutableSequence):
             result_range.start_time += parent_range.start_time
             current = parent
 
-        if not self.source_range:
+        if not self.source_range or not result_range:
             return result_range
 
         new_start_time = max(

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -135,12 +135,12 @@ def _extract_start_timecode(mob):
     """Given a mob with a single timecode slot, return the timecode in that
     slot or None if no timecode slots could be found.
     """
-    
+
     tc_list = []
     for s in mob.slots():
         if s.segment.media_kind != 'Timecode':
             continue
-        
+
         if s.segment.get('Start'):
             tc_list.append(s.segment.get('Start').value)
 

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -693,7 +693,10 @@ def _simplify(thing):
                 ):
                     # Pull the child's children into the parent
                     num = len(child)
-                    thing[c:c + 1] = child[:]
+                    children_of_child = child[:]
+                    # clear out the ownership of 'child'
+                    del child[:]
+                    thing[c:c + 1] = children_of_child
 
                     # TODO: We may be discarding metadata, should we merge it?
                     # TODO: Do we need to offset the markers in time?

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -89,5 +89,9 @@ class ComposableTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         # change seqi
         seqi_3 = otio.core.Composable()
+        with self.assertRaises(ValueError):
+            seqi_2._set_parent(seqi_3)
+        # remove it from other object
+        seqi_2._set_parent(None)
         seqi_2._set_parent(seqi_3)
         self.assertEqual(seqi_3, seqi_2.parent())

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -695,8 +695,8 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_delete_parent_container(self):
         # deleting the parent container should null out the parent pointer
-        sq = otio.schema.Track(children=[otio.core.Item()])
-        it = sq[0]
+        it = otio.core.Item()
+        sq = otio.schema.Track(children=[it])
         del sq
         self.assertIsNone(it.parent())
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -707,6 +707,9 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         sq = otio.schema.Track(children=[it])
         self.assertEqual(sq.range_of_child_at_index(0), tr)
 
+        # It is an error to add an item to composition if it is already in
+        # another composition.  This clears out the old test composition
+        # (and also clears out its parent pointers).
         del sq
         sq = otio.schema.Track(
             children=[it, it.copy(), it.copy(), it.copy()],

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 #
 # Copyright 2017 Pixar Animation Studios
@@ -122,6 +123,19 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         co = otio.core.Composition(children=[it])
         self.assertIs(it.parent(), co)
 
+    def test_move_child(self):
+        it = otio.core.Item()
+        co = otio.core.Composition(children=[it])
+        self.assertIs(it.parent(), co)
+
+        co2 = otio.core.Composition()
+        with self.assertRaises(ValueError):
+            co2.append(it)
+
+        del co[0]
+        co2.append(it)
+        self.assertIs(it.parent(), co2)
+
     def test_each_child_recursion(self):
         tl = otio.schema.Timeline(name="TL")
 
@@ -185,6 +199,38 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             [tr1, c1, c2, c3, tr2, c4, c5, st, c6, tr3, c7, c8],
             all_children
         )
+
+    def test_remove_actually_removes(self):
+        """Test that removed item is no longer 'in' composition."""
+        tr = otio.schema.Track()
+        cl = otio.schema.Clip()
+
+        # test inclusion
+        tr.append(cl)
+        self.assertIn(cl, tr)
+
+        # delete by index
+        del tr[0]
+        self.assertNotIn(cl, tr)
+
+        # delete by slice
+        tr = otio.schema.Track()
+        tr.append(cl)
+        del tr[:]
+        self.assertNotIn(cl, tr)
+
+        # delete by setting over item
+        tr = otio.schema.Track()
+        tr.append(cl)
+        cl2 = otio.schema.Clip()
+        tr[0] = cl2
+        self.assertNotIn(cl, tr)
+
+        # delete by pop
+        tr = otio.schema.Track()
+        tr.insert(0, cl)
+        tr.pop()
+        self.assertNotIn(cl, tr)
 
 
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
@@ -647,6 +693,13 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             sq[1:] = [it, copy.deepcopy(it)]
         self.assertEqual(len(sq), 2)
 
+    def test_delete_parent_container(self):
+        # deleting the parent container should null out the parent pointer
+        sq = otio.schema.Track(children=[otio.core.Item()])
+        it = sq[0]
+        del sq
+        self.assertIsNone(it.parent())
+
     def test_range(self):
         length = otio.opentime.RationalTime(5, 1)
         tr = otio.opentime.TimeRange(otio.opentime.RationalTime(), length)
@@ -654,6 +707,7 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         sq = otio.schema.Track(children=[it])
         self.assertEqual(sq.range_of_child_at_index(0), tr)
 
+        del sq
         sq = otio.schema.Track(
             children=[it, it.copy(), it.copy(), it.copy()],
         )

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -339,6 +339,7 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             self.trackZ[:]
         )
 
+        del stack
         stack = otio.schema.Stack(children=[
             self.trackZ,
             self.trackABC
@@ -362,6 +363,8 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertIsNot(flat_track[1], self.trackABC[1])
         self.assertIsNot(flat_track[2], self.trackDgE[2])
 
+        # create a new stack out of the old parts, delete the old stack first
+        del stack
         stack = otio.schema.Stack(children=[
             self.trackABC,
             self.trackgFg
@@ -391,6 +394,7 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
         self.assertIsOTIOEquivalentTo(flat_track[2], self.trackDgE[2])
 
+        del stack
         stack = otio.schema.Stack(children=[
             self.trackZ,
             self.trackgFg

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -339,11 +339,16 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             self.trackZ[:]
         )
 
+        # It is an error to add an item to composition if it is already in
+        # another composition.  This clears out the old test composition
+        # (and also clears out its parent pointers).
         del stack
-        stack = otio.schema.Stack(children=[
-            self.trackZ,
-            self.trackABC
-        ])
+        stack = otio.schema.Stack(
+            children=[
+                self.trackZ,
+                self.trackABC,
+            ]
+        )
         flat_track = otio.algorithms.flatten_stack(stack)
         self.assertJsonEqual(
             flat_track[:],


### PR DESCRIPTION
If you have an item whose `.parent()` is not `None`, it is now a ValueError to add it to another composition.  You need to remove it from the other composition before adding it to the new one.  This is to anticipate an implementation detail of the C++ API.