### PR TITLE
Add media linker arguments to commandline tools

### DIFF
--- a/opentimelineio/console/__init__.py
+++ b/opentimelineio/console/__init__.py
@@ -34,5 +34,6 @@ from . import (
     otioconvert,
     otiocat,
     otiostat,
+    console_utils,
 )
 

--- a/opentimelineio/console/console_utils.py
+++ b/opentimelineio/console/console_utils.py
@@ -23,7 +23,6 @@
 #
 
 import ast
-import sys
 
 """Utilities for OpenTimelineIO commandline modules."""
 
@@ -35,20 +34,19 @@ def arg_list_to_map(arg_list, label):
 
     argument_map = {}
     for pair in arg_list:
-        if '=' in pair:
-            key, val = pair.split('=', 1)  # only split on the 1st '='
-            try:
-                # Sometimes we need to pass a bool, int, list, etc.
-                parsed_value = ast.literal_eval(val)
-            except (ValueError, SyntaxError):
-                # Fall back to a simple string
-                parsed_value = val
-            argument_map[key] = parsed_value
-        else:
-            print(
+        if '=' not in pair:
+            raise ValueError(
                 "error: {} arguments must be in the form key=value"
                 " got: {}".format(label, pair)
             )
-            sys.exit(1)
+
+        key, val = pair.split('=', 1)  # only split on the 1st '='
+        try:
+            # Sometimes we need to pass a bool, int, list, etc.
+            parsed_value = ast.literal_eval(val)
+        except (ValueError, SyntaxError):
+            # Fall back to a simple string
+            parsed_value = val
+        argument_map[key] = parsed_value
 
     return argument_map

--- a/opentimelineio/console/console_utils.py
+++ b/opentimelineio/console/console_utils.py
@@ -1,0 +1,30 @@
+import ast
+import sys
+
+"""Utilities for OpenTimelineIO commandline modules."""
+
+
+def arg_list_to_map(arg_list, label):
+    """
+    Convert an argument of the form -A foo=bar from the parsed result to a map.
+    """
+
+    argument_map = {}
+    for pair in arg_list:
+        if '=' in pair:
+            key, val = pair.split('=', 1)  # only split on the 1st '='
+            try:
+                # Sometimes we need to pass a bool, int, list, etc.
+                parsed_value = ast.literal_eval(val)
+            except (ValueError, SyntaxError):
+                # Fall back to a simple string
+                parsed_value = val
+            argument_map[key] = parsed_value
+        else:
+            print(
+                "error: {} arguments must be in the form key=value"
+                " got: {}".format(label, pair)
+            )
+            sys.exit(1)
+
+    return argument_map

--- a/opentimelineio/console/console_utils.py
+++ b/opentimelineio/console/console_utils.py
@@ -1,3 +1,27 @@
+#
+# Copyright 2019 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
 import ast
 import sys
 

--- a/opentimelineio/console/console_utils.py
+++ b/opentimelineio/console/console_utils.py
@@ -24,6 +24,8 @@
 
 import ast
 
+import opentimelineio as otio
+
 """Utilities for OpenTimelineIO commandline modules."""
 
 
@@ -50,3 +52,19 @@ def arg_list_to_map(arg_list, label):
         argument_map[key] = parsed_value
 
     return argument_map
+
+
+def media_linker_name(ml_name_arg):
+    """
+    Parse commandline arguments for the media linker, which can be not set
+    (fall back to default), "" or "none" (don't link media) or the name of a
+    media linker to use.
+    """
+    if ml_name_arg.lower() == 'default':
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
+    elif ml_name_arg.lower() in ['none', '']:
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
+    else:
+        media_linker_name = ml_name_arg
+
+    return media_linker_name

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -26,8 +26,6 @@
 """Print the contents of an OTIO file to stdout."""
 
 import argparse
-import ast
-import sys
 
 import opentimelineio as otio
 
@@ -81,28 +79,6 @@ def _parsed_args():
     return parser.parse_args()
 
 
-def _convert_argument_list_to_map(arg_list, label):
-    argument_map = {}
-    for pair in arg_list:
-        if '=' in pair:
-            key, val = pair.split('=', 1)  # only split on the 1st '='
-            try:
-                # Sometimes we need to pass a bool, int, list, etc.
-                parsed_value = ast.literal_eval(val)
-            except (ValueError, SyntaxError):
-                # Fall back to a simple string
-                parsed_value = val
-            argument_map[key] = parsed_value
-        else:
-            print(
-                "error: {} arguments must be in the form key=value"
-                " got: {}".format(label, pair)
-            )
-            sys.exit(1)
-
-    return argument_map
-
-
 def _otio_compatible_file_to_json_string(
         fpath,
         media_linker_name,
@@ -137,8 +113,11 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = _convert_argument_list_to_map(args.adapter_arg, "adapter")
-    media_linker_argument_map = _convert_argument_list_to_map(
+    argument_map = otio.console.console_utils.arg_list_to_map(
+        args.adapter_arg,
+        "adapter"
+    )
+    media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
         args.media_linker_arg,
         "media linker"
     )

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -113,7 +113,7 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = otio.console.console_utils.arg_list_to_map(
+    read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
         "adapter"
     )
@@ -128,7 +128,7 @@ def main():
                 fpath,
                 ml,
                 media_linker_argument_map,
-                argument_map
+                read_adapter_arg_map
             )
         )
 

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -106,13 +106,9 @@ def main():
 
     args = _parsed_args()
 
