### PR TITLE
Remove the copy() method and make __copy__ an error.

### DIFF
--- a/opentimelineio/core/serializable_object.py
+++ b/opentimelineio/core/serializable_object.py
@@ -147,13 +147,9 @@ class SerializableObject(object):
         return False
 
     def __copy__(self):
-        result = self.__class__()
-        result._data = copy.copy(self._data)
-
-        return result
-
-    def copy(self):
-        return self.__copy__()
+        raise NotImplementedError(
+            "Shallow copying is not permitted.  Use a deep copy."
+        )
 
     def __deepcopy__(self, md):
         result = type(self)()

--- a/opentimelineio_contrib/adapters/hls_playlist.py
+++ b/opentimelineio_contrib/adapters/hls_playlist.py
@@ -58,7 +58,7 @@ In general, you can author otio as follows:
     )
 
     # Make a copy of the media ref specifying the byte range for the fragment
-    media_ref1 = fragmented_media_ref.copy()
+    media_ref1 = fragmented_media_ref.deepcopy()
     media_ref1.available_range=otio.opentime.TimeRange(
         otio.opentime.RationalTime(0, 1),
         otio.opentime.RationalTime(2.002, 1)

--- a/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
@@ -145,7 +145,7 @@ class HLSPMedialaylistAdapterTest(unittest.TestCase):
 
         # Make a copy of the media ref specifying the byte range for the
         # segment
-        media_ref1 = segmented_media_ref.copy()
+        media_ref1 = segmented_media_ref.deepcopy()
         media_ref1.available_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0, 1),
             otio.opentime.RationalTime(2.002, 1)
@@ -677,7 +677,7 @@ class HLSPMasterPlaylistAdapterTest(unittest.TestCase):
 
         # Make a copy of the media ref specifying the byte range for the
         # segment
-        media_ref1 = segmented_media_ref.copy()
+        media_ref1 = segmented_media_ref.deepcopy()
         media_ref1.available_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(0, 1),
             otio.opentime.RationalTime(2.002, 1)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -655,7 +655,7 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertEqual(sq.range_of_child_at_index(0), tr)
 
         sq = otio.schema.Track(
-            children=[it, it.copy(), it.copy(), it.copy()],
+            children=[it, it.deepcopy(), it.deepcopy(), it.deepcopy()],
         )
         self.assertEqual(
             sq.range_of_child_at_index(index=1),
@@ -893,11 +893,7 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
             ]
         )
 
-        #  Subtle point, but copy() of a Track returns a new Track with a copy
-        #  of all of its metadata, but not of its children.  To get that you
-        #  need to deepcopy().
         self.assertEqual(len(track), 3)
-        self.assertEqual(len(track.copy()), 0)
         self.assertEqual(len(track.deepcopy()), 3)
 
         # make a nested track with 3 sub-tracks, each with 3 clips

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -313,16 +313,6 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             )
         )
 
-        it_copy = it.copy()
-        self.assertIsOTIOEquivalentTo(it, it_copy)
-        it.metadata["foo"] = "bar2"
-        # shallow copy, should change both dictionaries
-        self.assertEqual(it_copy.metadata["foo"], "bar2")
-
-        # name should be different
-        it.name = "foo"
-        self.assertNotEqual(it_copy.name, it.name)
-
         # deep copy should have different dictionaries
         it_dcopy = it.deepcopy()
         it_dcopy.metadata["foo"] = "not bar"
@@ -351,17 +341,7 @@ class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             )
         )
 
-        # shallow test
         import copy
-        it_copy = copy.copy(it)
-        self.assertIsOTIOEquivalentTo(it, it_copy)
-        it.metadata["foo"] = "bar2"
-        # shallow copy, should change both dictionaries
-        self.assertEqual(it_copy.metadata["foo"], "bar2")
-
-        # name should be different
-        it.name = "foo"
-        self.assertNotEqual(it_copy.name, it.name)
 
         # deep copy should have different dictionaries
         it_dcopy = copy.deepcopy(it)

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -75,16 +75,9 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         import copy
 
-        # shallow copy
-        so_cp = copy.copy(so)
-        so_cp._data["meta_data"]["foo"] = "not bar"
-        self.assertEqual(so._data, so_cp._data)
-
-        so.foo = "bar"
-        so_cp = copy.copy(so)
-        # copy only copies members of the _data dictionary, *not* other attrs.
-        with self.assertRaises(AttributeError):
-            so_cp.foo
+        # shallow copy is an error
+        with self.assertRaises(NotImplementedError):
+            so_cp = copy.copy(so)
 
         # deep copy
         so_cp = copy.deepcopy(so)
@@ -103,7 +96,10 @@ class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         import copy
 
-        foo_copy = copy.copy(foo)
+        with self.assertRaises(NotImplementedError):
+            foo_copy = copy.copy(foo)
+
+        foo_copy = copy.deepcopy(foo)
 
         self.assertEqual(Foo, type(foo_copy))
 

--- a/tests/test_track_algo.py
+++ b/tests/test_track_algo.py
@@ -78,7 +78,7 @@ class TransitionExpansionTests(unittest.TestCase):
         seq.append(trx)
         cl_2 = copy.deepcopy(cl)
         cl_2.name = name + "_post"
-        seq.append(copy.copy(cl))
+        seq.append(copy.deepcopy(cl))
 
         pre_duration = copy.deepcopy(seq[0].source_range.duration)
 


### PR DESCRIPTION
Again, anticipating the C++ implementation, we are removing the shallow copy function.  It doesn't look like anyone in the code base was using it.