### PR TITLE
otioconvert fixes output adapter arguments

### DIFF
--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -101,6 +101,16 @@ def _parsed_args():
         'key=value. Values are strings, numbers or Python literals: True, '
         'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
     )
+    parser.add_argument(
+        '-A',
+        '--output-adapter-arg',
+        type=str,
+        default=[],
+        action='append',
+        help='Extra arguments to be passed to output adapter in the form of '
+        'key=value. Values are strings, numbers or Python literals: True, '
+        'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
+    )
 
     return parser.parse_args()
 
@@ -161,7 +171,30 @@ def main():
             result_tracks.append(tr)
         result_tl.tracks = result_tracks
 
-    otio.adapters.write_to_file(result_tl, args.output, out_adapter)
+    argument_map = {}
+    for pair in args.output_adapter_arg:
+        if '=' in pair:
+            key, val = pair.split('=', 1)  # only split on the 1st '='
+            try:
+                # Sometimes we need to pass a bool, int, list, etc.
+                parsed_value = ast.literal_eval(val)
+            except (ValueError, SyntaxError):
+                # Fall back to a simple string
+                parsed_value = val
+            argument_map[key] = parsed_value
+        else:
+            print(
+                "error: adapter arguments must be in the form key=value"
+                " got: {}".format(pair)
+            )
+            sys.exit(1)
+
+    otio.adapters.write_to_file(
+        result_tl,
+        args.output,
+        out_adapter,
+        **argument_map
+    )
 
 
 if __name__ == '__main__':

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -167,7 +167,7 @@ def main():
         for track in args.tracks.split(","):
             tr = result_tl.tracks[int(track)]
             del result_tl.tracks[int(track)]
-            print("track {} is of kind: {}".format(track, tr.kind))
+            print("track {0} is of kind: '{1}'".format(track, tr.kind))
             result_tracks.append(tr)
         result_tl.tracks = result_tracks
 

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -167,7 +167,7 @@ def main():
         for track in args.tracks.split(","):
             tr = result_tl.tracks[int(track)]
             del result_tl.tracks[int(track)]
-            print "track {} is of kind: {}".format(track, tr.kind)
+            print("track {} is of kind: {}".format(track, tr.kind))
             result_tracks.append(tr)
         result_tl.tracks = result_tracks
 

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -109,7 +109,7 @@ def _parsed_args():
         action='append',
         help='Extra arguments to be passed to output adapter in the form of '
         'key=value. Values are strings, numbers or Python literals: True, '
-        'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
+        'False, etc. Can be used multiple times: -A burrito="bar" -A taco=12.'
     )
 
     return parser.parse_args()

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -26,6 +26,7 @@
 import argparse
 import sys
 import ast
+import copy
 
 import opentimelineio as otio
 
@@ -151,9 +152,13 @@ def main():
     )
 
     if args.tracks:
-        result_tracks = []
+        result_tracks = copy.deepcopy(otio.schema.Stack())
+        del result_tracks[:]
         for track in args.tracks.split(","):
-            result_tracks.append(result_tl.tracks[int(track)])
+            tr = result_tl.tracks[int(track)]
+            del result_tl.tracks[int(track)]
+            print "track {} is of kind: {}".format(track, tr.kind)
+            result_tracks.append(tr)
         result_tl.tracks = result_tracks
 
     otio.adapters.write_to_file(result_tl, args.output, out_adapter)


### PR DESCRIPTION
- fixes the track selection in `otioconvert`, which was broken when we switched the parenting rules
- adds support for -A to send arguments to the output adapter as well.