-    # allow user to explicitly set or pass to default or disable the linker.
-    if args.media_linker.lower() == 'default':
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
-    elif args.media_linker.lower() in ['none', '']:
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
-    else:
-        media_linker_name = args.media_linker
+    media_linker_name = otio.console.console_utils.media_linker_name(
+        args.media_linker
+    )
 
     try:
         read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -67,11 +67,48 @@ def _parsed_args():
             " of the media linker to use."
         )
     )
+    parser.add_argument(
+        '-M',
+        '--media-linker-arg',
+        type=str,
+        default=[],
+        action='append',
+        help='Extra arguments to be passed to the media linker in the form of '
+        'key=value. Values are strings, numbers or Python literals: True, '
+        'False, etc. Can be used multiple times: -M burrito="bar" -M taco=12.'
+    )
 
     return parser.parse_args()
 
 
-def _otio_compatible_file_to_json_string(fpath, ml, adapter_argument_map):
+def _convert_argument_list_to_map(arg_list, label):
+    argument_map = {}
+    for pair in arg_list:
+        if '=' in pair:
+            key, val = pair.split('=', 1)  # only split on the 1st '='
+            try:
+                # Sometimes we need to pass a bool, int, list, etc.
+                parsed_value = ast.literal_eval(val)
+            except (ValueError, SyntaxError):
+                # Fall back to a simple string
+                parsed_value = val
+            argument_map[key] = parsed_value
+        else:
+            print(
+                "error: {} arguments must be in the form key=value"
+                " got: {}".format(label, pair)
+            )
+            sys.exit(1)
+
+    return argument_map
+
+
+def _otio_compatible_file_to_json_string(
+        fpath,
+        media_linker_name,
+        media_linker_argument_map,
+        adapter_argument_map
+):
     """Read the file at fpath with the default otio adapter and return the json
     as a string.
     """
@@ -80,7 +117,8 @@ def _otio_compatible_file_to_json_string(fpath, ml, adapter_argument_map):
     return adapter.write_to_string(
         otio.adapters.read_from_file(
             fpath,
-            media_linker_name=ml,
+            media_linker_name=media_linker_name,
+            media_linker_argument_map=media_linker_argument_map,
             **adapter_argument_map
         )
     )
