### PR TITLE
Prepending blank movieproc to audio track sources in RV to hide any video

### DIFF
--- a/opentimelineio_contrib/adapters/extern_rv.py
+++ b/opentimelineio_contrib/adapters/extern_rv.py
@@ -242,8 +242,9 @@ def _create_media_reference(item, src, track_kind=None):
                     item.available_range().end_time_inclusive().value,
                     item.available_range().duration.rate
                 )
-                # Appending blank to media promotes name of audio file in RV
-                media.append(blank)
+                # Inserting blank media here forces all content to only
+                # produce audio.
+                media.insert(0, blank)
 
             src.setMedia(media)
             return True

--- a/opentimelineio_contrib/adapters/extern_rv.py
+++ b/opentimelineio_contrib/adapters/extern_rv.py
@@ -243,8 +243,9 @@ def _create_media_reference(item, src, track_kind=None):
                     item.available_range().duration.rate
                 )
                 # Inserting blank media here forces all content to only
-                # produce audio.
-                media.insert(0, blank)
+                # produce audio. We do it twice in case we look at this in
+                # stereo
+                media = [blank, blank] + media
 
             src.setMedia(media)
             return True

--- a/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
+++ b/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
@@ -61,7 +61,7 @@ sourceGroup000000_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86501.0,end=86531.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86501,end=86531,fps=24.0.movieproc"
     }
 
     attributes
@@ -93,7 +93,7 @@ sourceGroup000001_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86557.0,end=86606.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86557,end=86606,fps=24.0.movieproc"
     }
 
     attributes
@@ -125,7 +125,7 @@ sourceGroup000002_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86601.0,end=86628.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86601,end=86628,fps=24.0.movieproc"
     }
 
     attributes
@@ -157,7 +157,7 @@ sourceGroup000003_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86641.0,end=86755.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86641,end=86755,fps=24.0.movieproc"
     }
 
     attributes
@@ -189,7 +189,7 @@ sourceGroup000004_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86753.0,end=86853.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86753,end=86853,fps=24.0.movieproc"
     }
 
     attributes
@@ -221,7 +221,7 @@ sourceGroup000005_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86501.0,end=86661.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86501,end=86661,fps=24.0.movieproc"
     }
 
     attributes
@@ -253,7 +253,7 @@ sourceGroup000006_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86628.0,end=86797.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86628,end=86797,fps=24.0.movieproc"
     }
 
     attributes
@@ -285,7 +285,7 @@ sourceGroup000007_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86722.0,end=86857.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86722,end=86857,fps=24.0.movieproc"
     }
 
     attributes
@@ -317,7 +317,7 @@ sourceGroup000008_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=86501.0,end=86757.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=86501,end=86757,fps=24.0.movieproc"
     }
 
     attributes

--- a/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
+++ b/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
@@ -118,7 +118,7 @@ sourceGroup000000_source : RVFileSource (1)
 
     media
     {
-        string movie = "blank,start=0.0,end=19.0,fps=24.0.movieproc"
+        string movie = "blank,start=0.0,end=19.0,fps=24.movieproc"
     }
 
     attributes
@@ -150,7 +150,7 @@ sourceGroup000001_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=-10.0,end=9.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=-10.0,end=9.0,fps=24.movieproc"
     }
 
     attributes
@@ -182,7 +182,7 @@ sourceGroup000002_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=10.0,end=39.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=10.0,end=39.0,fps=24.movieproc"
     }
 
     attributes
@@ -214,7 +214,7 @@ sourceGroup000003_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=40.0,end=59.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=40.0,end=59.0,fps=24.movieproc"
     }
 
     attributes
@@ -246,7 +246,7 @@ sourceGroup000004_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=-10.0,end=9.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=-10.0,end=9.0,fps=24.movieproc"
     }
 
     attributes
@@ -278,7 +278,7 @@ sourceGroup000005_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=10.0,end=49.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=10.0,end=49.0,fps=24.movieproc"
     }
 
     attributes
@@ -310,7 +310,7 @@ sourceGroup000006_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=0.0,end=39.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=0.0,end=39.0,fps=24.movieproc"
     }
 
     attributes
@@ -342,7 +342,7 @@ sourceGroup000007_source : RVFileSource (1)
 
     media
     {
-        string movie = "smptebars,start=40.0,end=59.0,fps=24.0.movieproc"
+        string movie = "smptebars,start=40.0,end=59.0,fps=24.movieproc"
     }
 
     attributes
@@ -374,7 +374,7 @@ sourceGroup000008_source : RVFileSource (1)
 
     media
     {
-        string movie = "blank,start=-10.0,end=9.0,fps=24.0.movieproc"
+        string movie = "blank,start=-10.0,end=9.0,fps=24.movieproc"
     }
 
     attributes

--- a/opentimelineio_contrib/adapters/tests/test_rvsession.py
+++ b/opentimelineio_contrib/adapters/tests/test_rvsession.py
@@ -515,7 +515,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
 
         audio_video_source = (
             'string movie = '
-            '[ "/path/to/audio.wav" "blank,start=0,end=499,fps=25.movieproc" ]'
+            '[ "blank,start=0,end=499,fps=25.movieproc" "/path/to/audio.wav" ]'
         )
 
         with open(tmp_path, "r") as f:

--- a/opentimelineio_contrib/adapters/tests/test_rvsession.py
+++ b/opentimelineio_contrib/adapters/tests/test_rvsession.py
@@ -521,7 +521,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
         with open(tmp_path, "r") as f:
             rv_session = f.read()
             self.assertEqual(rv_session.count("string movie"), 2)
-            self.assertEqual(rv_session.count("blank"), 1)
+            self.assertEqual(rv_session.count("blank"), 2)
             self.assertEqual(rv_session.count(audio_video_source), 1)
 
     def test_nested_stack(self):

--- a/opentimelineio_contrib/adapters/tests/test_rvsession.py
+++ b/opentimelineio_contrib/adapters/tests/test_rvsession.py
@@ -515,7 +515,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
 
         audio_video_source = (
             'string movie = '
-            '[ "blank,start=0,end=499,fps=25.movieproc" "/path/to/audio.wav" ]'
+            '[ "blank,start=0,end=499,fps=25.movieproc" "blank,start=0,end=499,fps=25.movieproc" "/path/to/audio.wav" ]'
         )
 
         with open(tmp_path, "r") as f:
@@ -537,7 +537,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
 
         audio_video_source = (
             'string movie = '
-            '[ "blank,start=0,end=237,fps=24.movieproc" "/path/to/some/audio.wav" ]'
+            '[ "blank,start=0,end=237,fps=24.movieproc" "blank,start=0,end=237,fps=24.movieproc" "/path/to/some/audio.wav" ]'
         )
         video_source = (
             'string movie = "/path/to/some/video.mov"'

--- a/opentimelineio_contrib/adapters/tests/test_rvsession.py
+++ b/opentimelineio_contrib/adapters/tests/test_rvsession.py
@@ -537,7 +537,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
 
         audio_video_source = (
             'string movie = '
-            '[ "/path/to/some/audio.wav" "blank,start=0,end=237,fps=24.movieproc" ]'
+            '[ "blank,start=0,end=237,fps=24.movieproc" "/path/to/some/audio.wav" ]'
         )
         video_source = (
             'string movie = "/path/to/some/video.mov"'


### PR DESCRIPTION
For discussion, but coming out of #363, this alternate approach will hide any video that might be coming through via an "Audio" track kind.