### PR TITLE
Remove unneeded import of aaf2 in test_aaf_adapter

### DIFF
--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -29,7 +29,6 @@ import os
 import sys
 import unittest
 import tempfile
-import aaf2
 
 import opentimelineio as otio
 


### PR DESCRIPTION
Co-authored-by: Freeson Wang <freeson@pixar.com>