### PR TITLE
Store the REEL variable in the cmx_3600 metadata when not `AX`

### DIFF
--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -111,7 +111,7 @@ class EDLParser(object):
             clip.metadata['cmx_3600']['reel'] = reel
 
         if comment_handler.unhandled:
-            if clip.metadata.get('cmx_3600', None) is None:
+            if clip.metadata.get('cmx_3600') is None:
                 clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600'].setdefault("comments", [])
             clip.metadata['cmx_3600']['comments'] += (

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -105,10 +105,10 @@ class EDLParser(object):
         clip_handler = ClipHandler(line, comment_handler.handled, rate=rate)
         clip = clip_handler.clip
         reel = clip_handler.reel
-        
+
         # A reel name of `AX` represents an unknown or auxilary source
         # We don't currently track these sources outside of this adapter
-        # So lets skip adding AX reels as metadata for now, 
+        # So lets skip adding AX reels as metadata for now,
         # as that would dirty json outputs with non-relevant infomartion
         if reel != 'AX':
             clip.metadata.setdefault("cmx_3600", {})

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -105,14 +105,17 @@ class EDLParser(object):
         clip_handler = ClipHandler(line, comment_handler.handled, rate=rate)
         clip = clip_handler.clip
         reel = clip_handler.reel
+        
+        # A reel name of `AX` represents an unknown or auxilary source
+        # We don't currently track these sources outside of this adapter
+        # So lets skip adding AX reels as metadata for now, 
+        # as that would dirty json outputs with non-relevant infomartion
         if reel != 'AX':
-            if not clip.metadata.get('cmx_3600'):
-                clip.metadata.setdefault("cmx_3600", {})
+            clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600']['reel'] = reel
 
         if comment_handler.unhandled:
-            if clip.metadata.get('cmx_3600') is None:
-                clip.metadata.setdefault("cmx_3600", {})
+            clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600'].setdefault("comments", [])
             clip.metadata['cmx_3600']['comments'] += (
                 comment_handler.unhandled

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -109,7 +109,7 @@ class EDLParser(object):
         # A reel name of `AX` represents an unknown or auxilary source
         # We don't currently track these sources outside of this adapter
         # So lets skip adding AX reels as metadata for now,
-        # as that would dirty json outputs with non-relevant infomartion
+        # as that would dirty json outputs with non-relevant information
         if reel != 'AX':
             clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600']['reel'] = reel

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -106,12 +106,12 @@ class EDLParser(object):
         clip = clip_handler.clip
         reel = clip_handler.reel
         if reel != 'AX':
-            if clip.metadata.get('cmx_3600',None) is None:
+            if clip.metadata.get('cmx_3600', None) is None:
                 clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600']['reel'] = reel
 
         if comment_handler.unhandled:
-            if clip.metadata.get('cmx_3600',None) is None:
+            if clip.metadata.get('cmx_3600', None) is None:
                 clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600'].setdefault("comments", [])
             clip.metadata['cmx_3600']['comments'] += (

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -106,7 +106,7 @@ class EDLParser(object):
         clip = clip_handler.clip
         reel = clip_handler.reel
         if reel != 'AX':
-            if clip.metadata.get('cmx_3600', None) is None:
+            if not clip.metadata.get('cmx_3600'):
                 clip.metadata.setdefault("cmx_3600", {})
             clip.metadata['cmx_3600']['reel'] = reel
 

--- a/tests/sample_data/nucoda_example.edl
+++ b/tests/sample_data/nucoda_example.edl
@@ -1,4 +1,4 @@
-TITLE:  Nucoda_Example.01
+TITLE:   Nucoda_Example.01
 001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
 * FROM CLIP NAME:  take_1
 * FROM FILE: S:\path\to\ZZ100_501.take_1.0001.exr

--- a/tests/sample_data/nucoda_example.edl
+++ b/tests/sample_data/nucoda_example.edl
@@ -1,4 +1,5 @@
-TITLE:   Nucoda_Example.01
+TITLE: Nucoda_Example.01
+
 001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
 * FROM CLIP NAME:  take_1
 * FROM FILE: S:\path\to\ZZ100_501.take_1.0001.exr

--- a/tests/sample_data/nucoda_example.edl
+++ b/tests/sample_data/nucoda_example.edl
@@ -1,5 +1,4 @@
-TITLE: Nucoda_Example.01
-
+TITLE:  Nucoda_Example.01
 001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
 * FROM CLIP NAME:  take_1
 * FROM FILE: S:\path\to\ZZ100_501.take_1.0001.exr

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -505,7 +505,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertMultiLineEqual(result, expected)
 
     def test_reels_edl_round_trip_string2mem2string(self):
-        
+
         sample_data = r'''TITLE: Reels_Example.01
 
 001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
@@ -515,10 +515,10 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 * FROM CLIP NAME:  take_2
 * FROM FILE: S:\path\to\ZZ100_502A.take_2.0101.exr
 '''
-        
+
         timeline = otio.adapters.read_from_string(sample_data, adapter_name="cmx_3600")
-        otio_data = otio.adapters.write_to_string(timeline, adapter_name="cmx_3600", style="nucoda")
-        
+        otio_data = otio.adapters.write_to_string(timeline, adapter_name="cmx_3600",
+                                                  style="nucoda")
         self.assertMultiLineEqual(sample_data, otio_data)
 
     def test_nucoda_edl_write_with_transition(self):

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -567,6 +567,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = r'''TITLE: Example CrossDissolve
+
 001  Clip1    V     C        00:00:05:11 00:00:07:08 00:00:00:00 00:00:01:21
 * FROM CLIP NAME:  Clip1
 * FROM FILE: /var/tmp/clip1.001.exr
@@ -614,6 +615,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = r'''TITLE: Example Fade In
+
 001  BL       V     C        00:00:00:00 00:00:00:00 00:00:00:00 00:00:00:00
 001  My_Clip  V     D 012    00:00:02:02 00:00:03:04 00:00:00:00 00:00:01:02
 * TO CLIP NAME:  My Clip
@@ -653,6 +655,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = r'''TITLE: Example Fade Out
+
 001  My_Clip  V     C        00:00:01:00 00:00:01:12 00:00:00:00 00:00:00:12
 * FROM CLIP NAME:  My Clip
 * FROM FILE: /var/tmp/clip.001.exr
@@ -706,6 +709,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = '''TITLE: Double Transition
+
 001  Reel1    V     C        00:00:01:00 00:00:01:18 00:00:00:00 00:00:00:18
 002  Reel1    V     C        00:00:01:18 00:00:01:18 00:00:00:18 00:00:00:18
 002  Reel2    V     D 012    00:00:00:18 00:00:01:18 00:00:00:18 00:00:01:18

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -504,15 +504,22 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(result, expected)
 
-    def test_nucoda_edl_round_trip_disk2mem2string(self):
-        edl_path = NUCODA_EXAMPLE_PATH
-        timeline = otio.adapters.read_from_file(edl_path)
+    def test_reels_edl_round_trip_string2mem2string(self):
+        
+        sample_data = r'''TITLE: Reels_Example.01
+
+001  ZZ100_50 V     C        01:00:04:05 01:00:05:12 00:59:53:11 00:59:54:18
+* FROM CLIP NAME:  take_1
+* FROM FILE: S:\path\to\ZZ100_501.take_1.0001.exr
+002  ZZ100_50 V     C        01:00:06:13 01:00:08:15 00:59:54:18 00:59:56:20
+* FROM CLIP NAME:  take_2
+* FROM FILE: S:\path\to\ZZ100_502A.take_2.0101.exr
+'''
+        
+        timeline = otio.adapters.read_from_string(sample_data, adapter_name="cmx_3600")
         otio_data = otio.adapters.write_to_string(timeline, adapter_name="cmx_3600", style="nucoda")
         
-        nucoda_data = ""
-        with open(edl_path, 'r') as nucodafile:
-            nucoda_data=nucodafile.read()
-        self.assertMultiLineEqual(nucoda_data,otio_data)
+        self.assertMultiLineEqual(sample_data,otio_data)
 
     def test_nucoda_edl_write_with_transition(self):
         track = otio.schema.Track()

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -504,6 +504,16 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(result, expected)
 
+    def test_nucoda_edl_round_trip_disk2mem2string(self):
+        edl_path = NUCODA_EXAMPLE_PATH
+        timeline = otio.adapters.read_from_file(edl_path)
+        otio_data = otio.adapters.write_to_string(timeline, adapter_name="cmx_3600", style="nucoda")
+        
+        nucoda_data = ""
+        with open(edl_path, 'r') as nucodafile:
+            nucoda_data=nucodafile.read()
+        self.assertMultiLineEqual(nucoda_data,otio_data)
+
     def test_nucoda_edl_write_with_transition(self):
         track = otio.schema.Track()
         tl = otio.schema.Timeline(
@@ -557,7 +567,6 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = r'''TITLE: Example CrossDissolve
-
 001  Clip1    V     C        00:00:05:11 00:00:07:08 00:00:00:00 00:00:01:21
 * FROM CLIP NAME:  Clip1
 * FROM FILE: /var/tmp/clip1.001.exr
@@ -605,7 +614,6 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = r'''TITLE: Example Fade In
-
 001  BL       V     C        00:00:00:00 00:00:00:00 00:00:00:00 00:00:00:00
 001  My_Clip  V     D 012    00:00:02:02 00:00:03:04 00:00:00:00 00:00:01:02
 * TO CLIP NAME:  My Clip
@@ -645,7 +653,6 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = r'''TITLE: Example Fade Out
-
 001  My_Clip  V     C        00:00:01:00 00:00:01:12 00:00:00:00 00:00:00:12
 * FROM CLIP NAME:  My Clip
 * FROM FILE: /var/tmp/clip.001.exr
@@ -699,7 +706,6 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         expected = '''TITLE: Double Transition
-
 001  Reel1    V     C        00:00:01:00 00:00:01:18 00:00:00:00 00:00:00:18
 002  Reel1    V     C        00:00:01:18 00:00:01:18 00:00:00:18 00:00:00:18
 002  Reel2    V     D 012    00:00:00:18 00:00:01:18 00:00:00:18 00:00:01:18

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -519,7 +519,7 @@ class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         timeline = otio.adapters.read_from_string(sample_data, adapter_name="cmx_3600")
         otio_data = otio.adapters.write_to_string(timeline, adapter_name="cmx_3600", style="nucoda")
         
-        self.assertMultiLineEqual(sample_data,otio_data)
+        self.assertMultiLineEqual(sample_data, otio_data)
 
     def test_nucoda_edl_write_with_transition(self):
         track = otio.schema.Track()


### PR DESCRIPTION
Stashes the clip_handlers `reel` in the cmx_3600 metadata so it can be recalled when written back out by the cmx_3600 adapter

Also added a test event that `round trips` the sample nucoda edl while maintaining the REEL(SOURCE_ID) field

~BREAKING CHANGE: had to update the nucoda sample edl to match the output format, which includes a new line after Title.  May or may not effect others using that sample~