### PR TITLE
Optimize `each_child` when used with the `search_range` option

### DIFF
--- a/opentimelineio/algorithms/__init__.py
+++ b/opentimelineio/algorithms/__init__.py
@@ -31,7 +31,8 @@ from .track_algo import (
 )
 
 from .stack_algo import (
-    flatten_stack
+    flatten_stack,
+    top_clip_at_time,
 )
 
 from .filter import (

--- a/opentimelineio/algorithms/stack_algo.py
+++ b/opentimelineio/algorithms/stack_algo.py
@@ -58,11 +58,11 @@ def top_clip_at_time(in_stack, t):
 
     # build a range to use the `each_child`method.
     search_range = opentime.TimeRange(
-        start_time = t,
+        start_time=t,
         # 0 duration so we are just sampling a point in time.
         # XXX Should this duration be equal to the length of one sample?
         #     opentime.RationalTime(1, rate)?
-        duration = opentime.RationalTime(0, t.rate)
+        duration=opentime.RationalTime(0, t.rate)
     )
 
     # walk through the children of the stack in reverse order.
@@ -80,6 +80,7 @@ def top_clip_at_time(in_stack, t):
             return result
 
     return None
+
 
 def flatten_stack(in_stack):
     """Flatten a Stack, or a list of Tracks, into a single Track.

--- a/opentimelineio/algorithms/stack_algo.py
+++ b/opentimelineio/algorithms/stack_algo.py
@@ -35,6 +35,52 @@ from . import (
 )
 
 
+def top_clip_at_time(in_stack, t):
+    """Return the topmost visible child that overlaps with time t.
+
+    Example:
+    tr1: G1, A, G2
+    tr2: [B------]
+    G1, and G2 are gaps, A and B are clips.
+
+    If t is within A, a will be returned.  If t is within G1 or G2, B will be
+    returned.
+    """
+
+    # ensure that it only runs on stacks
+    if not isinstance(in_stack, schema.Stack):
+        raise ValueError(
+            "Argument in_stack must be of type otio.schema.Stack, "
+            "not: '{}'".format(
+                type(in_stack)
+            )
+        )
+
+    # build a range to use the `each_child`method.
+    search_range = opentime.TimeRange(
+        start_time = t,
+        # 0 duration so we are just sampling a point in time.
+        # XXX Should this duration be equal to the length of one sample?
+        #     opentime.RationalTime(1, rate)?
+        duration = opentime.RationalTime(0, t.rate)
+    )
+
+    # walk through the children of the stack in reverse order.
+    for track in reversed(in_stack):
+        valid_results = []
+        if hasattr(track, "each_child"):
+            valid_results = list(
+                c for c in track.each_clip(search_range, shallow_search=True)
+                if c.visible()
+            )
+
+        # XXX doesn't handle nested tracks/stacks at the moment
+
+        for result in valid_results:
+            return result
+
+    return None
+
 def flatten_stack(in_stack):
     """Flatten a Stack, or a list of Tracks, into a single Track.
     Note that the 1st Track is the bottom one, and the last is the top.

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -98,14 +98,15 @@ def _bisect_left(
         upper_search_bound = len(seq)
 
     while lower_search_bound < upper_search_bound:
-        midpoint_index = (lower_search_bound+upper_search_bound)//2
+        midpoint_index = (lower_search_bound + upper_search_bound)//2
 
         if key_func(seq[midpoint_index]) < tgt:
-            lower_search_bound = midpoint_index+1
+            lower_search_bound = midpoint_index + 1
         else:
             upper_search_bound = midpoint_index
 
     return lower_search_bound
+
 
 @type_registry.register_type
 class Composition(item.Item, collections.MutableSequence):
@@ -198,7 +199,7 @@ class Composition(item.Item, collections.MutableSequence):
         if search_range:
             range_map = self.range_of_all_children()
 
-            # find the first item whose end_time_inclusive is after the 
+            # find the first item whose end_time_inclusive is after the
             # start_time of the search range
             first_inside_range = _bisect_left(
                 seq=self._children,
@@ -206,7 +207,7 @@ class Composition(item.Item, collections.MutableSequence):
                 key_func=lambda child: range_map[child].end_time_inclusive(),
             )
 
-            # find the last item whose start_time is before the 
+            # find the last item whose start_time is before the
             # end_time_inclusive of the search_range
             last_in_range = _bisect_right(
                 seq=self._children,

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -38,6 +38,7 @@ from .. import (
     exceptions
 )
 
+
 def _bisect_right(
         seq,
         tgt,
@@ -63,12 +64,12 @@ def _bisect_right(
         upper_search_bound = len(seq)
 
     while lower_search_bound < upper_search_bound:
-        midpoint_index = (lower_search_bound+upper_search_bound)//2
+        midpoint_index = (lower_search_bound + upper_search_bound) // 2
 
         if tgt < key_func(seq[midpoint_index]):
             upper_search_bound = midpoint_index
         else:
-            lower_search_bound = midpoint_index+1
+            lower_search_bound = midpoint_index + 1
 
     return lower_search_bound
 
@@ -98,7 +99,7 @@ def _bisect_left(
         upper_search_bound = len(seq)
 
     while lower_search_bound < upper_search_bound:
-        midpoint_index = (lower_search_bound + upper_search_bound)//2
+        midpoint_index = (lower_search_bound + upper_search_bound) // 2
 
         if key_func(seq[midpoint_index]) < tgt:
             lower_search_bound = midpoint_index + 1

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -67,6 +67,9 @@ def _bisect_left(a, x, lo=0, hi=None, key=lambda y: y):
     slice of a to be searched.
     """
 
+    # @TODO: Unit test where a track has three clips with duration 0 so they 
+    #        all start at the same time
+
     if lo < 0:
         raise ValueError('lo must be non-negative')
     if hi is None:
@@ -160,19 +163,24 @@ class Composition(item.Item, collections.MutableSequence):
 
     transform = serializable_object.deprecated_field()
 
-    def each_child(self, search_range=None, descended_from_type=composable.Composable):
+    def each_child(
+            self,
+            search_range=None,
+            descended_from_type=composable.Composable
+    ):
         if search_range:
+            range_map = self.range_of_all_children()
             left = _bisect_left(
                 self._children,
                 search_range.start_time,
-                key=lambda y: y.trimmed_range_in_parent().end_time_inclusive()
+                key=lambda y: range_map[y].end_time_inclusive(),
             )
 
             right = _bisect_right(
                 self._children,
                 search_range.end_time_inclusive(),
                 left,
-                key=lambda y: y.trimmed_range_in_parent().start_time
+                key=lambda y: range_map[y].start_time,
             )
 
             children = self._children[left:right]
@@ -226,6 +234,11 @@ class Composition(item.Item, collections.MutableSequence):
 
         To be implemented by child.
         """
+
+        raise NotImplementedError
+
+    def range_of_all_children(self):
+        """Return a dict mapping children to their range in this object."""
 
         raise NotImplementedError
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -201,7 +201,7 @@ class Composition(item.Item, collections.MutableSequence):
 
         search_time is in the space of self.
 
-        If shallow_search is false, will recurse into compositions.  
+        If shallow_search is false, will recurse into compositions.
         """
 
         range_map = self.range_of_all_children()
@@ -230,8 +230,12 @@ class Composition(item.Item, collections.MutableSequence):
                 result = thing
                 break
 
-        # result = children[0]
-        if shallow_search or not hasattr(result, "child_at_time"):
+        # if the search cannot or should not continue
+        if (
+                result is None
+                or shallow_search
+                or not hasattr(result, "child_at_time")
+        ):
             return result
 
         # before you recurse, you have to transform the time into the 
@@ -285,6 +289,8 @@ class Composition(item.Item, collections.MutableSequence):
 
         for child in children:
             # filter out children who are not descended from the specified type
+            # shortcut the isinstance if descended_from_type is composable
+            # (since all objects in compositions are already composables)
             is_descendant = descended_from_type == composable.Composable
             if is_descendant or isinstance(child, descended_from_type):
                 yield child
@@ -292,9 +298,14 @@ class Composition(item.Item, collections.MutableSequence):
             # if not a shallow_search, for children that are compositions, 
             # recurse into their children
             if not shallow_search and hasattr(child, "each_child"):
+
+                if search_range is not None:
+                    search_range = self.transformed_time_range(search_range, child)
+
                 for valid_child in child.each_child(
                         search_range,
-                        descended_from_type
+                        descended_from_type,
+                        shallow_search
                 ):
                     yield valid_child
 

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -238,7 +238,7 @@ class Composition(item.Item, collections.MutableSequence):
         ):
             return result
 
-        # before you recurse, you have to transform the time into the 
+        # before you recurse, you have to transform the time into the
         # space of the child
         child_search_time = self.transformed_time(search_time, result)
 
@@ -295,7 +295,7 @@ class Composition(item.Item, collections.MutableSequence):
             if is_descendant or isinstance(child, descended_from_type):
                 yield child
 
-            # if not a shallow_search, for children that are compositions, 
+            # if not a shallow_search, for children that are compositions,
             # recurse into their children
             if not shallow_search and hasattr(child, "each_child"):
 

--- a/opentimelineio/core/item.py
+++ b/opentimelineio/core/item.py
@@ -152,6 +152,13 @@ class Item(composable.Composable):
         t = t argument
         """
 
+        if not isinstance(t, opentime.RationalTime):
+            raise ValueError(
+                "transformed_time only operates on RationalTime, not {}".format(
+                    type(t)
+                )
+            )
+
         # does not operate in place
         result = copy.copy(t)
 
@@ -182,14 +189,12 @@ class Item(composable.Composable):
 
             item = parent
 
-        assert(item == ancestor)
+        assert(item is ancestor)
 
         return result
 
     def transformed_time_range(self, tr, to_item):
-        """Transforms the timerange tr to the range of child or self to_item.
-
-        """
+        """Transforms the timerange tr to the range of child or self to_item."""
 
         return opentime.TimeRange(
             self.transformed_time(tr.start_time, to_item),

--- a/opentimelineio/schema/stack.py
+++ b/opentimelineio/schema/stack.py
@@ -87,6 +87,12 @@ class Stack(core.Composition):
             duration=duration
         )
 
+    def range_of_all_children(self):
+        child_map = {}
+        for i, c in enumerate(self._children):
+            child_map[c] = self.range_of_child_at_index(i)
+        return child_map
+
     def trimmed_range_of_child_at_index(self, index, reference_space=None):
         range = self.range_of_child_at_index(index)
 

--- a/opentimelineio/schema/stack.py
+++ b/opentimelineio/schema/stack.py
@@ -22,7 +22,20 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-"""Implement Track and Stack."""
+"""A stack represents a series of composable.Composables that are arranged such
+that their start times are at the same point.
+
+Most commonly, this would be a series of schema.Track objects that then
+contain clips.  The 0 time of those tracks would be coincide with the 0-time of
+the stack.
+
+Stacks are in compositing order, with later children obscuring earlier
+children. In other words, from bottom to top.  If a stack has three children,
+[A, B, C], C is above B which is above A.
+
+A stack is the length of its longest child.  If a child ends before the other
+children, then an earlier index child would be visible before it.
+"""
 
 from .. import (
     core,

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -233,7 +233,6 @@ class Track(core.Composition):
                 )
                 result_map[thing] = last_range
                 last_end_time = last_range.end_time_exclusive()
-        # @TODO: this probably needs to test against track range boundaries
 
         return result_map
 

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -233,6 +233,7 @@ class Track(core.Composition):
                 )
                 result_map[thing] = last_range
                 last_end_time = last_range.end_time_exclusive()
+        # @TODO: this probably needs to test against track range boundaries
 
         return result_map
 

--- a/opentimelineio/schema/track.py
+++ b/opentimelineio/schema/track.py
@@ -146,8 +146,8 @@ class Track(core.Composition):
 
         return result
 
-    def each_clip(self, search_range=None):
-        return self.each_child(search_range, clip.Clip)
+    def each_clip(self, search_range=None, shallow_search=False):
+        return self.each_child(search_range, clip.Clip, shallow_search)
 
     def neighbors_of(self, item, insert_gap=NeighborGapPolicy.never):
         """Returns the neighbors of the item as a namedtuple, (previous, next).

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1769,22 +1769,25 @@ class NestingTest(unittest.TestCase):
             item = sq.child_at_time(playhead)
             mediaframe = sq.transformed_time(playhead, item)
 
-            self.assertIsNotNone(
-                item,
-                msg="Error: result for time {} was None, expected: {}".format(
-                    playhead,
-                    expected_val
-                )
+            measured_val = (item.name, otio.opentime.to_frames(mediaframe, 24))
+
+            self.assertEqual(
+                measured_val,
+                expected_val,
+                msg="Error with Search Time: {}, expected: {}, "
+                "got {}".format(playhead, expected_val, measured_val)
             )
 
-            try:
-                measured_val = (
-                    item.name,
-                    otio.opentime.to_frames(mediaframe, 24)
-                )
-            except Exception:
-                self.fail("Assertion thrown on: {}".format(playhead))
-                raise
+            # then test each_child
+            search_range = otio.opentime.TimeRange(
+                otio.opentime.RationalTime(frame, 24),
+                # with a 0 duration, should have the same result as above
+            )
+
+            item = list(sq.each_clip(search_range))[0]
+            mediaframe = sq.transformed_time(playhead, item)
+
+            measured_val = (item.name, otio.opentime.to_frames(mediaframe, 24))
 
             self.assertEqual(
                 measured_val,

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1379,6 +1379,7 @@ class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         track = otio.schema.Track()
         self.assertEqual(track.range_of_all_children(), {})
 
+
 class EdgeCases(unittest.TestCase):
 
     def test_empty_compositions(self):
@@ -1795,6 +1796,7 @@ class NestingTest(unittest.TestCase):
                 msg="Error with Search Time: {}, expected: {}, "
                 "got {}".format(playhead, expected_val, measured_val)
             )
+
 
 class MembershipTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -506,7 +506,7 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             otio.schema.Track(
                 children=[
                     otio.schema.Gap(
-                        source_range = otio.opentime.TimeRange(
+                        source_range=otio.opentime.TimeRange(
                             otio.opentime.RationalTime(0, 24),
                             otio.opentime.RationalTime(10, 24)
                         )

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -488,6 +488,39 @@ class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertEqual(4, len(flat_track))
         self.assertEqual(flat_track[1].name, "test_transition")
 
+    def test_top_child_at_time(self):
+        stack = otio.schema.Stack(
+            children=[
+                self.trackABC,
+                self.trackDgE,
+            ]
+        )
+
+        top_child = otio.algorithms.top_clip_at_time(
+            stack,
+            otio.opentime.RationalTime(0, 24)
+        )
+        self.assertEqual(top_child, self.trackDgE[0])
+
+        stack.append(
+            otio.schema.Track(
+                children=[
+                    otio.schema.Gap(
+                        source_range = otio.opentime.TimeRange(
+                            otio.opentime.RationalTime(0, 24),
+                            otio.opentime.RationalTime(10, 24)
+                        )
+                    )
+                ]
+            )
+        )
+
+        top_child = otio.algorithms.top_clip_at_time(
+            stack,
+            otio.opentime.RationalTime(0, 24)
+        )
+        self.assertEqual(top_child, self.trackDgE[0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -129,6 +129,31 @@ class TimelineTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         search_range = otio.opentime.TimeRange(rt_start, rt_end)
         self.assertEqual([cl], list(tl.each_clip(search_range)))
 
+        # check to see if full range works
+        search_range = tl.tracks.trimmed_range()
+        self.assertEqual([cl, cl2, cl3], list(tl.each_clip(search_range)))
+
+        # just one clip
+        search_range = cl2.range_in_parent()
+        self.assertEqual([cl2], list(tl.each_clip(search_range)))
+
+        # the last two clips
+        search_range = otio.opentime.TimeRange(
+            start_time=cl2.range_in_parent().start_time,
+            duration=cl2.trimmed_range().duration + rt_end
+        )
+        self.assertEqual([cl2, cl3], list(tl.each_clip(search_range)))
+
+        # no clips
+        search_range = otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(
+                value=-10,
+                rate=rt_start.rate
+            ),
+            duration=rt_end
+        )
+        self.assertEqual([], list(tl.each_clip(search_range)))
+
     def test_str(self):
         self.maxDiff = None
         clip = otio.schema.Clip(


### PR DESCRIPTION
- Combining #373 w/ #358 
- Also refactors `top_child_..` into algorithms
- This speeds performance of iterating over `each_child` with a search range considerably (in a test with a full feature film timeline, from 691s to 0.8s)
- Adds documentation
- Adds an implementation of `range_of_all_children` on stack so that it can be called recursively.

(Big thanks to @alatdneg, this just built off his work)