### PR TITLE
GStreamer Editing Services XML adapter

### DIFF
--- a/opentimelineio_contrib/adapters/contrib_adapters.plugin_manifest.json
+++ b/opentimelineio_contrib/adapters/contrib_adapters.plugin_manifest.json
@@ -49,6 +49,13 @@
             "execution_scope" : "in process",
             "filepath" : "advanced_authoring_format.py",
             "suffixes" : ["aaf"]
+        },
+        {
+            "OTIO_SCHEMA": "Adapter.1",
+            "name": "xges",
+            "execution_scope": "in process",
+            "filepath": "xges.py",
+            "suffixes": ["xges"]
         }
     ]
 }

--- a/opentimelineio_contrib/adapters/tests/sample_data/xges_example.xges
+++ b/opentimelineio_contrib/adapters/tests/sample_data/xges_example.xges
@@ -1,0 +1,44 @@
+<ges version='0.3'>
+  <project properties='properties;' metadatas='metadatas, author=(string)&quot;Thibault\ saunier&quot;, render-scale=(double)100, format-version=(string)0.3;'>
+    <encoding-profiles>
+      <encoding-profile name='pitivi-profile' description='Pitivi encoding profile' type='container' preset-name='oggmux' format='application/ogg' >
+        <stream-profile parent='pitivi-profile' id='0' type='video' presence='0' format='video/x-theora, framerate=(fraction)[ 1/2147483647, 2147483647/1 ], width=(int)[ 1, 2147483647 ], height=(int)[ 1, 2147483647 ]' preset-name='theoraenc' restriction='video/x-raw, framerate=(fraction)25/1, width=(int)384, height=(int)288, pixel-aspect-ratio=(fraction)1/1' pass='0' variableframerate='0' />
+        <stream-profile parent='pitivi-profile' id='1' type='audio' presence='0' format='audio/x-vorbis, rate=(int)[ 1, 200000 ], channels=(int)[ 1, 255 ]' preset-name='vorbisenc' restriction='audio/x-raw, rate=(int)11025, channels=(int)1' />
+      </encoding-profile>
+    </encoding-profiles>
+    <ressources>
+      <asset id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/flac/samples.multimedia.cx_flac_Yesterday.flac' extractable-type-name='GESUriClip' properties='properties, supported-formats=(int)2, duration=(guint64)126615510204;' metadatas='metadatas, audio-codec=(string)&quot;Free\ Lossless\ Audio\ Codec\ \(FLAC\)&quot;, file-size=(guint64)11218495;' />
+      <asset id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/raw_video.avi' extractable-type-name='GESUriClip' properties='properties, supported-formats=(int)4, duration=(guint64)3333333333;' metadatas='metadatas, video-codec=(string)&quot;Uncompressed\ planar\ YUV\ 4:2:0&quot;, bitrate=(uint)27648000, container-format=(string)AVI, file-size=(guint64)11523200;'  proxy-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/raw_video.avi.11523200.proxy.mkv' />
+      <asset id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/raw_video.avi.11523200.proxy.mkv' extractable-type-name='GESUriClip' properties='properties, supported-formats=(int)4, duration=(guint64)3333333333;' metadatas='metadatas, container-format=(string)Matroska, video-codec=(string)&quot;Motion\ JPEG&quot;, file-size=(guint64)1260426;' />
+      <asset id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/bowlerhatdancer.sleepytom.SGP.mjpeg.avi.11469256.proxy.mkv' extractable-type-name='GESUriClip' properties='properties, supported-formats=(int)4, duration=(guint64)19400000000;' metadatas='metadatas, container-format=(string)Matroska, video-codec=(string)&quot;Motion\ JPEG&quot;, file-size=(guint64)21464554;' />
+      <asset id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/samples.multimedia.cx_testsuite_iv31.avi' extractable-type-name='GESUriClip' properties='properties, supported-formats=(int)6, duration=(guint64)47416477000;' metadatas='metadatas, audio-codec=(string)&quot;Uncompressed\ 8-bit\ PCM\ audio&quot;, bitrate=(uint)88200, container-format=(string)AVI, video-codec=(string)&quot;Intel\ Video\ 3&quot;, file-size=(guint64)3820040;' />
+      <asset id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/bowlerhatdancer.sleepytom.SGP.mjpeg.avi' extractable-type-name='GESUriClip' properties='properties, supported-formats=(int)4, duration=(guint64)19400000000;' metadatas='metadatas, video-codec=(string)&quot;Motion\ JPEG&quot;, bitrate=(uint)4721297, container-format=(string)AVI, file-size=(guint64)11469256;'  proxy-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/bowlerhatdancer.sleepytom.SGP.mjpeg.avi.11469256.proxy.mkv' />
+      <asset id='crossfade' extractable-type-name='GESTransitionClip' properties='properties;' metadatas='metadatas, description=(string)GES_VIDEO_STANDARD_TRANSITION_TYPE_CROSSFADE;' />
+    </ressources>
+    <timeline properties='properties, auto-transition=(boolean)true, snapping-distance=(guint64)83957176;' metadatas='metadatas, duration=(guint64)36215932868, framerate=(fraction)25/1;'>
+      <track caps='video/x-raw(ANY)' track-type='4' track-id='0' properties='properties, async-handling=(boolean)false, message-forward=(boolean)true, caps=(string)&quot;video/x-raw\(ANY\)&quot;, restriction-caps=(string)&quot;video/x-raw\,\ width\=\(int\)384\,\ height\=\(int\)288\,\ framerate\=\(fraction\)25/1\,\ pixel-aspect-ratio\=\(fraction\)1/1&quot;, mixing=(boolean)true;' metadatas='metadatas;'/>
+      <track caps='audio/x-raw(ANY)' track-type='2' track-id='1' properties='properties, async-handling=(boolean)false, message-forward=(boolean)true, caps=(string)&quot;audio/x-raw\(ANY\)&quot;, restriction-caps=(string)&quot;audio/x-raw\,\ rate\=\(int\)11025\,\ channels\=\(int\)1&quot;, mixing=(boolean)true;' metadatas='metadatas;'/>
+      <layer priority='0' properties='properties, auto-transition=(boolean)true;' metadatas='metadatas, volume=(float)1;'>
+        <clip id='0' asset-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/samples.multimedia.cx_testsuite_iv31.avi' type-name='GESUriClip' layer-priority='0' track-types='6' start='1894092578' duration='5284314119' inpoint='0' rate='0' properties='properties, name=(string)uriclip43, mute=(boolean)false, is-image=(boolean)false;' />
+      </layer>
+      <layer priority='1' properties='properties, auto-transition=(boolean)true;' metadatas='metadatas, volume=(float)1;'>
+        <clip id='1' asset-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/raw_video.avi.11523200.proxy.mkv' type-name='GESUriClip' layer-priority='1' track-types='4' start='11095856186' duration='3333333333' inpoint='0' rate='0' properties='properties, name=(string)uriclip45, mute=(boolean)false, is-image=(boolean)false;' />
+        <clip id='2' asset-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/samples.multimedia.cx_testsuite_iv31.avi' type-name='GESUriClip' layer-priority='1' track-types='6' start='25678779157' duration='10537153711' inpoint='5284314119' rate='0' properties='properties, name=(string)uriclip47, mute=(boolean)false, is-image=(boolean)false;' />
+      </layer>
+      <layer priority='2' properties='properties, auto-transition=(boolean)true;' metadatas='metadatas, volume=(float)1;'>
+        <clip id='3' asset-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/bowlerhatdancer.sleepytom.SGP.mjpeg.avi.11469256.proxy.mkv' type-name='GESUriClip' layer-priority='2' track-types='4' start='6821836273' duration='10187887743' inpoint='0' rate='0' properties='properties, name=(string)uriclip49, mute=(boolean)false, is-image=(boolean)false;' />
+        <clip id='4' asset-id='crossfade' type-name='GESTransitionClip' layer-priority='2' track-types='4' start='15170742086' duration='1838981930' inpoint='0' rate='0' properties='properties, name=(string)transitionclip2;'  children-properties='properties, GESVideoTransition::border=(uint)0, GESVideoTransition::invert=(boolean)false;' />
+        <clip id='5' asset-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/avi/bowlerhatdancer.sleepytom.SGP.mjpeg.avi.11469256.proxy.mkv' type-name='GESUriClip' layer-priority='2' track-types='4' start='15170742086' duration='9212112257' inpoint='10187887743' rate='0' properties='properties, name=(string)uriclip51, mute=(boolean)false, is-image=(boolean)false;' />
+      </layer>
+      <layer priority='3' properties='properties, auto-transition=(boolean)true;' metadatas='metadatas, volume=(float)1;'>
+        <clip id='6' asset-id='file:///home/thiblahute/gst-validate/gst-integration-testsuites/medias/defaults/flac/samples.multimedia.cx_flac_Yesterday.flac' type-name='GESUriClip' layer-priority='3' track-types='2' start='0' duration='36215932868' inpoint='0' rate='0' properties='properties, name=(string)uriclip53, mute=(boolean)false, is-image=(boolean)false;' />
+      </layer>
+      <groups>
+        <group id='7' properties='properties, name=(string)group5;'>
+          <child id='0' name='uriclip43'/>
+          <child id='1' name='uriclip45'/>
+        </group>
+      </groups>
+    </timeline>
+</project>
+</ges>