@@ -99,29 +137,18 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = {}
-    for pair in args.adapter_arg:
-        if '=' in pair:
-            key, val = pair.split('=', 1)  # only split on the 1st '='
-            try:
-                # Sometimes we need to pass a bool, int, list, etc.
-                parsed_value = ast.literal_eval(val)
-            except (ValueError, SyntaxError):
-                # Fall back to a simple string
-                parsed_value = val
-            argument_map[key] = parsed_value
-        else:
-            print(
-                "error: adapter arguments must be in the form key=value"
-                " got: {}".format(pair)
-            )
-            sys.exit(1)
+    argument_map = _convert_argument_list_to_map(args.adapter_arg, "adapter")
+    media_linker_argument_map = _convert_argument_list_to_map(
+        args.media_linker_arg,
+        "media linker"
+    )
 
     for fpath in args.filepath:
         print(
             _otio_compatible_file_to_json_string(
                 fpath,
                 ml,
+                media_linker_argument_map,
                 argument_map
             )
         )

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -120,7 +120,7 @@ def main():
             "media linker"
         )
     except ValueError as exc:
-        sys.stderr.write("\n" + exc.message + "\n")
+        sys.stderr.write("\n" + str(exc) + "\n")
         sys.exit(1)
 
     for fpath in args.filepath:

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -107,11 +107,11 @@ def main():
 
     # allow user to explicitly set or pass to default or disable the linker.
     if args.media_linker.lower() == 'default':
-        ml = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
     elif args.media_linker.lower() in ['none', '']:
-        ml = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
     else:
-        ml = args.media_linker
+        media_linker_name = args.media_linker
 
     read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
@@ -126,7 +126,7 @@ def main():
         print(
             _otio_compatible_file_to_json_string(
                 fpath,
-                ml,
+                media_linker_name,
                 media_linker_argument_map,
                 read_adapter_arg_map
             )

--- a/opentimelineio/console/otiocat.py
+++ b/opentimelineio/console/otiocat.py
@@ -26,6 +26,7 @@
 """Print the contents of an OTIO file to stdout."""
 
 import argparse
+import sys
 
 import opentimelineio as otio
 
@@ -113,14 +114,18 @@ def main():
     else:
         media_linker_name = args.media_linker
 
-    read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
-        args.adapter_arg,
-        "adapter"
-    )
-    media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
-        args.media_linker_arg,
-        "media linker"
-    )
+    try:
+        read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
+            args.adapter_arg,
+            "adapter"
+        )
+        media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
+            args.media_linker_arg,
+            "media linker"
+        )
+    except ValueError as exc:
+        sys.stderr.write("\n" + exc.message + "\n")
+        sys.exit(1)
 
     for fpath in args.filepath:
         print(

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -200,14 +200,18 @@ def main():
     else:
         media_linker_name = args.media_linker
 
-    read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
-        args.adapter_arg,
-        "input adapter"
-    )
-    ml_args = otio.console.console_utils.arg_list_to_map(
-        args.media_linker_arg,
-        "media linker"
-    )
+    try:
+        read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
+            args.adapter_arg,
+            "input adapter"
+        )
+        ml_args = otio.console.console_utils.arg_list_to_map(
+            args.media_linker_arg,
+            "media linker"
+        )
+    except ValueError as exc:
+        sys.stderr.write("\n" + exc.message + "\n")
+        sys.exit(1)
 
     result_tl = otio.adapters.read_from_file(
         args.input,
@@ -234,10 +238,14 @@ def main():
             otio.opentime.range_from_start_end_time(args.begin, args.end)
         )
 
-    write_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
-        args.output_adapter_arg,
-        "output adapter"
-    )
+    try:
+        write_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
+            args.output_adapter_arg,
+            "output adapter"
+        )
+    except ValueError as exc:
+        sys.stderr.write("\n" + exc.message + "\n")
+        sys.exit(1)
 
     otio.adapters.write_to_file(
         result_tl,

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -192,13 +192,9 @@ def main():
     if out_adapter is None:
         out_adapter = otio.adapters.from_filepath(args.output).name
 
-    # allow user to explicitly set or pass to default or disable the linker.
-    if args.media_linker.lower() == 'default':
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
-    elif args.media_linker.lower() in ['none', '']:
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
-    else:
-        media_linker_name = args.media_linker
+    media_linker_name = otio.console.console_utils.media_linker_name(
+        args.media_linker
+    )
 
     try:
         read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -200,7 +200,7 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = otio.console.console_utils.arg_list_to_map(
+    read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
         "input adapter"
     )
@@ -214,7 +214,7 @@ def main():
         in_adapter,
         media_linker_name=ml,
         media_linker_argument_map=ml_args,
-        **argument_map
+        **read_adapter_arg_map
     )
 
     if args.tracks:
