### PR TITLE
Add timeline trimming feature to `otioconvert`

### DIFF
--- a/opentimelineio/algorithms/__init__.py
+++ b/opentimelineio/algorithms/__init__.py
@@ -38,3 +38,6 @@ from .filter import (
     filtered_composition,
     filtered_with_sequence_context
 )
+from .timeline_algo import (
+    timeline_trimmed_to_range
+)

--- a/opentimelineio/algorithms/timeline_algo.py
+++ b/opentimelineio/algorithms/timeline_algo.py
@@ -1,0 +1,56 @@
+#
+# Copyright 2019 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""Algorithms for timeline objects."""
+
+import copy
+
+from . import (
+    track_algo
+)
+
+
+def timeline_trimmed_to_range(in_timeline, trim_range):
+    """Returns a new timeline that is a copy of the in_timeline, but with items
+    outside the trim_range removed and items on the ends trimmed to the
+    trim_range. Note that the timeline is never expanded, only shortened.
+    Please note that you could do nearly the same thing non-destructively by
+    just setting the Track's source_range but sometimes you want to really cut
+    away the stuff outside and that's what this function is meant for."""
+    new_timeline = copy.deepcopy(in_timeline)
+
+    for track_num, child_track in enumerate(in_timeline.tracks):
+        # @TODO: put the trim_range into the space of the tracks
+        # new_range = new_timeline.tracks.transformed_time_range(
+        #     trim_range,
+        #     child_track
+        # )
+
+        # trim the track and assign it to the new stack.
+        new_timeline.tracks[track_num] = track_algo.track_trimmed_to_range(
+            child_track,
+            trim_range
+        )
+
+    return new_timeline

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -147,7 +147,6 @@ def _parsed_args():
         try:
             value, rate = result.begin.split(",")
             result.begin = otio.opentime.RationalTime(float(value), float(rate))
-            print "foo: ", result.begin
         except ValueError:
             parser.error(
                 "--begin argument needs to be of the form: VALUE,RATE where "

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -111,8 +111,64 @@ def _parsed_args():
         'key=value. Values are strings, numbers or Python literals: True, '
         'False, etc. Can be used multiple times: -A burrito="bar" -A taco=12.'
     )
+    trim_args = parser.add_argument_group(
+        title="Trim Arguments",
+        description="Arguments that allow you to trim the OTIO file."
+    )
+    trim_args.add_argument(
+        '--begin',
+        type=str,
+        default=None,
+        help=(
+            "Trim out everything in the timeline before this time, in the "
+            "global time frame of the timeline.  Argument should be in the form"
+            ' "VALUE,RATE", eg: --begin "10,24".  Requires --end argument.'
+        ),
+    )
+    trim_args.add_argument(
+        '--end',
+        type=str,
+        default=None,
+        help=(
+            "Trim out everything in the timeline after this time, in the "
+            "global time frame of the timeline.  Argument should be in the form"
+            ' "VALUE,RATE", eg: --begin "10,24".  Requires --begin argument.'
+        ),
+    )
 
-    return parser.parse_args()
+    result = parser.parse_args()
+
+    if result.begin is not None and result.end is None:
+        parser.error("--begin requires --end.")
+    if result.end is not None and result.begin is None:
+        parser.error("--end requires --begin.")
+
+    if result.begin is not None:
+        try:
+            value, rate = result.begin.split(",")
+            result.begin = otio.opentime.RationalTime(float(value), float(rate))
+            print "foo: ", result.begin
+        except ValueError:
+            parser.error(
+                "--begin argument needs to be of the form: VALUE,RATE where "
+                "VALUE is the (float) time value of the resulting RationalTime "
+                "and RATE is the (float) time rate of the resulting RationalTime,"
+                " not '{}'".format(result.begin)
+            )
+
+    if result.end is not None:
+        try:
+            value, rate = result.end.split(",")
+            result.end = otio.opentime.RationalTime(float(value), float(rate))
+        except ValueError:
+            parser.error(
+                "--end argument needs to be of the form: VALUE,RATE where "
+                "VALUE is the (float) time value of the resulting RationalTime "
+                "and RATE is the (float) time rate of the resulting RationalTime,"
+                " not '{}'".format(result.begin)
+            )
+
+    return result
 
 
 def main():
@@ -170,6 +226,13 @@ def main():
             print("track {0} is of kind: '{1}'".format(track, tr.kind))
             result_tracks.append(tr)
         result_tl.tracks = result_tracks
+
+    # handle trim arguments
+    if args.begin is not None and args.end is not None:
+        result_tl = otio.algorithms.timeline_trimmed_to_range(
+            result_tl,
+            otio.opentime.range_from_start_end_time(args.begin, args.end)
+        )
 
     argument_map = {}
     for pair in args.output_adapter_arg:

