### PR TITLE
Add test and fix for trimmed_range_in_parent when the item is trimmed out

### DIFF
--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -371,7 +371,7 @@ class Composition(item.Item, collections.MutableSequence):
             result_range.start_time += parent_range.start_time
             current = parent
 
-        if not self.source_range:
+        if not self.source_range or not result_range:
             return result_range
 
         new_start_time = max(

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -847,6 +847,70 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         with self.assertRaises(otio.exceptions.NotAChildError):
             otio.schema.Clip().trimmed_range_in_parent()
 
+    def test_range_trimmed_out(self):
+        track = otio.schema.Track(
+            name="top_track",
+            children=[
+                otio.schema.Clip(
+                    name="clip1",
+                    source_range=otio.opentime.TimeRange(
+                        start_time=otio.opentime.RationalTime(
+                            value=100,
+                            rate=24
+                        ),
+                        duration=otio.opentime.RationalTime(
+                            value=50,
+                            rate=24
+                        )
+                    )
+                ),
+                otio.schema.Clip(
+                    name="clip2",
+                    source_range=otio.opentime.TimeRange(
+                        start_time=otio.opentime.RationalTime(
+                            value=101,
+                            rate=24
+                        ),
+                        duration=otio.opentime.RationalTime(
+                            value=50,
+                            rate=24
+                        )
+                    )
+                ),
+            ],
+            # should trim out clip 1
+            source_range=otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(60, 24),
+                duration=otio.opentime.RationalTime(10, 24)
+            )
+        )
+
+        # should be trimmed out, at the moment, the sentinel for that is None
+        nothing = track.trimmed_range_of_child_at_index(0)
+        self.assertIsNone(nothing)
+
+        # should the same as above
+        nothing = track[0].trimmed_range_in_parent()
+        self.assertIsNone(nothing)
+
+        not_nothing = track.trimmed_range_of_child_at_index(1)
+        self.assertEqual(not_nothing, track.source_range)
+
+        # should trim out second clip
+        track.source_range = otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(0, 24),
+            duration=otio.opentime.RationalTime(10, 24)
+        )
+
+        nothing = track.trimmed_range_of_child_at_index(1)
+        self.assertIsNone(nothing)
+
+        nothing = track[1].trimmed_range_in_parent()
+        self.assertIsNone(nothing)
+
+        not_nothing = track.trimmed_range_of_child_at_index(0)
+        self.assertEqual(not_nothing, track.source_range)
+
     def test_range_nested(self):
         track = otio.schema.Track(
             name="inner",


### PR DESCRIPTION
There was a bug in `trimmed_range_in_parent` that was causing a crash when the item was trimmed out of the parent.  Now it correctly returns `None` and has a unit test for this.