### PR TITLE
AAF writer: Adding support for audio transitions

### DIFF
--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -920,9 +920,6 @@ def write_to_file(input_otio, filepath):
                     filler = transcriber.aaf_filler(otio_child)
                     transcriber.sequence.components.append(filler)
                 elif isinstance(otio_child, otio.schema.Transition):
-                    if otio_track.kind == otio.schema.TrackKind.Audio:
-                        # XXX: Audio transitions are not working right now
-                        continue
                     transition = transcriber.aaf_transition(otio_child)
                     if transition:
                         transcriber.sequence.components.append(transition)

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -1013,8 +1013,10 @@ class AAFAdapterTest(unittest.TestCase):
                     for compmob_clip in sequence.components:
                         self.assertTrue(isinstance(compmob_clip,
                                                    (aaf2.components.SourceClip,
-                                                    aaf2.components.Filler)))
-                        if isinstance(compmob_clip, aaf2.components.Filler):
+                                                    aaf2.components.Filler,
+                                                    aaf2.components.Transition)))
+                        if isinstance(compmob_clip, (aaf2.components.Filler,
+                                                     aaf2.components.Transition)):
                             continue
 
                         self.assertTrue(isinstance(


### PR DESCRIPTION
Creating abstract method _transition_parameters that is called in _TrackTranscriber.aaf_transition to support both video and audio transitions

side note: Using metadata clip length instead of duration() in aaf_sourceclip. We'll fix this later


Co-authored-by: Freeson Wang <freeson@pixar.com>