--- a/tests/test_timeline_algo.py
+++ b/tests/test_timeline_algo.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python
+#
+# Copyright 2019 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""Test file for the track algorithms library."""
+
+import unittest
+
+import opentimelineio as otio
+
+
+class TimelineTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+    """ test harness for timeline trimming function """
+
+    def make_sample_timeline(self):
+        result = otio.adapters.read_from_string(
+            """
+            {
+                "OTIO_SCHEMA": "Timeline.1",
+                "metadata": {},
+                "name": null,
+                "tracks": {
+                    "OTIO_SCHEMA": "Stack.1",
+                    "children": [
+                        {
+                            "OTIO_SCHEMA": "Track.1",
+                            "children": [
+                                {
+                                    "OTIO_SCHEMA": "Clip.1",
+                                    "effects": [],
+                                    "markers": [],
+                                    "media_reference": null,
+                                    "metadata": {},
+                                    "name": "A",
+                                    "source_range": {
+                                        "OTIO_SCHEMA": "TimeRange.1",
+                                        "duration": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 50
+                                        },
+                                        "start_time": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 0.0
+                                        }
+                                    }
+                                },
+                                {
+                                    "OTIO_SCHEMA": "Clip.1",
+                                    "effects": [],
+                                    "markers": [],
+                                    "media_reference": null,
+                                    "metadata": {},
+                                    "name": "B",
+                                    "source_range": {
+                                        "OTIO_SCHEMA": "TimeRange.1",
+                                        "duration": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 50
+                                        },
+                                        "start_time": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 0.0
+                                        }
+                                    }
+                                },
+                                {
+                                    "OTIO_SCHEMA": "Clip.1",
+                                    "effects": [],
+                                    "markers": [],
+                                    "media_reference": null,
+                                    "metadata": {},
+                                    "name": "C",
+                                    "source_range": {
+                                        "OTIO_SCHEMA": "TimeRange.1",
+                                        "duration": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 50
+                                        },
+                                        "start_time": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 0.0
+                                        }
+                                    }
+                                }
+                            ],
+                            "effects": [],
+                            "kind": "Video",
+                            "markers": [],
+                            "metadata": {},
+                            "name": "Sequence1",
+                            "source_range": null
+                        }
+                    ],
+                    "effects": [],
+                    "markers": [],
+                    "metadata": {},
+                    "name": "tracks",
+                    "source_range": null
+                }
+            }""",
+            "otio_json"
+        )
+
+        return result, result.tracks[0]
+
+    def test_trim_to_existing_range(self):
+        original_timeline, original_track = self.make_sample_timeline()
+        self.assertEqual(
+            original_track.trimmed_range(),
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24),
+                duration=otio.opentime.RationalTime(150, 24)
+            )
+        )
+
+        # trim to the exact range it already has
+        trimmed = otio.algorithms.timeline_trimmed_to_range(
+            original_timeline,
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24),
+                duration=otio.opentime.RationalTime(150, 24)
+            )
+        )
+        # it shouldn't have changed at all
+        self.assertIsOTIOEquivalentTo(original_timeline, trimmed)
+
+    def test_trim_to_longer_range(self):
+        original_timeline, original_track = self.make_sample_timeline()
+        # trim to a larger range
+        trimmed = otio.algorithms.timeline_trimmed_to_range(
+            original_timeline,
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(-10, 24),
+                duration=otio.opentime.RationalTime(160, 24)
+            )
+        )
+        # it shouldn't have changed at all
+        self.assertJsonEqual(original_timeline, trimmed)
+
+    def test_trim_front(self):
+        original_timeline, original_track = self.make_sample_timeline()
+        # trim off the front (clip A and part of B)
+        trimmed = otio.algorithms.timeline_trimmed_to_range(
+            original_timeline,
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(60, 24),
+                duration=otio.opentime.RationalTime(90, 24)
+            )
+        )
+        self.assertNotEqual(original_timeline, trimmed)
+        trimmed = trimmed.tracks[0]
+
+        self.assertEqual(len(trimmed), 2)
+        self.assertEqual(
+            trimmed.trimmed_range(),
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24),
+                duration=otio.opentime.RationalTime(90, 24)
+            )
+        )
+        # did clip B get trimmed?
+        self.assertEqual(trimmed[0].name, "B")
+        self.assertEqual(
+            trimmed[0].trimmed_range(),
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(10, 24),
+                duration=otio.opentime.RationalTime(40, 24)
+            )
+        )
+        # clip C should have been left alone
+        self.assertIsOTIOEquivalentTo(trimmed[1], original_track[2])
+
+    def test_trim_end(self):
+        original_timeline, original_track = self.make_sample_timeline()
+        # trim off the end (clip C and part of B)
+        trimmed_timeline = otio.algorithms.timeline_trimmed_to_range(
+            original_timeline,
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24),
+                duration=otio.opentime.RationalTime(90, 24)
+            )
+        )
+        # rest of the tests are on the track
+        trimmed = trimmed_timeline.tracks[0]
+
+        self.assertNotEqual(original_timeline, trimmed)
+        self.assertEqual(len(trimmed), 2)
+        self.assertEqual(
+            trimmed.trimmed_range(),
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24),
+                duration=otio.opentime.RationalTime(90, 24)
+            )
+        )
+
+        # clip A should have been left alone
+        self.assertIsOTIOEquivalentTo(trimmed[0], original_track[0])
+        # did clip B get trimmed?
+        self.assertEqual(trimmed[1].name, "B")
+        self.assertEqual(
+            trimmed[1].trimmed_range(),
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(0, 24),
+                duration=otio.opentime.RationalTime(40, 24)
+            )
+        )
+
+    def test_trim_with_transitions(self):
+        original_timeline, original_track = self.make_sample_timeline()
+        self.assertEqual(
+            otio.opentime.RationalTime(150, 24),
+            original_timeline.duration()
+        )
+        self.assertEqual(len(original_track), 3)
+
+        # add a transition
+        tr = otio.schema.Transition(
+            in_offset=otio.opentime.RationalTime(12, 24),
+            out_offset=otio.opentime.RationalTime(20, 24)
+        )
+        original_track.insert(1, tr)
+        self.assertEqual(len(original_track), 4)
+        self.assertEqual(
+            otio.opentime.RationalTime(150, 24),
+            original_timeline.duration()
+        )
+
+        # if you try to sever a Transition in the middle it should fail
+        with self.assertRaises(otio.exceptions.CannotTrimTransitionsError):
+            trimmed = otio.algorithms.timeline_trimmed_to_range(
+                original_timeline,
+                otio.opentime.TimeRange(
+                    start_time=otio.opentime.RationalTime(5, 24),
+                    duration=otio.opentime.RationalTime(50, 24)
+                )
+            )
+
+        with self.assertRaises(otio.exceptions.CannotTrimTransitionsError):
+            trimmed = otio.algorithms.timeline_trimmed_to_range(
+                original_timeline,
+                otio.opentime.TimeRange(
+                    start_time=otio.opentime.RationalTime(45, 24),
+                    duration=otio.opentime.RationalTime(50, 24)
+                )
+            )
+
+        trimmed = otio.algorithms.timeline_trimmed_to_range(
+            original_timeline,
+            otio.opentime.TimeRange(
+                start_time=otio.opentime.RationalTime(25, 24),
+                duration=otio.opentime.RationalTime(50, 24)
+            )
+        )
+        self.assertNotEqual(original_timeline, trimmed)
+
+        expected = otio.adapters.read_from_string(
+            """
+            {
+                "OTIO_SCHEMA": "Timeline.1",
+                "metadata": {},
+                "name": null,
+                "tracks": {
+                    "OTIO_SCHEMA": "Stack.1",
+                    "children": [
+                        {
+                            "OTIO_SCHEMA": "Track.1",
+                            "children": [
+                                {
+                                    "OTIO_SCHEMA": "Clip.1",
+                                    "effects": [],
+                                    "markers": [],
+                                    "media_reference": null,
+                                    "metadata": {},
+                                    "name": "A",
+                                    "source_range": {
+                                        "OTIO_SCHEMA": "TimeRange.1",
+                                        "duration": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 25
+                                        },
+                                        "start_time": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 25.0
+                                        }
+                                    }
+                                },
+                                {
+                                    "OTIO_SCHEMA": "Transition.1",
+                                    "in_offset": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24,
+                                        "value": 12
+                                    },
+                                    "metadata": {},
+                                    "name": null,
+                                    "out_offset": {
+                                        "OTIO_SCHEMA": "RationalTime.1",
+                                        "rate": 24,
+                                        "value": 20
+                                    },
+                                    "transition_type": null
+                                },
+                                {
+                                    "OTIO_SCHEMA": "Clip.1",
+                                    "effects": [],
+                                    "markers": [],
+                                    "media_reference": null,
+                                    "metadata": {},
+                                    "name": "B",
+                                    "source_range": {
+                                        "OTIO_SCHEMA": "TimeRange.1",
+                                        "duration": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 25
+                                        },
+                                        "start_time": {
+                                            "OTIO_SCHEMA": "RationalTime.1",
+                                            "rate": 24,
+                                            "value": 0.0
+                                        }
+                                    }
+                                }
+                            ],
+                            "effects": [],
+                            "kind": "Video",
+                            "markers": [],
+                            "metadata": {},
+                            "name": "Sequence1",
+                            "source_range": null
+                        }
+                    ],
+                    "effects": [],
+                    "markers": [],
+                    "metadata": {},
+                    "name": "tracks",
+                    "source_range": null
+                }
+            }
+            """,
+            "otio_json"
+        )
+
+        self.assertJsonEqual(expected, trimmed)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Adds `--begin` and `--end` arguments to `otioconvert` shell program, which lets you trim out everything outside the range described by the begin/end arguments
- Also adds a `timeline_algo.py` module with a convenience wrapper around `track_trimmed_to_range`