### PR TITLE
Add Effect Widget.

### DIFF
--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -107,7 +107,7 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
             return
         if not self.item.effects:
             return
-        effect = Effect(self.item.effects, self.rect())
+        effect = EffectItem(self.item.effects, self.rect())
         effect.setParentItem(self)
 
     def _position_labels(self):
@@ -214,10 +214,10 @@ class GapItem(_BaseItem):
         self.source_name_label.setText('GAP')
 
 
-class Effect(QtWidgets.QGraphicsRectItem):
+class EffectItem(QtWidgets.QGraphicsRectItem):
 
     def __init__(self, item, rect, *args, **kwargs):
-        super(Effect, self).__init__(rect, *args, **kwargs)
+        super(EffectItem, self).__init__(rect, *args, **kwargs)
         self.item = item
         self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
         self.init()
@@ -252,13 +252,13 @@ class Effect(QtWidgets.QGraphicsRectItem):
         for effect in self.item:
             name = effect.name if effect.name else ""
             effect_name = effect.effect_name if effect.effect_name else ""
-            tool_tips.append("%s %s" % (name, effect_name))
+            tool_tips.append("{} {}".format(name, effect_name))
         self.setToolTip("\n".join(tool_tips))
 
     def paint(self, *args, **kwargs):
         new_args = [args[0],
                     QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
-        super(Effect, self).paint(*new_args, **kwargs)
+        super(EffectItem, self).paint(*new_args, **kwargs)
 
     def itemChange(self, change, value):
         if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
@@ -272,7 +272,7 @@ class Effect(QtWidgets.QGraphicsRectItem):
                 self.zValue() + 1 if self.isSelected() else self.zValue() - 1
             )
 
-        return super(Effect, self).itemChange(change, value)
+        return super(EffectItem, self).itemChange(change, value)
 
 
 class TransitionItem(_BaseItem):

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -128,8 +128,8 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
         )
         self.source_out_label.setText(
             '{value}\n@{rate}'.format(
-                value=trimmed_range.end_time_exclusive().value,
-                rate=trimmed_range.end_time_exclusive().rate
+                value=trimmed_range.end_time_inclusive().value,
+                rate=trimmed_range.end_time_inclusive().rate
             )
         )
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -36,6 +36,7 @@ TIME_MULTIPLIER = 25
 LABEL_MARGIN = 5
 MARKER_SIZE = 10
 RULER_SIZE = 10
+EFFECT_HEIGHT = 0.25 * TRACK_HEIGHT
 
 
 class _BaseItem(QtWidgets.QGraphicsRectItem):
@@ -61,6 +62,7 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
         self._add_markers()
         self._set_labels()
         self._set_tooltip()
+        self._add_effects()       
 
     def paint(self, *args, **kwargs):
         new_args = [args[0],
@@ -99,6 +101,14 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
                 ) * TIME_MULTIPLIER
             )
             marker.setParentItem(self)
+
+    def _add_effects(self):
+        if not hasattr(self.item,"effects") :
+            return
+        if not self.item.effects :
+            return
+        effect = Effect(self.item.effects, self.timeline_range, self.rect())
+        effect.setParentItem(self)
 
     def _position_labels(self):
         self.source_in_label.setY(LABEL_MARGIN)
@@ -204,6 +214,60 @@ class GapItem(_BaseItem):
         )
         self.source_name_label.setText('GAP')
 
