### PR TITLE
Use PyAAF2’s `def walk()`.

### DIFF
--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -52,37 +52,6 @@ def _get_parameter(item, parameter_name):
     return values.get(parameter_name)
 
 
-def _walk_item(thing):
-    slot = thing.slot
-    if not slot:
-        return
-    segment = slot.segment
-    if isinstance(segment, aaf2.components.SourceClip):
-        yield segment
-        for item in _walk_item(segment):
-            yield item
-    # elif isinstance(segment, aaf2.components.Sequence):
-    #     clip = segment.component_at_time(thing.start_time)
-    #     if isinstance(clip, SourceClip):
-    #         yield clip
-    #         for item in clip._walk_item():
-    #             yield item
-    #     else:
-    #         raise NotImplementedError(
-    #            "Sequence returned {} not implemented".format(type(segment))
-    elif isinstance(segment, aaf2.components.EssenceGroup):
-        yield segment
-    elif isinstance(segment, aaf2.components.Filler):
-        yield segment
-    elif isinstance(segment, (aaf2.components.OperationGroup,
-                              aaf2.components.Pulldown)):
-        yield segment
-    else:
-        raise NotImplementedError(
-            "walking {} not implemented".format(type(segment))
-        )
-
-
 def _get_name(item):
     if isinstance(item, aaf2.components.SourceClip):
         try:
@@ -136,7 +105,7 @@ def _transcribe_property(prop):
 def _find_timecode_mobs(item):
     mobs = [item.mob]
 
-    for c in _walk_item(item):
+    for c in item.walk():
         if isinstance(c, aaf2.components.SourceClip):
             mob = c.mob
             if mob:

--- a/setup.py
+++ b/setup.py
@@ -222,7 +222,7 @@ setup(
     },
 
     install_requires=[
-        'pyaaf2==1.1.0'
+        'pyaaf2==1.2.0'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Some changes (c77bbb1, 5b2cfa5) in PyAAF2 hasn’t been in a versioned tag yet.
We need to update OTIO’s pinned pyaaf2 version (from 1.1.0) to make this working properly.