--- a/opentimelineio_contrib/adapters/tests/test_xges_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_xges_adapter.py
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2019 Igalia S.L
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import os
+import tempfile
+import unittest
+
+import opentimelineio as otio
+
+SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
+XGES_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "xges_example.xges")
+
+
+class AdaptersXGESTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+
+    def test_read(self):
+        timeline = otio.adapters.read_from_file(XGES_EXAMPLE_PATH)[0]
+        self.assertIsNotNone(timeline)
+        self.assertEqual(len(timeline.tracks), 6)
+
+        video_tracks = [
+            t for t in timeline.tracks
+            if t.kind == otio.schema.TrackKind.Video
+        ]
+        audio_tracks = [
+            t for t in timeline.tracks
+            if t.kind == otio.schema.TrackKind.Audio
+        ]
+
+        self.assertEqual(len(video_tracks), 3)
+        self.assertEqual(len(audio_tracks), 3)
+
+    def test_roundtrip_disk2mem2disk(self):
+        self.maxDiff = None
+        timeline = otio.adapters.read_from_file(XGES_EXAMPLE_PATH)
+        tmp_path = tempfile.mkstemp(suffix=".xges", text=True)[1]
+
+        otio.adapters.write_to_file(timeline, tmp_path)
+        result = otio.adapters.read_from_file(tmp_path)
+
+        original_json = otio.adapters.write_to_string(timeline, 'otio_json')
+        output_json = otio.adapters.write_to_string(result, 'otio_json')
+        self.assertMultiLineEqual(original_json, output_json)
+
+        self.assertIsOTIOEquivalentTo(timeline, result)
+
+        # But the xml text on disk is not identical because otio has a subset
+        # of features to xges and we drop all the nle specific preferences.
+        with open(XGES_EXAMPLE_PATH, "r") as original_file:
+            with open(tmp_path, "r") as output_file:
+                self.assertNotEqual(original_file.read(), output_file.read())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/opentimelineio_contrib/adapters/xges.py
+++ b/opentimelineio_contrib/adapters/xges.py
@@ -1,0 +1,787 @@
+#
+# Copyright (C) 2019 Igalia S.L
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+"""OpenTimelineIO GStreamer Editing Services XML Adapter. """
+import os
+import re
+import unittest
+
+from collections import defaultdict
+from decimal import Decimal
+from fractions import Fraction
+from xml.etree import cElementTree
+from xml.dom import minidom
+import opentimelineio as otio
+
+META_NAMESPACE = "XGES"
+
+
+FRAMERATE_FRAMEDURATION = {23.98: "24000/1001",
+                           24: "600/25",
+                           25: "25/1",
+                           29.97: "30000/1001",
+                           30: "30/1",
+                           50: "50/1",
+                           59.94: "60000/1001",
+                           60: "60/1"}
+
+
+TRANSITION_MAP = {
+    "crossfade": otio.schema.TransitionTypes.SMPTE_Dissolve
+}
+# Two way map
+TRANSITION_MAP.update(dict([(v, k) for k, v in TRANSITION_MAP.items()]))
+
+
+class GstParseError(otio.exceptions.OTIOError):
+    pass
+
+
+class GstStructure(object):
+    """
+    GstStructure parser with a "dictionary" like API.
+    """
+    UNESCAPE = re.compile(r'(?<!\\)\\(.)')
+    INT_TYPES = "".join(
+        ("int", "uint", "int8", "uint8", "int16",
+         "uint16", "int32", "uint32", "int64", "uint64")
+    )
+
+    def __init__(self, text):
+        self.text = text
+        self.modified = False
+        self.name, self.types, self.values = GstStructure._parse(text + ";")
+
+    def __repr__(self):
+        if not self.modified:
+            return self.text
+
+        res = self.name
+        for key, value in self.values.items():
+            value_type = self.types[key]
+            res += ', %s=(%s)"%s"' % (key, value_type, self.escape(value))
+        res += ';'
+
+        return res
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+    def set(self, key, value_type, value):
+        if self.types.get(key) == value_type and self.values.get(key) == value:
+            return
+
+        self.modified = True
+        self.types[key] = value_type
+        self.values[key] = value
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    @staticmethod
+    def _find_eos(s):
+        # find next '"' without preceeding '\'
+        l = 0
+        while 1:  # faster than regexp for '[^\\]\"'
+            p = s.index('"')
+            l += p + 1
+            if s[p - 1] != '\\':
+                return l
+            s = s[(p + 1):]
+        return -1
+
+    @staticmethod
+    def escape(s):
+        # XXX: The unicode type doesn't exist in Python 3 (all strings are unicode)
+        # so we have to use type(u"") which works in both Python 2 and 3.
+        if type(s) not in (str, type(u"")):
+            return s
+        return s.replace(" ", "\\ ")
+
+    @staticmethod
+    def _parse(s):
+        in_string = s
+        types = {}
+        values = {}
+        scan = True
+        # parse id
+        p = s.find(',')
+        if p == -1:
+            try:
+                p = s.index(';')
+            except ValueError:
+                p = len(s)
+            scan = False
+        name = s[:p]
+        # parse fields
+        while scan:
+            comma_space_it = p
+            # skip 'name, ' / 'value, '
+            while s[comma_space_it] in [' ', ',']:
+                comma_space_it += 1
+            s = s[comma_space_it:]
+            p = s.index('=')
+            k = s[:p]
+            if not s[p + 1] == '(':
+                raise ValueError("In %s position: %d" % (in_string, p))
+            s = s[(p + 2):]  # skip 'key=('
+            p = s.index(')')
+            t = s[:p]
+            s = s[(p + 1):]  # skip 'type)'
+
+            if s[0] == '"':
+                s = s[1:]  # skip '"'
+                p = GstStructure._find_eos(s)
+                if p == -1:
+                    raise ValueError
+                v = s[:(p - 1)]
+                if s[p] == ';':
+                    scan = False
+                # unescape \., but not \\. (using a backref)
+                # need a reverse for re.escape()
+                v = v.replace('\\\\', '\\')
+                v = GstStructure.UNESCAPE.sub(r'\1', v)
+            else:
+                p = s.find(',')
+                if p == -1:
+                    p = s.index(';')
+                    scan = False
+                v = s[:p]
+
+            if t == 'structure':
+                v = GstStructure(v)
+            elif t == 'string' and len(v) and v[0] == '"':
+                v = v[1:-1]
+            elif t == 'boolean':
+                v = (v == '1')
+            elif t in GstStructure.INT_TYPES:
+                v = int(v)
+            types[k] = t
+            values[k] = v
+
+        return (name, types, values)
+
+
+class GESTrackType:
+    UNKNOWN = 1 << 0
+    AUDIO = 1 << 1
+    VIDEO = 1 << 2
+    TEXT = 1 << 3
+    CUSTOM = 1 << 4
+
+    @staticmethod
+    def to_otio_type(_type):
+        if _type == GESTrackType.AUDIO:
+            return otio.schema.TrackKind.Audio
+        elif _type == GESTrackType.VIDEO:
+            return otio.schema.TrackKind.Video
+
+        raise GstParseError("Can't translate track type %s" % _type)
+
+
+GST_CLOCK_TIME_NONE = 18446744073709551615
+GST_SECOND = 1000000000
+
+
+def to_gstclocktime(rational_time):
+    """
+    This converts a RationalTime object to a GstClockTime
+
+    Args:
+        rational_time (RationalTime): This is a RationalTime object
+
+    Returns:
+        int: A time in nanosecond
+    """
+
+    return int(rational_time.value_rescaled_to(1) * GST_SECOND)
+
+
+def get_from_structure(xmlelement, fieldname, default=None, attribute="properties"):
+    structure = GstStructure(xmlelement.get(attribute, attribute))
+    return structure.get(fieldname, default)
+
+
+class XGES:
+    """
+    This object is responsible for knowing how to convert an xGES
+    project into an otio timeline
+    """
+
+    def __init__(self, xml_string):
+        self.xges_xml = cElementTree.fromstring(xml_string)
+        self.rate = 25
+
+    def _set_rate_from_timeline(self, timeline):
+        metas = GstStructure(timeline.attrib.get("metadatas", "metadatas"))
+        framerate = metas.get("framerate")
+        if framerate:
+            rate = Fraction(framerate)
+        else:
+            video_track = timeline.find("./track[@track-type='4']")
+            rate = None
+            if video_track is not None:
+                properties = GstStructure(
+                    video_track.get("properties", "properties;"))
+                restriction_caps = GstStructure(properties.get(
+                    "restriction-caps", "restriction-caps"))
+                rate = restriction_caps.get("framerate")
+
+        if rate is None:
+            return
+
+        self.rate = float(Fraction(rate))
+        if self.rate == int(self.rate):
+            self.rate = int(self.rate)
+        else:
+            self.rate = float(round(Decimal(self.rate), 2))
+
+    def to_rational_time(self, ns_timestamp):
+        """
+        This converts a GstClockTime value to an otio RationalTime object
+
+        Args:
+            ns_timestamp (int): This is a GstClockTime value (nanosecond absolute value)
+
+        Returns:
+            RationalTime: A RationalTime object
+        """
+        return otio.opentime.RationalTime(round(int(ns_timestamp) / (GST_SECOND / self.rate)), self.rate)
+
+    def to_otio(self):
+        """
+        Convert an xges to an otio
+
+        Returns:
+            OpenTimeline: An OpenTimeline Timeline object
+        """
+
+        project = self.xges_xml.find("./project")
+        metas = GstStructure(project.attrib.get("metadatas", "metadatas"))
+        otio_project = otio.schema.SerializableCollection(
+            name=metas.get('name'),
+            metadata={
+                META_NAMESPACE: {"metadatas": project.attrib.get(
+                    "metadatas", "metadatas")}
+            }
+        )
+        timeline = project.find("./timeline")
+        self._set_rate_from_timeline(timeline)
+
+        otio_timeline = otio.schema.Timeline(
+            name=metas.get('name', "unnamed"),
+            metadata={
+                META_NAMESPACE: {
+                    "metadatas": timeline.attrib.get("metadatas", "metadatas"),
+                    "properties": timeline.attrib.get("properties", "properties")
+                }
+            }
+        )
+
+        all_names = set()
+        self._add_layers(timeline, otio_timeline, all_names)
+        otio_project.append(otio_timeline)
+
+        return otio_project
+
+    def _add_layers(self, timeline, otio_timeline, all_names):
+        for layer in timeline.findall("./layer"):
+            tracks = self._build_tracks_from_layer_clips(layer, all_names)
+            otio_timeline.tracks.extend(tracks)
+
+    def _get_clips_for_type(self, clips, track_type):
+        if not clips:
+            return False
+
+        clips_for_type = []
+        for clip in clips:
+            if int(clip.attrib['track-types']) & track_type:
+                clips_for_type.append(clip)
+
+        return clips_for_type
+
+    def _build_tracks_from_layer_clips(self, layer, all_names):
+        all_clips = layer.findall('./clip')
+
+        tracks = []
+        for track_type in [GESTrackType.VIDEO, GESTrackType.AUDIO]:
+            clips = self._get_clips_for_type(all_clips, track_type)
+            if not clips:
+                continue
+
+            track = otio.schema.Track()
+            track.kind = GESTrackType.to_otio_type(track_type)
+            self._add_clips_in_track(clips, track, all_names)
+
+            tracks.append(track)
+
+        return tracks
+
+    def _add_clips_in_track(self, clips, track, all_names):
+        for clip in clips:
+            otio_clip = self._create_otio_clip(clip, all_names)
+            if otio_clip is None:
+                continue
+
+            clip_offset = self.to_rational_time(int(clip.attrib['start']))
+            if clip_offset > track.duration():
+                track.append(
+                    self._create_otio_gap(
+                        0,
+                        (clip_offset - track.duration())
+                    )
+                )
+
+            track.append(otio_clip)
+
+        return track
+
+    def _get_clip_name(self, clip, all_names):
+        i = 0
+        tmpname = name = clip.get("name", GstStructure(clip.get("properties", "properties;")).get("name"))
+        while True:
+            if tmpname not in all_names:
+                all_names.add(tmpname)
+                return tmpname
+
+            i += 1
+            tmpname = name + '_%d' % i
+
+    def _create_otio_transition(self, clip, all_names):
+        start = self.to_rational_time(clip.attrib["start"])
+        end = start + self.to_rational_time(clip.attrib["duration"])
+        cut_point = otio.opentime.RationalTime((end.value - start.value) / 2, start.rate)
+
+        return otio.schema.Transition(
+            name=self._get_clip_name(clip, all_names),
+            transition_type=TRANSITION_MAP.get(
+                clip.attrib["asset-id"], otio.schema.TransitionTypes.Custom
+            ),
+            in_offset=cut_point,
+            out_offset=cut_point,
+        )
+
+    def _create_otio_uri_clip(self, clip, all_names):
+        source_range = otio.opentime.TimeRange(
+            start_time=self.to_rational_time(clip.attrib["inpoint"]),
+            duration=self.to_rational_time(clip.attrib["duration"]),
+        )
+
+        otio_clip = otio.schema.Clip(
+            name=self._get_clip_name(clip, all_names),
+            source_range=source_range,
+            media_reference=self._reference_from_id(
+                clip.get("asset-id"), clip.get("type-name")),
+        )
+
+        return otio_clip
+
+
+    def _create_otio_clip(self, clip, all_names):
+        otio_clip = None
+
+        if clip.get("type-name") == "GESTransitionClip":
+            otio_clip = self._create_otio_transition(clip, all_names)
+        elif clip.get("type-name") == "GESUriClip":
+            otio_clip = self._create_otio_uri_clip(clip, all_names)
+
+        if otio_clip is None:
+            print("Could not represent: %s" % clip.attrib)
+            return None
+
+        otio_clip.metadata[META_NAMESPACE] = {
+            "properties": clip.get("properties", "properties;"),
+            "metadatas": clip.get("metadatas", "metadatas;"),
+        }
+
+        return otio_clip
+
+    def _create_otio_gap(self, start, duration):
+        source_range = otio.opentime.TimeRange(
+            start_time=otio.opentime.RationalTime(start),
+            duration=duration
+        )
+        return otio.schema.Gap(source_range=source_range)
+
+    def _reference_from_id(self, asset_id, asset_type="GESUriClip"):
+        asset = self._asset_by_id(asset_id, asset_type)
+        if asset is None:
+            return None
+        if not asset.get("id", ""):
+            return otio.schema.MissingReference()
+
+        duration = GST_CLOCK_TIME_NONE
+        if asset_type == "GESUriClip":
+            duration = get_from_structure(asset, "duration", duration)
+
+        available_range = otio.opentime.TimeRange(
+            start_time=self.to_rational_time(0),
+            duration=self.to_rational_time(duration)
+        )
+        ref = otio.schema.ExternalReference(
+            target_url=asset.get("id"),
+            available_range=available_range
+        )
+
+        ref.metadata[META_NAMESPACE] = {
+            "properties": asset.get("properties"),
+            "metadatas": asset.get("metadatas"),
+        }
+
+        return ref
+
+    # --------------------
+    # search helpers
+    # --------------------
+    def _asset_by_id(self, asset_id, asset_type):
+        return self.xges_xml.find(
+            "./project/ressources/asset[@id='{}'][@extractable-type-name='{}']".format(
+                asset_id, asset_type)
+        )
+
+    def _timeline_element_by_name(self, timeline, name):
+        for clip in timeline.findall("./layer/clip"):
+            if get_from_structure(clip, 'name') == name:
+                return clip
+
+        return None
+
+
+class XGESOtio:
+
+    def __init__(self, input_otio):
+        self.container = input_otio
+        self.rate = 25
+
+    def _insert_new_sub_element(self, into_parent, tag, attrib=None, text=''):
+        elem = cElementTree.SubElement(into_parent, tag, **attrib or {})
+        elem.text = text
+        return elem
+
+    def _get_element_properties(self, element):
+        return element.metadata.get(META_NAMESPACE, {}).get("properties", "properties;")
+
+    def _get_element_metadatas(self, element):
+        return element.metadata.get(META_NAMESPACE, {"GES": {}}).get("metadatas", "metadatas;")
+
+    def _serialize_ressource(self, ressources, ressource, asset_type):
+        if isinstance(ressource, otio.schema.MissingReference):
+            return
+
+        if ressources.find("./asset[@id='%s'][@extractable-type-name='%s']" % (
+                ressource.target_url, asset_type)) is not None:
+            return
+
+        properties = GstStructure(self._get_element_properties(ressource))
+        if properties.get('duration') is None:
+            properties.set('duration', 'guin64', to_gstclocktime(ressource.available_range.duration))
+
+        self._insert_new_sub_element(
+            ressources, 'asset',
+            attrib={
+                "id": ressource.target_url,
+                "extractable-type-name": 'GESUriClip',
+                "properties": str(properties),
+                "metadatas":  self._get_element_metadatas(ressource),
+            }
+        )
+
+    def _get_transition_times(self, offset, otio_transition):
+        rational_offset = otio.opentime.RationalTime(round(int(offset) / (GST_SECOND / self.rate)), self.rate)
+        start = rational_offset - otio_transition.in_offset
+        end = rational_offset + otio_transition.out_offset
+
+        return 0, to_gstclocktime(start), to_gstclocktime(end - start)
+
+    def _serialize_clip(self, otio_track, layer, layer_priority, ressources, otio_clip, clip_id, offset):
+        # FIXME - Figure out a proper way to determine clip type!
+        asset_id = "GESTitleClip"
+        asset_type = "GESTitleClip"
+
+        if isinstance(otio_clip, otio.schema.Transition):
+            asset_type = "GESTransitionClip"
+            asset_id = TRANSITION_MAP.get(otio_clip.transition_type, "crossfade")
+            inpoint, offset, duration = self._get_transition_times(offset, otio_clip)
+        else:
+            inpoint = to_gstclocktime(otio_clip.source_range.start_time)
+            duration = to_gstclocktime(otio_clip.source_range.duration)
+
+            if not isinstance(otio_clip.media_reference, otio.schema.MissingReference):
+                asset_id = otio_clip.media_reference.target_url
+                asset_type = "GESUriClip"
+
+            self._serialize_ressource(ressources, otio_clip.media_reference,
+                                    asset_type)
+
+        if otio_track.kind == otio.schema.TrackKind.Audio:
+            track_types = GESTrackType.AUDIO
+        elif otio_track.kind == otio.schema.TrackKind.Video:
+            track_types = GESTrackType.VIDEO
+        else:
+            raise ValueError("Unhandled track type: %s" % otio_track.kind)
+
+        properties = otio_clip.metadata.get(
+            META_NAMESPACE,
+            {
+                "properties": 'properties, name=(string)"%s"' % (
+                    GstStructure.escape(otio_clip.name)
+                )
+            }).get("properties")
+        return self._insert_new_sub_element(
+            layer, 'clip',
+            attrib={
+                "id": str(clip_id),
+                "properties": properties,
+                "asset-id": str(asset_id),
+                "type-name": str(asset_type),
+                "track-types": str(track_types),
+                "layer-priority": str(layer_priority),
+                "start": str(offset),
+                "rate": '0',
+                "inpoint": str(inpoint),
+                "duration": str(duration),
+                "metadatas":  self._get_element_metadatas(otio_clip),
+            }
+        )
+
+    def _serialize_tracks(self, timeline, otio_timeline):
+        properties = 'properties, restriction-caps=(string)audio/x-raw(ANY),framerate=(GstFraction)1/%s' % otio_timeline.duration().rate
+        self._insert_new_sub_element(
+            timeline, 'track',
+            attrib={
+                "caps": "audio/x-raw(ANY)",
+                "track-type": '2',
+                'track-id': '0',
+                'properties': properties
+            }
+        )
+
+        properties = 'properties, restriction-caps=(string)video/x-raw(ANY),framerate=(GstFraction)1/%s' % otio_timeline.duration().rate
+        for otio_track in otio_timeline.tracks:
+            if otio_track.kind == otio.schema.TrackKind.Video:
+                self._insert_new_sub_element(
+                    timeline, 'track',
+                    attrib={
+                        "caps": "video/x-raw(ANY)",
+                        "track-type": '4',
+                        'track-id': '1',
+                        'properties': properties,
+                    }
+                )
+
+                return
+
+    def _serialize_layer(self, timeline, layers, layer_priority):
+        if layer_priority not in layers:
+            layers[layer_priority] = self._insert_new_sub_element(
+                timeline, 'layer',
+                attrib={
+                    "priority": str(layer_priority),
+                }
+            )
+
+    def _serialize_timeline_element(self, timeline, layers, layer_priority,
+                                    offset, otio_track, otio_element, ressources, all_clips):
+        self._serialize_layer(timeline, layers, layer_priority)
+        layer = layers[layer_priority]
+        if isinstance(otio_element, (otio.schema.Clip, otio.schema.Transition)):
+            element = self._serialize_clip(otio_track, layer, layer_priority,
+                    ressources, otio_element, str(len(all_clips)), offset)
+            all_clips.add(element)
+            if isinstance(otio_element, otio.schema.Transition):
+                # Make next clip overlap
+                return int(element.get("start")) - offset
+        elif not isinstance(otio_element, otio.schema.Gap):
+            print("FIXME: Add support for %s" % type(otio_element))
+            return 0
+
+        return to_gstclocktime(otio_element.source_range.duration)
+
+    def _make_element_names_unique(self, all_names, otio_element):
+        if isinstance(otio_element, otio.schema.Gap):
+            return
+
+        if not isinstance(otio_element, otio.schema.Track):
+            i = 0
+            name = otio_element.name
+            while True:
+                if name not in all_names:
+                    otio_element.name = name
+                    break
+
+                i += 1
+                name = otio_element.name + '_%d' % i
+            all_names.add(otio_element.name)
+
+        if isinstance(otio_element, (otio.schema.Stack, otio.schema.Track)):
+            for sub_element in otio_element:
+                self._make_element_names_unique(all_names, sub_element)
+
+    def _make_timeline_elements_names_unique(self, otio_timeline):
+        element_names = set()
+        for track in otio_timeline.tracks:
+            for element in track:
+                self._make_element_names_unique(element_names, element)
+
+    def _serialize_timeline(self, project, ressources, otio_timeline):
+        metadatas = GstStructure(self._get_element_metadatas(otio_timeline))
+        metadatas.set(
+            "framerate", "fraction", self._framerate_to_frame_duration(
+                otio_timeline.duration().rate
+            )
+        )
+        timeline = self._insert_new_sub_element(
+            project, 'timeline',
+            attrib={
+                "properties": self._get_element_properties(otio_timeline),
+                "metadatas":  str(metadatas),
+            }
+        )
+        self._serialize_tracks(timeline, otio_timeline)
+
+        self._make_timeline_elements_names_unique(otio_timeline)
+
+        all_clips = set()
+        layers = {}
+        for layer_priority, otio_track in enumerate(otio_timeline.tracks):
+            self._serialize_layer(timeline, layers, layer_priority)
+            offset = 0
+            for otio_element in otio_track:
+                offset += self._serialize_timeline_element(
+                    timeline, layers, layer_priority, offset,
+                    otio_track, otio_element, ressources, all_clips,
+                )
+
+        for layer in layers.values():
+            layer[:] = sorted(layer, key=lambda child: int(child.get("start")))
+
+    # --------------------
+    # static methods
+    # --------------------
+    @staticmethod
+    def _framerate_to_frame_duration(framerate):
+        frame_duration = FRAMERATE_FRAMEDURATION.get(int(framerate), "")
+        if not frame_duration:
+            frame_duration = FRAMERATE_FRAMEDURATION.get(float(framerate), "")
+        return frame_duration
+
+    def to_xges(self):
+        xges = cElementTree.Element('ges', version="0.4")
+
+        metadatas = GstStructure(self._get_element_metadatas(self.container))
+        if self.container.name is not None:
+            metadatas.set( "name", "string", self.container.name)
+        if not isinstance(self.container, otio.schema.Timeline):
+            project = self._insert_new_sub_element(
+                xges, 'project',
+                attrib={
+                    "properties": self._get_element_properties(self.container),
+                    "metadatas":  str(metadatas),
+                }
+            )
+
+            if len(self.container) > 1:
+                print(
+                    "WARNING: Only one timeline supported, using *only* the first one.")
+
+            otio_timeline = self.container[0]
+
+        else:
+            project = self._insert_new_sub_element(
+                xges, 'project',
+                attrib={
+                    "metadatas":  str(metadatas),
+                }
+            )
+            otio_timeline = self.container
+
+        ressources = self._insert_new_sub_element(project, 'ressources')
+        self.rate = otio_timeline.duration().rate
+        self._serialize_timeline(project, ressources, otio_timeline)
+
+        # with indentations.
+        string = cElementTree.tostring(xges, encoding="UTF-8")
+        dom = minidom.parseString(string)
+        return dom.toprettyxml(indent='    ')
+
+
+# --------------------
+# adapter requirements
+# --------------------
+def read_from_string(input_str):
+    """
+    Necessary read method for otio adapter
+
+    Args:
+        input_str (str): A GStreamer Editing Services formated project
+
+    Returns:
+        OpenTimeline: An OpenTimeline object
+    """
+
+    return XGES(input_str).to_otio()
+
+
+def write_to_string(input_otio):
+    """
+    Necessary write method for otio adapter
+
+    Args:
+        input_otio (OpenTimeline): An OpenTimeline object
+
+    Returns:
+        str: The string contents of an FCP X XML
+    """
+
+    return XGESOtio(input_otio).to_xges()
+
+
+# --------------------
+# Some unit check for internal types
+# --------------------
+
+class XGESTests(unittest.TestCase):
+
+    def test_gst_structure_parsing(self):
+        struct = GstStructure('properties, name=(string)"%s";' % (
+            GstStructure.escape("sc01 sh010_anim.mov"))
+        )
+        self.assertEqual(struct["name"], "sc01 sh010_anim.mov")
+
+    def test_gst_structure_editing(self):
+        struct = GstStructure('properties, name=(string)"%s";' % (
+            GstStructure.escape("sc01 sh010_anim.mov"))
+        )
+        self.assertEqual(struct["name"], "sc01 sh010_anim.mov")
+
+        struct.set("name", "string", "test")
+        self.assertEqual(struct["name"], "test")
+        self.assertEqual(str(struct), 'properties, name=(string)"test";')
+
+    def test_empty_string(self):
+        struct = GstStructure('properties, name=(string)"";')
+        self.assertEqual(struct["name"], "")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This implement the basic for a "xges" adapter, the native [GStreamer Editing Services] serialization format.

## Implemented features:

- [x] Clip serialization/de-serialization
- [x] Transitions

## Missing features

- [ ] Stacks inside Tracks, we are missing [nested timelines](https://gitlab.freedesktop.org/gstreamer/gst-editing-services/issues/60) in **GES**
- [ ] [GESGroups](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-editing-services/html/GESGroup.html), basically I can't find any way to represent them in **otio**. Groups are simply a way to represent the fact that several clips are meant to be manipulated together in a timeline.
- [ ] Effects, **otio** doesn't seem to have that feature yet
- [ ] Keyframes, **otio** doesn't seem to have that feature yet

I have already implemented a [GESFormatter](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-editing-services/html/GESFormatter.html) to be able to take advantage of the otio formatter in any project using GES. I am not sure if it belongs to otio itself or GES, what would you prefer?

Also note that in GES each and every timestamp is a GstClockTime (a.k.a `long unsigned int`) representing times in nanoseconds, this lead to big approximation because of the nature of times representation in otio. Note that this "restriction" in GES is being worked on and we plan on introducing a mode where we would work with rational time exclusively (see [this issue](https://gitlab.freedesktop.org/gstreamer/gst-editing-services/issues/61)). 

[GStreamer Editing Services]: https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer-editing-services/html/ch01.html