@@ -234,7 +234,7 @@ def main():
             otio.opentime.range_from_start_end_time(args.begin, args.end)
         )
 
-    argument_map = otio.console.console_utils.arg_list_to_map(
+    write_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
         "output adapter"
     )
@@ -243,7 +243,7 @@ def main():
         result_tl,
         args.output,
         out_adapter,
-        **argument_map
+        **write_adapter_arg_map
     )
 
 

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -194,11 +194,11 @@ def main():
 
     # allow user to explicitly set or pass to default or disable the linker.
     if args.media_linker.lower() == 'default':
-        ml = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
     elif args.media_linker.lower() in ['none', '']:
-        ml = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
     else:
-        ml = args.media_linker
+        media_linker_name = args.media_linker
 
     read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
@@ -212,7 +212,7 @@ def main():
     result_tl = otio.adapters.read_from_file(
         args.input,
         in_adapter,
-        media_linker_name=ml,
+        media_linker_name=media_linker_name,
         media_linker_argument_map=ml_args,
         **read_adapter_arg_map
     )

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -235,7 +235,7 @@ def main():
         )
 
     write_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
-        args.adapter_arg,
+        args.output_adapter_arg,
         "output adapter"
     )
 

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -25,7 +25,6 @@
 
 import argparse
 import sys
-import ast
 import copy
 
 import opentimelineio as otio
@@ -180,28 +179,6 @@ def _parsed_args():
     return result
 
 
-def _convert_argument_list_to_map(arg_list, label):
-    argument_map = {}
-    for pair in arg_list:
-        if '=' in pair:
-            key, val = pair.split('=', 1)  # only split on the 1st '='
-            try:
-                # Sometimes we need to pass a bool, int, list, etc.
-                parsed_value = ast.literal_eval(val)
-            except (ValueError, SyntaxError):
-                # Fall back to a simple string
-                parsed_value = val
-            argument_map[key] = parsed_value
-        else:
-            print(
-                "error: {} arguments must be in the form key=value"
-                " got: {}".format(label, pair)
-            )
-            sys.exit(1)
-
-    return argument_map
-
-
 def main():
     """Parse arguments and convert the files."""
 
@@ -223,8 +200,14 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = _convert_argument_list_to_map(args.adapter_arg, "input adapter")
-    ml_args = _convert_argument_list_to_map(args.media_linker_arg, "media linker")
+    argument_map = otio.console.console_utils.arg_list_to_map(
+        args.adapter_arg,
+        "input adapter"
+    )
+    ml_args = otio.console.console_utils.arg_list_to_map(
+        args.media_linker_arg,
+        "media linker"
+    )
 
     result_tl = otio.adapters.read_from_file(
         args.input,
@@ -251,7 +234,10 @@ def main():
             otio.opentime.range_from_start_end_time(args.begin, args.end)
         )
 
-    argument_map = _convert_argument_list_to_map(args.adapter_arg, "output adapter")
+    argument_map = otio.console.console_utils.arg_list_to_map(
+        args.adapter_arg,
+        "output adapter"
+    )
 
     otio.adapters.write_to_file(
         result_tl,

--- a/opentimelineio/console/otioconvert.py
+++ b/opentimelineio/console/otioconvert.py
@@ -206,7 +206,7 @@ def main():
             "media linker"
         )
     except ValueError as exc:
-        sys.stderr.write("\n" + exc.message + "\n")
+        sys.stderr.write("\n" + str(exc) + "\n")
         sys.exit(1)
 
     result_tl = otio.adapters.read_from_file(
@@ -240,7 +240,7 @@ def main():
             "output adapter"
         )
     except ValueError as exc:
