### PR TITLE
Use walk() method provided by PyAAF2 classes

### DIFF
--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -106,7 +106,17 @@ def _find_timecode_mobs(item):
     mobs = [item.mob]
 
     for c in item.walk():
-        if isinstance(c, aaf2.components.EssenceGroup):
+        # Only `SourceReference` implements `mob` for now.
+        if isinstance(c, aaf2.components.SourceReference):
+            mob = c.mob
+            if mob:
+                mobs.append(mob)
+
+        else:
+            # This could be `EssenceGroup`, `Pulldown` or other segment subclasses
+            # See also: https://jira.pixar.com/browse/SE-3457
+
+            # For example:
             # An EssenceGroup is a Segment that has one or more
             # alternate choices, each of which represent different variations
             # of one actual piece of content.
@@ -122,10 +132,8 @@ def _find_timecode_mobs(item):
             # TODO: Is the Timecode for an EssenceGroup correct?
             # TODO: Try CountChoices() and ChoiceAt(i)
             # For now, lets just skip it.
+
             continue
-        mob = c.mob
-        if mob:
-            mobs.append(mob)
 
     return mobs
 

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -52,34 +52,6 @@ def _get_parameter(item, parameter_name):
     return values.get(parameter_name)
 
 
-def _walk_item(thing):
-    slot = thing.slot
-    if not slot:
-        return
-    segment = slot.segment
-    if isinstance(segment, aaf2.components.SourceClip):
-        yield segment
-        for item in _walk_item(segment):
-            yield item
-    # elif isinstance(segment, aaf2.components.Sequence):
-    #     clip = segment.component_at_time(thing.start_time)
-    #     if isinstance(clip, SourceClip):
-    #         yield clip
-    #         for item in clip._walk_item():
-    #             yield item
-    #     else:
-    #         raise NotImplementedError(
-    #            "Sequence returned {} not implemented".format(type(segment))
-    elif isinstance(segment, aaf2.components.EssenceGroup):
-        yield segment
-    elif isinstance(segment, aaf2.components.Filler):
-        yield segment
-    else:
-        raise NotImplementedError(
-            "walking {} not implemented".format(type(segment))
-        )
-
-
 def _get_name(item):
     if isinstance(item, aaf2.components.SourceClip):
         try:
@@ -133,7 +105,7 @@ def _transcribe_property(prop):
 def _find_timecode_mobs(item):
     mobs = [item.mob]
 
-    for c in _walk_item(item):
+    for c in item.walk():
         if isinstance(c, aaf2.components.EssenceGroup):
             # An EssenceGroup is a Segment that has one or more
             # alternate choices, each of which represent different variations


### PR DESCRIPTION
Now what Shahbaz’s pull request https://github.com/markreidvfx/pyaaf2/pull/21 was merged to PyAAF2, we could simplify this.

TODO: in PyAAF2, `Sequence` needs to implement `component_at_time` method as suggested in https://github.com/markreidvfx/pyaaf2/pull/21#issuecomment-448089635