### PR TITLE
Ruler

### DIFF
--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -35,7 +35,6 @@ TIME_MULTIPLIER = 25
 LABEL_MARGIN = 5
 MARKER_SIZE = 10
 RULER_SIZE = 10
-EFFECT_HEIGHT = 0.25 * TRACK_HEIGHT
 
 
 class _BaseItem(QtWidgets.QGraphicsRectItem):
@@ -60,8 +59,7 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
 
         self._add_markers()
         self._set_labels()
-        self._set_tooltip()
-        self._add_effects()       
+        self._set_tooltip()    
 
     def paint(self, *args, **kwargs):
         new_args = [args[0],
@@ -100,14 +98,6 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
                 ) * TIME_MULTIPLIER
             )
             marker.setParentItem(self)
-
-    def _add_effects(self):
-        if not hasattr(self.item,"effects") :
-            return
-        if not self.item.effects :
-            return
-        effect = Effect(self.item.effects, self.timeline_range, self.rect())
-        effect.setParentItem(self)
 
     def _position_labels(self):
         self.source_in_label.setY(LABEL_MARGIN)
@@ -213,60 +203,6 @@ class GapItem(_BaseItem):
         )
         self.source_name_label.setText('GAP')
 
-class Effect(QtWidgets.QGraphicsRectItem):
-
-    def __init__(self, item, timeline_range, rect, *args, **kwargs):
-        super(Effect, self).__init__(rect,*args, **kwargs)
-        self.item = item
-        self.timeline_range = timeline_range
-        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
-        self.init()
-
-    def init(self):
-        rect = self.rect()
-        rect.setY(TRACK_HEIGHT - EFFECT_HEIGHT)
-        rect.setHeight(EFFECT_HEIGHT)
-        self.setRect(rect)
-
-        colour = QtGui.QColor(255, 255, 255, 255)
-        gradient = QtGui.QLinearGradient(QtCore.QPoint(0,0), QtCore.QPoint(0, EFFECT_HEIGHT))
-        gradient.setColorAt(1, QtCore.Qt.transparent)
-        gradient.setColorAt(.5, colour)
-        gradient.setColorAt(0, QtCore.Qt.transparent)
-        gradient.setSpread(QtGui.QGradient.ReflectSpread)
-
-        pen = self.pen()
-        pen.setColor( QtGui.QColor(0, 0, 0, 80))
-        pen.setWidth(0)
-
-        self.setPen(pen)
-        self.setBrush(QtGui.QBrush(gradient))
-
-    def _set_tooltip(self):
-        self.setToolTip(self.item.name)
-
-    def paint(self, *args, **kwargs):
-        new_args = [args[0],
-                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
-        super(Effect, self).paint(*new_args, **kwargs)
-
-    def itemChange(self, change, value):
-        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
-            pen = self.pen()
-            pen.setColor(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
-                else QtGui.QColor(0, 0, 0, 255)
-            )
-            self.setPen(pen)
-            self.setZValue(
-                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
-            )
-
-        return super(Effect, self).itemChange(change, value)
-    
-    def counteract_zoom(self, zoom_level=1.0):
-        print "counter_act effect"
-        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
 
 class TransitionItem(_BaseItem):
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -509,6 +509,7 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
 
     def map_to_time_space (self, item):     
         '''
+        Temporary implementation.
         @TODO: modify this function once Time Coordinates Spaces 
         feature is implemented.
         '''   
@@ -531,9 +532,7 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
             is_bounded = True
         if round(f_nb) == start_time :
             is_head = True
-            is_tail = False
         if round(f_nb) >= (start_time + duration) :
-            is_head = False
             is_tail = True
 
         bounded_data = namedtuple("bounded_data",["f","is_bounded","is_tail","is_head"])
@@ -610,17 +609,6 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
         self._add_time_slider()
         self._add_markers()
         self._ruler = self._add_ruler()
-
-    def setMouseTracking(self, flag):
-        def recursive_set(parent):
-            for child in parent.findChildren(QtCore.QObject):
-                try:
-                    child.setMouseTracking(flag)
-                except:
-                    pass
-                recursive_set(child)
-        QtGui.QWidget.setMouseTracking(self, flag)
-        recursive_set(self)
 
     def _adjust_scene_size(self):
         scene_range = self.composition.trimmed_range()
@@ -792,6 +780,7 @@ class CompositionView(QtWidgets.QGraphicsView):
             for item in selection :
                 if not isinstance(item, Ruler):
                     self.selection_changed.emit(item.item)
+                    break
 
     def mousePressEvent(self, mouse_event):
         modifiers = QtWidgets.QApplication.keyboardModifiers()
@@ -1092,7 +1081,7 @@ class Timeline(QtWidgets.QTabWidget):
         new_stack.open_stack.connect(self.add_stack)
         new_stack.selection_changed.connect(self.selection_changed)
         self.setCurrentIndex(self.count() - 1)
-        self.currentWidget().frame_all()
+        #self.currentWidget().frame_all()
         self.frame_all()
 
     def frame_all(self):

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -262,11 +262,11 @@ class NestedItem(_BaseItem):
         self.source_name_label.setText(self.item.name)
 
     def mouseDoubleClickEvent(self, event):
-        super(_BaseItem, self).mouseDoubleClickEvent(event)
+        super(NestedItem, self).mouseDoubleClickEvent(event)
         self.scene().views()[0].open_stack.emit(self.item)
 
     def keyPressEvent(self, key_event):
-        super(_BaseItem, self).keyPressEvent(key_event)
+        super(NestedItem, self).keyPressEvent(key_event)
         key = key_event.key()
 
         if key == QtCore.Qt.Key_Return:
@@ -428,7 +428,7 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
     time_space = OrderedDict ([ # @TODO pending on Global Space implementation
                                 #("external_space", "External Space"),
                                 ("media_space", "Media Space"),
-                                ("frame_number", "Frame Number")])
+                                ("trimmed_space", "Trimmed Space")])
 
     time_space_default = "media_space"
 
@@ -523,7 +523,7 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
         is_tail = False
         f = "-?-"
         f_nb = ratio * duration + start_time
-        if self._time_space == "frame_number":
+        if self._time_space == "trimmed_space":
             f = ratio * duration
         elif self._time_space == "media_space":
             f = duration * ratio + start_time
@@ -1081,7 +1081,6 @@ class Timeline(QtWidgets.QTabWidget):
         new_stack.open_stack.connect(self.add_stack)
         new_stack.selection_changed.connect(self.selection_changed)
         self.setCurrentIndex(self.count() - 1)
-        #self.currentWidget().frame_all()
         self.frame_all()
 
     def frame_all(self):


### PR DESCRIPTION
This is a pull request about the "ruler feature".
-show frame in "media space" or the frame number of the clip (right click on the ruler to show contextual menu)
-Ctrl-left and Ctrl-right to snap the ruler to the end or beginning an item
-Show previous and next frames when the rule is at the beginning of a clip.
-fix bug where markers in the TimeSlider would disappear when the marker was selected and ctrl was pressed.
Some methods will need to be adapted once the functionalities about Time Coordinate Space will be available.