-        sys.stderr.write("\n" + exc.message + "\n")
+        sys.stderr.write("\n" + str(exc) + "\n")
         sys.exit(1)
 
     otio.adapters.write_to_file(

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -28,7 +28,6 @@
 import os
 import sys
 import argparse
-import ast
 from PySide2 import QtWidgets, QtGui
 
 import opentimelineio as otio
@@ -81,28 +80,6 @@ def _parsed_args():
     )
 
     return parser.parse_args()
-
-
-def _convert_argument_list_to_map(arg_list, label):
-    argument_map = {}
-    for pair in arg_list:
-        if '=' in pair:
-            key, val = pair.split('=', 1)  # only split on the 1st '='
-            try:
-                # Sometimes we need to pass a bool, int, list, etc.
-                parsed_value = ast.literal_eval(val)
-            except (ValueError, SyntaxError):
-                # Fall back to a simple string
-                parsed_value = val
-            argument_map[key] = parsed_value
-        else:
-            print(
-                "error: {} arguments must be in the form key=value"
-                " got: {}".format(label, pair)
-            )
-            sys.exit(1)
-
-    return argument_map
 
 
 class TimelineWidgetItem(QtWidgets.QListWidgetItem):
@@ -246,7 +223,6 @@ class Main(QtWidgets.QMainWindow):
         self.timeline_widget.frame_all()
 
 
-
 def main():
     args = _parsed_args()
 
@@ -258,8 +234,11 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = _convert_argument_list_to_map(args.adapter_arg, "adapter")
-    media_linker_argument_map = _convert_argument_list_to_map(
+    argument_map = otio.console.console_utils.arg_list_to_map(
+        args.adapter_arg,
+        "adapter"
+    )
+    media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
         args.media_linker_arg,
         "media linker"
     )

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -240,7 +240,7 @@ def main():
             "media linker"
         )
     except ValueError as exc:
-        sys.stderr.write("\n" + exc.message + "\n")
+        sys.stderr.write("\n" + str(exc) + "\n")
         sys.exit(1)
 
     application = QtWidgets.QApplication(sys.argv)

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -226,21 +226,8 @@ class Main(QtWidgets.QMainWindow):
 def main():
     args = _parsed_args()
 
-    # allow user to explicitly set or pass to default or disable the linker.
-    if args.media_linker.lower() == 'default':
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
-    elif args.media_linker.lower() in ['none', '']:
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
-    else:
-        media_linker_name = args.media_linker
-
-    read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
-        args.adapter_arg,
-        "adapter"
-    )
-    media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
-        args.media_linker_arg,
-        "media linker"
+    media_linker_name = otio.console.console_utils.media_linker_name(
+        args.media_linker
     )
 
     application = QtWidgets.QApplication(sys.argv)

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -91,7 +91,7 @@ class TimelineWidgetItem(QtWidgets.QListWidgetItem):
 class Main(QtWidgets.QMainWindow):
     def __init__(
             self,
-            adapter_argument_map, 
+            adapter_argument_map,
             media_linker,
             media_linker_argument_map,
             *args,
@@ -228,11 +228,11 @@ def main():
 
     # allow user to explicitly set or pass to default or disable the linker.
     if args.media_linker.lower() == 'default':
-        ml = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
     elif args.media_linker.lower() in ['none', '']:
-        ml = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
+        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
     else:
-        ml = args.media_linker
+        media_linker_name = args.media_linker
 
     read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
@@ -245,7 +245,11 @@ def main():
 
     application = QtWidgets.QApplication(sys.argv)
 
-    window = Main(read_adapter_arg_map, ml, media_linker_argument_map)
+    window = Main(
+        read_adapter_arg_map,
+        media_linker_name,
+        media_linker_argument_map
+    )
 
     if args.input is not None:
         window.load(args.input)
@@ -254,6 +258,7 @@ def main():
     window.show()
     window.raise_()
     application.exec_()
+
 
 if __name__ == '__main__':
     main()

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -230,6 +230,19 @@ def main():
         args.media_linker
     )
 
