### PR TITLE
Guard against `timecode_start` is None

### DIFF
--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -260,7 +260,9 @@ def _transcribe(item, parent=None, editRate=24, masterMobs=None):
         startTime = int(metadata.get("StartTime", "0"))
         if timecode_info:
             timecode_start, timecode_length = timecode_info
-            startTime += timecode_start
+
+            if timecode_start is not None:
+                startTime += timecode_start
 
         result.source_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(startTime, editRate),

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -179,6 +179,13 @@ def _extract_timecode_info(mob):
         timecode = timecodes[0]
         timecode_start = timecode.getvalue('Start')
         timecode_length = timecode.getvalue('Length')
+
+        if timecode_start is None or timecode_length is None:
+            raise otio.exceptions.NotSupportedError(
+                "Unexpected timecode value(s) in mob name: `{}`."
+                " `Start`: {}, `Length`: {}".format(mob.name, timecode_start, timecode_length)
+            )
+
         return timecode_start, timecode_length
     elif len(timecodes) > 1:
         raise otio.exceptions.NotSupportedError(

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -182,7 +182,7 @@ def _extract_timecode_info(mob):
 
         if timecode_start is None or timecode_length is None:
             raise otio.exceptions.NotSupportedError(
-                "Unexpected timecode value(s) in mob name: `{}`."
+                "Unexpected timecode value(s) in mob named: `{}`."
                 " `Start`: {}, `Length`: {}".format(mob.name, timecode_start, timecode_length)
             )
 

--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -260,9 +260,7 @@ def _transcribe(item, parent=None, editRate=24, masterMobs=None):
         startTime = int(metadata.get("StartTime", "0"))
         if timecode_info:
             timecode_start, timecode_length = timecode_info
-
-            if timecode_start is not None:
-                startTime += timecode_start
+            startTime += timecode_start
 
         result.source_range = otio.opentime.TimeRange(
             otio.opentime.RationalTime(startTime, editRate),


### PR DESCRIPTION
With the change in https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/410 `_extract_timecode_info` could potential return startTime as None. 

It'll trigger error like this:
File "/Users/jchen/scratch/gitlab/transmogrifier2/lib/OpenTimelineIO/opentimelineio_contrib/adapters/advanced_authoring_format.py", line 262, in _transcribe startTime += timecode_start TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'

I ran into this several days ago. I will upload an example somewhere accessible.
