### PR TITLE
Fix slice insert membership bug

### DIFF
--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -653,15 +653,15 @@ class Composition(item.Item, collections.MutableSequence):
             old._set_parent(None)
             self._child_lookup.remove(old)
 
-        # put it into our membership tracking set
-        self._child_lookup.add(value)
-
         # put it into our list of children
         self._children[key] = value
 
         # set the new parent
         if value is not None:
             value._set_parent(self)
+
+            # put it into our membership tracking set
+            self._child_lookup.add(value)
 
     def insert(self, index, item):
         """Insert an item into the composition at location `index`."""
@@ -704,22 +704,15 @@ class Composition(item.Item, collections.MutableSequence):
         # grab the old value
         old = self._children[key]
 
-        # remove it from the membership tracking set
+        # remove it from the membership tracking set and clear parent
         if old is not None:
             if isinstance(key, slice):
                 for val in old:
                     self._child_lookup.remove(val)
+                    val._set_parent(None)
             else:
                 self._child_lookup.remove(old)
+                old._set_parent(None)
 
         # remove it from our list of children
         del self._children[key]
-
-        # unset the old value's parent
-        if old is not None:
-            if isinstance(key, slice):
-                for val in old:
-                    val._set_parent(None)
-            else:
-                old._set_parent(None)
-    # @}

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -620,6 +620,7 @@ class Composition(item.Item, collections.MutableSequence):
             # update old parent
             for val in old:
                 val._set_parent(None)
+                self._child_lookup.remove(val)
 
         # insert into _children
         self._children[key] = value

--- a/opentimelineio/core/composition.py
+++ b/opentimelineio/core/composition.py
@@ -628,6 +628,7 @@ class Composition(item.Item, collections.MutableSequence):
         if value:
             for val in value:
                 val._set_parent(self)
+                self._child_lookup.add(val)
 
     def __setitem__(self, key, value):
         # fetch the current thing at that index/slice

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -231,6 +231,29 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         tr.pop()
         self.assertNotIn(cl, tr)
 
+    def test_insert_slice(self):
+        """Test that inserting by slice actually correctly inserts"""
+
+        st = otio.schema.Stack()
+        cl = otio.schema.Clip()
+
+        st[:] = [cl]
+
+        self.assertEqual(cl, st[0])
+
+        del st[0]
+
+        self.assertEqual(len(st), 0)
+
+        # again, this time deleting with a slice as well.
+        st[:] = [cl]
+
+        self.assertEqual(cl, st[0])
+
+        del st[:]
+
+        self.assertEqual(len(st), 0)
+
 
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -264,6 +264,7 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertNotIn(cl, st)
         self.assertIn(cl2, st)
 
+
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
     def test_cons(self):

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -254,6 +254,15 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
 
         self.assertEqual(len(st), 0)
 
+        st = otio.schema.Stack()
+        cl = otio.schema.Clip()
+        cl2 = otio.schema.Clip()
+
+        st[:] = [cl]
+        st[:] = [cl2]
+
+        self.assertNotIn(cl, st)
+        self.assertIn(cl2, st)
 
 class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
 


### PR DESCRIPTION
Inserting to a composition with a slice was omitting members from the `_child_lookup` set.  This fixes that bug, and hopefully addresses #436.