+    try:
+        read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
+            args.adapter_arg,
+            "adapter"
+        )
+        media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
+            args.media_linker_arg,
+            "media linker"
+        )
+    except ValueError as exc:
+        sys.stderr.write("\n" + exc.message + "\n")
+        sys.exit(1)
+
     application = QtWidgets.QApplication(sys.argv)
 
     window = Main(

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -234,7 +234,7 @@ def main():
     else:
         ml = args.media_linker
 
-    argument_map = otio.console.console_utils.arg_list_to_map(
+    read_adapter_arg_map = otio.console.console_utils.arg_list_to_map(
         args.adapter_arg,
         "adapter"
     )
@@ -245,7 +245,7 @@ def main():
 
     application = QtWidgets.QApplication(sys.argv)
 
-    window = Main(argument_map, ml, media_linker_argument_map)
+    window = Main(read_adapter_arg_map, ml, media_linker_argument_map)
 
     if args.input is not None:
         window.load(args.input)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -74,8 +74,34 @@ class OTIOCatTests(ConsoleTester, unittest.TestCase):
         otio.console.otiocat.main()
         self.assertIn('"name": "Example_Screening.01",', sys.stdout.getvalue())
 
+    def test_input_argument_error(self):
+        sys.argv = [
+            'otiocat',
+            SCREENING_EXAMPLE_PATH,
+            "-a", "foobar",
+        ]
 
-class OTIOConvertTests(unittest.TestCase):
+        with self.assertRaises(SystemExit):
+            otio.console.otiocat.main()
+
+        # read results back in
+        self.assertIn('error: adapter', sys.stderr.getvalue())
+
+    def test_media_linker_argument_error(self):
+        sys.argv = [
+            'otiocat',
+            SCREENING_EXAMPLE_PATH,
+            "-M", "foobar",
+        ]
+
+        with self.assertRaises(SystemExit):
+            otio.console.otiocat.main()
+
+        # read results back in
+        self.assertIn('error: media linker', sys.stderr.getvalue())
+
+
+class OTIOConvertTests(ConsoleTester, unittest.TestCase):
     def test_basic(self):
         with tempfile.NamedTemporaryFile() as tf:
             sys.argv = [
@@ -90,6 +116,54 @@ class OTIOConvertTests(unittest.TestCase):
             # read results back in
             with open(tf.name, 'r') as fi:
                 self.assertIn('"name": "Example_Screening.01",', fi.read())
+
+    def test_input_argument_error(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', tf.name,
+                '-O', 'otio_json',
+                "-a", "foobar",
+            ]
+
+            with self.assertRaises(SystemExit):
+                otio.console.otioconvert.main()
+
+            # read results back in
+            self.assertIn('error: input adapter', sys.stderr.getvalue())
+
+    def test_output_argument_error(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', tf.name,
+                '-O', 'otio_json',
+                "-A", "foobar",
+            ]
+
+            with self.assertRaises(SystemExit):
+                otio.console.otioconvert.main()
+
+            # read results back in
+            self.assertIn('error: output adapter', sys.stderr.getvalue())
+
+    def test_media_linker_argument_error(self):
+        with tempfile.NamedTemporaryFile() as tf:
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', tf.name,
+                '-O', 'otio_json',
+                "-M", "foobar",
+            ]
+
+            with self.assertRaises(SystemExit):
+                otio.console.otioconvert.main()
+
+            # read results back in
+            self.assertIn('error: media linker', sys.stderr.getvalue())
 
 
 if __name__ == '__main__':

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -156,6 +156,8 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 '-i', SCREENING_EXAMPLE_PATH,
                 '-o', tf.name,
                 '-O', 'otio_json',
+                "-m", "fake_linker",
+                "-M", "somestring=foobar",
                 "-M", "foobar",
             ]
 


### PR DESCRIPTION
Adds:
- support for `-M foo=bar` media linker arguments to `otiocat`, `otioconvert`, `otioview`
- refactors code to turn `foo=bar` arguments into a `console_utils.py` module
- cleanup & linting.