### PR TITLE
Fix N^2 (over items) performance in otioview _populate

### DIFF
--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -275,8 +275,9 @@ class Track(QtWidgets.QGraphicsRectItem):
         self._populate()
 
     def _populate(self):
+        track_map = self.track.range_of_all_children()
         for n, item in enumerate(self.track):
-            timeline_range = self.track.range_of_child_at_index(n)
+            timeline_range = track_map[item]
 
             rect = QtCore.QRectF(
                 0,


### PR DESCRIPTION
- We added the range_of_all_children method for exactly this use case- it was missing here
- This _significantly_ improves performance of reading large files into otioview