+class Effect(QtWidgets.QGraphicsRectItem):
+
+    def __init__(self, item, timeline_range, rect, *args, **kwargs):
+        super(Effect, self).__init__(rect,*args, **kwargs)
+        self.item = item
+        self.timeline_range = timeline_range
+        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
+        self.init()
+
+    def init(self):
+        rect = self.rect()
+        rect.setY(TRACK_HEIGHT - EFFECT_HEIGHT)
+        rect.setHeight(EFFECT_HEIGHT)
+        self.setRect(rect)
+
+        colour = QtGui.QColor(255, 255, 255, 255)
+        gradient = QtGui.QLinearGradient(QtCore.QPoint(0,0), QtCore.QPoint(0, EFFECT_HEIGHT))
+        gradient.setColorAt(1, QtCore.Qt.transparent)
+        gradient.setColorAt(.5, colour)
+        gradient.setColorAt(0, QtCore.Qt.transparent)
+        gradient.setSpread(QtGui.QGradient.ReflectSpread)
+
+        pen = self.pen()
+        pen.setColor( QtGui.QColor(0, 0, 0, 80))
+        pen.setWidth(0)
+
+        self.setPen(pen)
+        self.setBrush(QtGui.QBrush(gradient))
+
+    def _set_tooltip(self):
+        self.setToolTip(self.item.name)
+
+    def paint(self, *args, **kwargs):
+        new_args = [args[0],
+                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
+        super(Effect, self).paint(*new_args, **kwargs)
+
+    def itemChange(self, change, value):
+        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
+            pen = self.pen()
+            pen.setColor(
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                else QtGui.QColor(0, 0, 0, 255)
+            )
+            self.setPen(pen)
+            self.setZValue(
+                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
+            )
+
+        return super(Effect, self).itemChange(change, value)
+    
+    def counteract_zoom(self, zoom_level=1.0):
+        print "counter_act effect"
+        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
 
 class TransitionItem(_BaseItem):
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -60,9 +60,9 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
         self.source_name_label = QtWidgets.QGraphicsSimpleTextItem(self)
 
         self._add_markers()
-        self._add_effects() 
+        self._add_effects()
         self._set_labels()
-        self._set_tooltip()    
+        self._set_tooltip()
 
     def paint(self, *args, **kwargs):
         new_args = [args[0],
@@ -103,11 +103,11 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
             marker.setParentItem(self)
 
     def _add_effects(self):
-        if not hasattr(self.item,"effects") :
+        if not hasattr(self.item, "effects"):
             return
-        if not self.item.effects :
+        if not self.item.effects:
             return
-        effect = Effect(self.item.effects, self.timeline_range, self.rect())
+        effect = Effect(self.item.effects, self.rect())
         effect.setParentItem(self)
 
     def _position_labels(self):
@@ -115,7 +115,7 @@ class _BaseItem(QtWidgets.QGraphicsRectItem):
         self.source_out_label.setY(LABEL_MARGIN)
         self.source_name_label.setY(
             (TRACK_HEIGHT -
-            self.source_name_label.boundingRect().height()) / 2.0
+             self.source_name_label.boundingRect().height()) / 2.0
         )
 
     def _set_labels_rational_time(self):
@@ -213,17 +213,17 @@ class GapItem(_BaseItem):
         )
         self.source_name_label.setText('GAP')
 
+
 class Effect(QtWidgets.QGraphicsRectItem):
 
-    def __init__(self, item, timeline_range, rect, *args, **kwargs):
-        super(Effect, self).__init__(rect,*args, **kwargs)
+    def __init__(self, item, rect, *args, **kwargs):
+        super(Effect, self).__init__(rect, *args, **kwargs)
         self.item = item
-        self.timeline_range = timeline_range
         self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
         self.init()
         self._set_tooltip()
 
-    def init(self):      
+    def init(self):
         rect = self.rect()
         rect.setY(TRACK_HEIGHT - EFFECT_HEIGHT)
         rect.setHeight(EFFECT_HEIGHT)
@@ -231,8 +231,11 @@ class Effect(QtWidgets.QGraphicsRectItem):
 
         dark = QtGui.QColor(0, 0, 0, 150)
         colour = QtGui.QColor(255, 255, 255, 200)
-        gradient = QtGui.QLinearGradient(QtCore.QPointF(0, self.boundingRect().top()),
-                                         QtCore.QPointF(0, self.boundingRect().bottom()))
+        gradient = QtGui.QLinearGradient(
+                   QtCore.QPointF(0,
+                                  self.boundingRect().top()),
+                   QtCore.QPointF(0,
+                                  self.boundingRect().bottom()))
         gradient.setColorAt(0.2, QtCore.Qt.transparent)
         gradient.setColorAt(0.45, colour)
         gradient.setColorAt(0.7, QtCore.Qt.transparent)
@@ -240,18 +243,16 @@ class Effect(QtWidgets.QGraphicsRectItem):
         self.setBrush(QtGui.QBrush(gradient))
 
         pen = self.pen()
-        pen.setColor( QtGui.QColor(0, 0, 0, 80))
+        pen.setColor(QtGui.QColor(0, 0, 0, 80))
         pen.setWidth(0)
         self.setPen(pen)
-        
+
     def _set_tooltip(self):
         tool_tips = list()
-        for effect in self.item :
+        for effect in self.item:
             name = effect.name if effect.name else ""
             effect_name = effect.effect_name if effect.effect_name else ""
-            tool_tips.append ("%s %s"%(name, effect_name))
-        #tool_tips = [ str(effect.effect_name+" "+effect.effect_name) for effect in self.item]
-        print "tool tips",tool_tips
+            tool_tips.append("%s %s" % (name, effect_name))
         self.setToolTip("\n".join(tool_tips))
 
     def paint(self, *args, **kwargs):
@@ -272,9 +273,6 @@ class Effect(QtWidgets.QGraphicsRectItem):
             )
 
         return super(Effect, self).itemChange(change, value)
-    
-    #def counteract_zoom(self, zoom_level=1.0):
-    #    self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
 
 
 class TransitionItem(_BaseItem):


### PR DESCRIPTION
1. Add an **Effect** Widget to easily spot clips with effects in the *otioviewer*.
2. Center the *source_name_label* in the track. Before it was sitting at 1/3 of its height and would have partially overlap with the **Effect** widget.
3. Display the latest *inclusive* frame rather than the latest *exclusive* frame. Now the last frame number on a clip matches the frame number from the *ruler*.