### PR TITLE
Add Key Navigation Filter Menu

### DIFF
--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -28,7 +28,6 @@
 import os
 import sys
 import argparse
-import ast
 from PySide2 import QtWidgets, QtGui
 
 import opentimelineio as otio

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -149,15 +149,12 @@ class Main(QtWidgets.QMainWindow):
         file_menu.addSeparator()
         file_menu.addAction(exit_action)
 
-<<<<<<< HEAD
-=======
         # navegation menu
         navigation_menu = QtWidgets.QMenu()
         navigation_menu.setTitle("Navigation")
         menubar.addMenu(navigation_menu)
         self._create_navegtion_menu(navigation_menu)
 
->>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
         # signals
         self.tracks_widget.itemSelectionChanged.connect(
             self._change_track
@@ -218,8 +215,6 @@ class Main(QtWidgets.QMainWindow):
         if selection:
             self.timeline_widget.set_timeline(selection[0].timeline)
 
-<<<<<<< HEAD
-=======
     def _create_navegtion_menu(self, navigation_menu):
 
         actions = otioViewWidget.timeline_widget.build_menu(
@@ -238,7 +233,6 @@ class Main(QtWidgets.QMainWindow):
 
         self.timeline_widget.navigationfilter_changed.emit(nav_filter)
 
->>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
     def center(self):
         frame = self.frameGeometry()
         desktop = QtWidgets.QApplication.desktop()

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -28,6 +28,7 @@
 import os
 import sys
 import argparse
+import ast
 from PySide2 import QtWidgets, QtGui
 
 import opentimelineio as otio
@@ -148,6 +149,15 @@ class Main(QtWidgets.QMainWindow):
         file_menu.addSeparator()
         file_menu.addAction(exit_action)
 
+<<<<<<< HEAD
+=======
+        # navegation menu
+        navigation_menu = QtWidgets.QMenu()
+        navigation_menu.setTitle("Navigation")
+        menubar.addMenu(navigation_menu)
+        self._create_navegtion_menu(navigation_menu)
+
+>>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
         # signals
         self.tracks_widget.itemSelectionChanged.connect(
             self._change_track
@@ -208,6 +218,27 @@ class Main(QtWidgets.QMainWindow):
         if selection:
             self.timeline_widget.set_timeline(selection[0].timeline)
 
+<<<<<<< HEAD
+=======
+    def _create_navegtion_menu(self, navigation_menu):
+
+        actions = otioViewWidget.timeline_widget.build_menu(
+                  navigation_menu)
+
+        def __callback():
+            self._navegation_filter_callback(actions)
+        navigation_menu.triggered[[QtWidgets.QAction]].connect(__callback)
+
+    def _navegation_filter_callback(self, filters):
+        nav_filter = 0
+        filter_dict = otioViewWidget.timeline_widget.get_nav_menu_data()
+        for filter in filters:
+            if filter.isChecked():
+                nav_filter += filter_dict[filter.text()].bitmask
+
+        self.timeline_widget.navigationfilter_changed.emit(nav_filter)
+
+>>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
     def center(self):
         frame = self.frameGeometry()
         desktop = QtWidgets.QApplication.desktop()

--- a/opentimelineview/console.py
+++ b/opentimelineview/console.py
@@ -149,11 +149,11 @@ class Main(QtWidgets.QMainWindow):
         file_menu.addSeparator()
         file_menu.addAction(exit_action)
 
-        # navegation menu
+        # navigation menu
         navigation_menu = QtWidgets.QMenu()
         navigation_menu.setTitle("Navigation")
         menubar.addMenu(navigation_menu)
-        self._create_navegtion_menu(navigation_menu)
+        self._create_navigation_menu(navigation_menu)
 
         # signals
         self.tracks_widget.itemSelectionChanged.connect(
@@ -215,16 +215,16 @@ class Main(QtWidgets.QMainWindow):
         if selection:
             self.timeline_widget.set_timeline(selection[0].timeline)
 
-    def _create_navegtion_menu(self, navigation_menu):
+    def _create_navigation_menu(self, navigation_menu):
 
         actions = otioViewWidget.timeline_widget.build_menu(
                   navigation_menu)
 
         def __callback():
-            self._navegation_filter_callback(actions)
+            self._navigation_filter_callback(actions)
         navigation_menu.triggered[[QtWidgets.QAction]].connect(__callback)
 
-    def _navegation_filter_callback(self, filters):
+    def _navigation_filter_callback(self, filters):
         nav_filter = 0
         filter_dict = otioViewWidget.timeline_widget.get_nav_menu_data()
         for filter in filters:

--- a/opentimelineview/ruler_widget.py
+++ b/opentimelineview/ruler_widget.py
@@ -1,0 +1,287 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+from PySide2 import QtGui, QtCore, QtWidgets
+import collections
+import math
+import track_widgets
+
+RULER_SIZE = 10
+
+
+class FrameNumber(QtWidgets.QGraphicsRectItem):
+
+    def __init__(self, text, position, *args, **kwargs):
+        super(FrameNumber, self).__init__(*args, **kwargs)
+        self.frameNumber = QtWidgets.QGraphicsSimpleTextItem(self)
+        self.frameNumber.setText("%s" % text)
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(5, 55, 0, 255))
+        )
+        self.setPen(
+            QtCore.Qt.NoPen
+        )
+        self.frameNumber.setBrush(
+            QtGui.QBrush(QtGui.QColor(25, 255, 10, 255))
+        )
+        # if position < 0 then the frameNumber will appear on the left side
+        # of the ruler
+        self.position = position
+
+    def setText(self, txt, highlight=False):
+        if txt:
+            self.show()
+            self.frameNumber.setText("%s" % txt)
+            rect = self.frameNumber.boundingRect()
+            self.setRect(self.frameNumber.boundingRect())
+            if highlight:
+                # paint with a different color when on
+                # the first frame of a clip
+                self.setBrush(
+                    QtGui.QBrush(QtGui.QColor(55, 5, 0, 120))
+                )
+                self.frameNumber.setBrush(
+                    QtGui.QBrush(QtGui.QColor(255, 250, 250, 255))
+                )
+            else:
+                self.frameNumber.setBrush(
+                    QtGui.QBrush(QtGui.QColor(25, 255, 10, 255))
+                )
+                self.setBrush(
+                    QtGui.QBrush(QtGui.QColor(5, 55, 0, 120))
+                )
+            if self.position < 0:
+                self.setX(-rect.width()-2)
+            else:
+                self.setX(2)
+        else:
+            self.hide()
+
+
+class Ruler(QtWidgets.QGraphicsPolygonItem):
+    #  @TODO pending on Global Space implementation
+    #  ("external_space", "External Space"),
+    time_space = collections.OrderedDict([("media_space", "Media Space"),
+                                          ("trimmed_space", "Trimmed Space")])
+
+    time_space_default = "media_space"
+
+    def __init__(self, height, composition, *args, **kwargs):
+
+        poly = QtGui.QPolygonF()
+        poly.append(QtCore.QPointF(0.5 * RULER_SIZE, -0.5 * RULER_SIZE))
+        poly.append(QtCore.QPointF(0.5 * RULER_SIZE, 0.5 * RULER_SIZE))
+        poly.append(QtCore.QPointF(0, RULER_SIZE))
+        poly.append(QtCore.QPointF(0, height))
+        poly.append(QtCore.QPointF(0, RULER_SIZE))
+        poly.append(QtCore.QPointF(-0.5 * RULER_SIZE, 0.5 * RULER_SIZE))
+        poly.append(QtCore.QPointF(-0.5 * RULER_SIZE, -0.5 * RULER_SIZE))
+        super(Ruler, self).__init__(poly, *args, **kwargs)
+
+        # to retrieve tracks and its children
+        self.composition = composition
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(50, 255, 20, 255))
+        )
+
+        self.setAcceptHoverEvents(True)
+        self.setFlag(QtWidgets.QGraphicsItem.ItemIsSelectable, True)
+        self.setFlag(QtWidgets.QGraphicsItem.ItemIsFocusable, True)
+
+        self.labels = list()
+        self._time_space = self.time_space_default
+        self._bounded_data = collections.namedtuple("bounded_data",
+                                                    ["f",
+                                                     "is_bounded",
+                                                     "is_tail",
+                                                     "is_head"])
+        self.init()
+
+    def contextMenuEvent(self, event):
+        menu = QtWidgets.QMenu()
+        for name, label in self.time_space.items():
+            def __callback():
+                self.set_time_space_callback(name)
+            menu.addAction(label, __callback)
+        menu.exec_(event.screenPos())
+
+        super(Ruler, self).contextMenuEvent(event)
+
+    def set_time_space_callback(self, time_space):
+        self._time_space = time_space
+        self.update_frame()
+
+    def mouseMoveEvent(self, mouse_event):
+        pos = self.mapToScene(mouse_event.pos())
+        self.setPos(QtCore.QPointF(pos.x(),
+                                   track_widgets.TIME_SLIDER_HEIGHT -
+                                   track_widgets.MARKER_SIZE))
+        self.update_frame()
+
+        super(Ruler, self).mouseMoveEvent(mouse_event)
+
+    def mouseReleaseEvent(self, mouse_event):
+        self.setSelected(False)
+        super(Ruler, self).mouseReleaseEvent(mouse_event)
+
+    def hoverEnterEvent(self, event):
+        self.setSelected(True)
+        super(Ruler, self).hoverEnterEvent(event)
+
+    def hoverLeaveEvent(self, event):
+        self.setSelected(False)
+        super(Ruler, self).hoverLeaveEvent(event)
+
+    def init(self):
+        for track_item in self.composition.items():
+            if isinstance(track_item, track_widgets.Track):
+                frameNumber_tail = FrameNumber("", position=-1)
+                frameNumber_tail.setParentItem(self)
+                frameNumber_head = FrameNumber("", position=1)
+                frameNumber_head.setParentItem(self)
+                frameNumber_tail.setY(track_item.pos().y())
+                frameNumber_head.setY(track_item.pos().y())
+                items = list()
+                for item in track_item.childItems():
+                    if not (isinstance(item, track_widgets.ClipItem) or
+                            isinstance(item, track_widgets.NestedItem)):
+                        continue
+                    items.append(item)
+                items.sort(key=lambda x: x.x())
+                self.labels.append([items, frameNumber_tail, frameNumber_head])
+
+        self.update_frame()
+
+    def setParentItem(self, timeSlider):
+        '''
+        subclass in order to add the rule to the timeSlider item.
+        '''
+        timeSlider.add_ruler(self)
+        super(Ruler, self).setParentItem(timeSlider)
+
+    def map_to_time_space(self, item):
+        '''
+        Temporary implementation.
+        @TODO: modify this function once Time Coordinates Spaces
+        feature is implemented.
+        '''
+
+        is_bounded = False
+        is_head = False
+        is_tail = False
+        f = "-?-"
+
+        ratio = (self.x() - item.x()) / float(item.rect().width())
+
+        # The 'if' condition should be : ratio < 0 or ration >= 1
+        # However, we are cheating in order to display the last frame of
+        # a clip (tail) and the first frame of the following clip (head)
+        # when we know that we cannot be on 2 frames at the same time
+        if ratio < 0 or ratio > 1:
+            return self._bounded_data(f, is_bounded, is_tail, is_head)
+
+        is_bounded = True
+        trimmed_range = item.item.trimmed_range()
+        duration = trimmed_range.duration.value
+        start_time = trimmed_range.start_time.value
+
+        f_nb = ratio * duration + start_time
+        if self._time_space == "trimmed_space":
+            f = ratio * duration
+        elif self._time_space == "media_space":
+            f = duration * ratio + start_time
+
+        f = math.floor(f)
+        f_nb = math.floor(f_nb)
+        if f_nb == start_time:
+            is_head = True
+
+        last_item_frame = start_time + duration - 1
+        if f_nb >= (last_item_frame):
+            is_tail = True
+            # As we cheated in the first place by saying that the ruler
+            # was within the boundary of this item when it is not...
+            if ratio == 1.0:
+                f -= 1
+
+        return self._bounded_data(f, is_bounded, is_tail, is_head)
+
+    def update_frame(self):
+
+        for track_widgets, frameNumber_tail, frameNumber_head in self.labels:
+            f_tail = ""
+            f_head = ""
+            highlight_head = False
+            for item_widget in track_widgets:
+                bounded_data = self.map_to_time_space(item_widget)
+                # check if ruler is within an item boundary
+                # in other word, start_frame <= ruler < end_frame
+                if not bounded_data.is_bounded:
+                    continue
+                f = int(round(bounded_data.f))
+                if bounded_data.is_head:
+                    highlight_head = True
+                if bounded_data.is_tail:
+                    f_tail = f
+                else:
+                    f_head = f
+                    break
+            frameNumber_head.setText("%s" % f_head, highlight_head)
+            frameNumber_tail.setText("%s" % f_tail)
+
+    def snap(self, direction, scene_width):
+        ruler_pos = self.x() + direction
+        closest_left = scene_width - ruler_pos
+        closest_right = 0 - ruler_pos
+        move_to_item = None
+
+        for track_widgets, frameNumber_tail, frameNumber_head in self.labels:
+            for item in track_widgets:
+                d = item.x() - ruler_pos
+                if direction > 0 and d > 0 and d < closest_left:
+                    closest_left = d
+                    move_to_item = item
+                elif direction < 0 and d < 0 and d > closest_right:
+                    closest_right = d
+                    move_to_item = item
+
+        if move_to_item:
+            self.setX(move_to_item.x())
+            self.update_frame()
+
+    def paint(self, *args, **kwargs):
+        new_args = [args[0],
+                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
+        super(Ruler, self).paint(*new_args, **kwargs)
+
+    def itemChange(self, change, value):
+        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
+            self.setPen(
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                else QtGui.QColor(0, 0, 0, 255)
+            )
+        return super(Ruler, self).itemChange(change, value)
+
+    def counteract_zoom(self, zoom_level=1.0):
+        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -27,673 +27,71 @@ from collections import OrderedDict, namedtuple
 import math
 
 import opentimelineio as otio
-
-TIME_SLIDER_HEIGHT = 20
-MEDIA_TYPE_SEPARATOR_HEIGHT = 5
-TRACK_HEIGHT = 45
-TRANSITION_HEIGHT = 10
-TIME_MULTIPLIER = 25
-LABEL_MARGIN = 5
-MARKER_SIZE = 10
-RULER_SIZE = 10
-EFFECT_HEIGHT = 1/3.0 * TRACK_HEIGHT
+import ruler_widget
+import track_widgets
 
 
-class _BaseItem(QtWidgets.QGraphicsRectItem):
+KEY_SYM = {QtCore.Qt.Key_Left: QtCore.Qt.Key_Right,
+           QtCore.Qt.Key_Right: QtCore.Qt.Key_Left,
+           QtCore.Qt.Key_Up: QtCore.Qt.Key_Down,
+           QtCore.Qt.Key_Down: QtCore.Qt.Key_Up}
 
-    def __init__(self, item, timeline_range, *args, **kwargs):
-        super(_BaseItem, self).__init__(*args, **kwargs)
-        self.item = item
-        self.timeline_range = timeline_range
 
-        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(180, 180, 180, 255))
-        )
+def get_nav_menu_data():
+    _nav_menu = namedtuple("nav_menu",
+                           ["bitmask", "otioItem", "default", "exclusive"])
+    filter_dict = OrderedDict([
+        ("Clip", _nav_menu(0b00000001, track_widgets.ClipItem,
+                           True, False)),
+        ("Nested Clip", _nav_menu(0b00000010, track_widgets.NestedItem,
+                                  True, False)),
+        ("Gap", _nav_menu(0b00000100, track_widgets.GapItem,
+                          True, False)),
+        ("Transition", _nav_menu(0b00001000, track_widgets.TransitionItem,
+                                 True, False)),
+        ("Only with Marker", _nav_menu(0b00010000, track_widgets.Marker,
+                                       False, True)),
+        ("Only with Effect", _nav_menu(0b00100000,
+                                       track_widgets.EffectItem,
+                                       False, True)),
+        # ("All", nav_menu(0b01000000, "None", False)) @TODO
+        ])
+    return filter_dict
 
-        pen = QtGui.QPen()
-        pen.setWidth(0)
-        self.setPen(pen)
 
-        self.source_in_label = QtWidgets.QGraphicsSimpleTextItem(self)
-        self.source_out_label = QtWidgets.QGraphicsSimpleTextItem(self)
-        self.source_name_label = QtWidgets.QGraphicsSimpleTextItem(self)
+def get_filters(filter_dict, bitmask):
+    filters = list()
+    for item in filter_dict.itervalues():
+        if bitmask & item.bitmask:
+            filters.append(item)
+    return filters
 
-        self._add_markers()
-        self._add_effects()
-        self._set_labels()
-        self._set_tooltip()
 
-    def paint(self, *args, **kwargs):
-        new_args = [args[0],
-                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
-        super(_BaseItem, self).paint(*new_args, **kwargs)
+def build_menu(navegation_menu):
+    filter_dict = get_nav_menu_data()
+    actions = list()
+    for label, nav in filter_dict.items():
+        if label == "Only with Marker":
+            navegation_menu.addSeparator()
 
-    def itemChange(self, change, value):
-        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
-            pen = self.pen()
-            pen.setColor(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
-                else QtGui.QColor(0, 0, 0, 255)
-            )
-            self.setPen(pen)
-            self.setZValue(
-                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
-            )
+        action = navegation_menu.addAction(label)
+        action.setCheckable(True)
+        action.setChecked(nav.default)
+        actions.append(action)
 
-        return super(_BaseItem, self).itemChange(change, value)
+    return actions
 
-    def _add_markers(self):
-        trimmed_range = self.item.trimmed_range()
 
-        for m in self.item.markers:
-            marked_time = m.marked_range.start_time
-            if not trimmed_range.overlaps(marked_time):
-                continue
-
-            # @TODO: set the marker color if its set from the OTIO object
-            marker = Marker(m, None)
-            marker.setY(0.5 * MARKER_SIZE)
-            marker.setX(
-                (
-                    otio.opentime.to_seconds(m.marked_range.start_time) -
-                    otio.opentime.to_seconds(trimmed_range.start_time)
-                ) * TIME_MULTIPLIER
-            )
-            marker.setParentItem(self)
-
-    def _add_effects(self):
-        if not hasattr(self.item, "effects"):
-            return
-        if not self.item.effects:
-            return
-        effect = EffectItem(self.item.effects, self.rect())
-        effect.setParentItem(self)
-
-    def _position_labels(self):
-        self.source_in_label.setY(LABEL_MARGIN)
-        self.source_out_label.setY(LABEL_MARGIN)
-        self.source_name_label.setY(
-            (TRACK_HEIGHT -
-             self.source_name_label.boundingRect().height()) / 2.0
-        )
-
-    def _set_labels_rational_time(self):
-        trimmed_range = self.item.trimmed_range()
-        self.source_in_label.setText(
-            '{value}\n@{rate}'.format(
-                value=trimmed_range.start_time.value,
-                rate=trimmed_range.start_time.rate
-            )
-        )
-        self.source_out_label.setText(
-            '{value}\n@{rate}'.format(
-                value=trimmed_range.end_time_inclusive().value,
-                rate=trimmed_range.end_time_inclusive().rate
-            )
-        )
-
-    def _set_labels_timecode(self):
-        self.source_in_label.setText(
-            '{timeline}\n{source}'.format(
-                timeline=otio.opentime.to_timecode(
-                    self.timeline_range.start_time,
-                    self.timeline_range.start_time.rate
-                ),
-                source=otio.opentime.to_timecode(
-                    self.item.trimmed_range.start_time,
-                    self.item.trimmed_range.start_time.rate
-                )
-            )
-        )
-
-        self.source_out_label.setText(
-            '{timeline}\n{source}'.format(
-                timeline=otio.opentime.to_timecode(
-                    self.timeline_range.end_time_exclusive(),
-                    self.timeline_range.end_time_exclusive().rate
-                ),
-                source=otio.opentime.to_timecode(
-                    self.item.trimmed_range.end_time_exclusive(),
-                    self.item.trimmed_range.end_time_exclusive().rate
-                )
-            )
-        )
-
-    def _set_labels(self):
-        self._set_labels_rational_time()
-        self.source_name_label.setText('PLACEHOLDER')
-        self._position_labels()
-
-    def _set_tooltip(self):
-        self.setToolTip(self.item.name)
-
-    def counteract_zoom(self, zoom_level=1.0):
-        for label in (
-            self.source_name_label,
-            self.source_in_label,
-            self.source_out_label
-        ):
-            label.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
-
-        self_rect = self.boundingRect()
-        name_width = self.source_name_label.boundingRect().width() * zoom_level
-        in_width = self.source_in_label.boundingRect().width() * zoom_level
-        out_width = self.source_out_label.boundingRect().width() * zoom_level
-
-        frames_space = in_width + out_width + 3 * LABEL_MARGIN * zoom_level
-
-        if frames_space > self_rect.width():
-            self.source_in_label.setVisible(False)
-            self.source_out_label.setVisible(False)
+def group_filters(bitmask):
+    inclusive_filters = list()
+    exclusive_filters = list()
+    filter_dict = get_nav_menu_data()
+    for item in get_filters(filter_dict, bitmask):
+        if item.exclusive:
+            exclusive_filters.append(item)
         else:
-            self.source_in_label.setVisible(True)
-            self.source_out_label.setVisible(True)
-
-            self.source_in_label.setX(LABEL_MARGIN * zoom_level)
-
-            self.source_out_label.setX(
-                self_rect.width() - LABEL_MARGIN * zoom_level - out_width
-            )
-
-        total_width = (name_width + frames_space + LABEL_MARGIN * zoom_level)
-        if total_width > self_rect.width():
-            self.source_name_label.setVisible(False)
-        else:
-            self.source_name_label.setVisible(True)
-            self.source_name_label.setX(0.5 * (self_rect.width() - name_width))
-
-
-class GapItem(_BaseItem):
-
-    def __init__(self, *args, **kwargs):
-        super(GapItem, self).__init__(*args, **kwargs)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(100, 100, 100, 255))
-        )
-        self.source_name_label.setText('GAP')
-
-
-class EffectItem(QtWidgets.QGraphicsRectItem):
-
-    def __init__(self, item, rect, *args, **kwargs):
-        super(EffectItem, self).__init__(rect, *args, **kwargs)
-        self.item = item
-        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
-        self.init()
-        self._set_tooltip()
-
-    def init(self):
-        rect = self.rect()
-        rect.setY(TRACK_HEIGHT - EFFECT_HEIGHT)
-        rect.setHeight(EFFECT_HEIGHT)
-        self.setRect(rect)
-
-        dark = QtGui.QColor(0, 0, 0, 150)
-        colour = QtGui.QColor(255, 255, 255, 200)
-        gradient = QtGui.QLinearGradient(
-                   QtCore.QPointF(0,
-                                  self.boundingRect().top()),
-                   QtCore.QPointF(0,
-                                  self.boundingRect().bottom()))
-        gradient.setColorAt(0.2, QtCore.Qt.transparent)
-        gradient.setColorAt(0.45, colour)
-        gradient.setColorAt(0.7, QtCore.Qt.transparent)
-        gradient.setColorAt(1.0, dark)
-        self.setBrush(QtGui.QBrush(gradient))
-
-        pen = self.pen()
-        pen.setColor(QtGui.QColor(0, 0, 0, 80))
-        pen.setWidth(0)
-        self.setPen(pen)
-
-    def _set_tooltip(self):
-        tool_tips = list()
-        for effect in self.item:
-            name = effect.name if effect.name else ""
-            effect_name = effect.effect_name if effect.effect_name else ""
-            tool_tips.append("{} {}".format(name, effect_name))
-        self.setToolTip("\n".join(tool_tips))
-
-    def paint(self, *args, **kwargs):
-        new_args = [args[0],
-                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
-        super(EffectItem, self).paint(*new_args, **kwargs)
-
-    def itemChange(self, change, value):
-        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
-            pen = self.pen()
-            pen.setColor(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
-                else QtGui.QColor(0, 0, 0, 80)
-            )
-            self.setPen(pen)
-            self.setZValue(
-                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
-            )
-
-        return super(EffectItem, self).itemChange(change, value)
-
-
-class TransitionItem(_BaseItem):
-
-    def __init__(self, item, timeline_range, rect, *args, **kwargs):
-        rect.setHeight(TRANSITION_HEIGHT)
-        super(TransitionItem, self).__init__(
-            item,
-            timeline_range,
-            rect,
-            *args,
-            **kwargs
-        )
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(237, 228, 148, 255))
-        )
-        self.setY(TRACK_HEIGHT - TRANSITION_HEIGHT)
-        self.setZValue(2)
-
-        # add extra bit of shading
-        shading_poly_f = QtGui.QPolygonF()
-        shading_poly_f.append(QtCore.QPointF(0, 0))
-        shading_poly_f.append(QtCore.QPointF(rect.width(), 0))
-        shading_poly_f.append(QtCore.QPointF(0, rect.height()))
-
-        shading_poly = QtWidgets.QGraphicsPolygonItem(
-            shading_poly_f, parent=self)
-        shading_poly.setBrush(QtGui.QBrush(QtGui.QColor(0, 0, 0, 30)))
-
-        try:
-            shading_poly.setPen(QtCore.Qt.NoPen)
-        except TypeError:
-            shading_poly.setPen(QtCore.Qt.transparent)
-
-    def _add_markers(self):
-        return
-
-    def _set_labels(self):
-        return
-
-
-class ClipItem(_BaseItem):
-
-    def __init__(self, *args, **kwargs):
-        super(ClipItem, self).__init__(*args, **kwargs)
-        self.setBrush(QtGui.QBrush(QtGui.QColor(168, 197, 255, 255)))
-        self.source_name_label.setText(self.item.name)
-
-
-class NestedItem(_BaseItem):
-
-    def __init__(self, *args, **kwargs):
-        super(NestedItem, self).__init__(*args, **kwargs)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(255, 113, 91, 255))
-        )
-
-        self.source_name_label.setText(self.item.name)
-
-    def mouseDoubleClickEvent(self, event):
-        super(NestedItem, self).mouseDoubleClickEvent(event)
-        self.scene().views()[0].open_stack.emit(self.item)
-
-    def keyPressEvent(self, key_event):
-        super(NestedItem, self).keyPressEvent(key_event)
-        key = key_event.key()
-
-        if key == QtCore.Qt.Key_Return:
-            self.scene().views()[0].open_stack.emit(self.item)
-
-
-class Track(QtWidgets.QGraphicsRectItem):
-
-    def __init__(self, track, *args, **kwargs):
-        super(Track, self).__init__(*args, **kwargs)
-        self.track = track
-
-        self.setBrush(QtGui.QBrush(QtGui.QColor(43, 52, 59, 255)))
-        self._populate()
-
-    def _populate(self):
-        track_map = self.track.range_of_all_children()
-        for n, item in enumerate(self.track):
-            timeline_range = track_map[item]
-
-            rect = QtCore.QRectF(
-                0,
-                0,
-                otio.opentime.to_seconds(timeline_range.duration) *
-                TIME_MULTIPLIER,
-                TRACK_HEIGHT
-            )
-
-            if isinstance(item, otio.schema.Clip):
-                new_item = ClipItem(item, timeline_range, rect)
-            elif isinstance(item, otio.schema.Stack):
-                new_item = NestedItem(item, timeline_range, rect)
-            elif isinstance(item, otio.schema.Track):
-                new_item = NestedItem(item, timeline_range, rect)
-            elif isinstance(item, otio.schema.Gap):
-                new_item = GapItem(item, timeline_range, rect)
-            elif isinstance(item, otio.schema.Transition):
-                new_item = TransitionItem(item, timeline_range, rect)
-            else:
-                print("Warning: could not add item {} to UI.".format(item))
-                continue
-
-            new_item.setParentItem(self)
-            new_item.setX(
-                otio.opentime.to_seconds(timeline_range.start_time) *
-                TIME_MULTIPLIER
-            )
-            new_item.counteract_zoom()
-
-
-class Marker(QtWidgets.QGraphicsPolygonItem):
-
-    def __init__(self, marker, *args, **kwargs):
-        self.item = marker
-
-        poly = QtGui.QPolygonF()
-        poly.append(QtCore.QPointF(0.5 * MARKER_SIZE, -0.5 * MARKER_SIZE))
-        poly.append(QtCore.QPointF(0.5 * MARKER_SIZE, 0.5 * MARKER_SIZE))
-        poly.append(QtCore.QPointF(0, MARKER_SIZE))
-        poly.append(QtCore.QPointF(-0.5 * MARKER_SIZE, 0.5 * MARKER_SIZE))
-        poly.append(QtCore.QPointF(-0.5 * MARKER_SIZE, -0.5 * MARKER_SIZE))
-        super(Marker, self).__init__(poly, *args, **kwargs)
-
-        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(121, 212, 177, 255))
-        )
-
-    def paint(self, *args, **kwargs):
-        new_args = [args[0],
-                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
-        super(Marker, self).paint(*new_args, **kwargs)
-
-    def itemChange(self, change, value):
-        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
-            self.setPen(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
-                else QtGui.QColor(0, 0, 0, 255)
-            )
-        return super(Marker, self).itemChange(change, value)
-
-    def counteract_zoom(self, zoom_level=1.0):
-        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
-
-
-class TimeSlider(QtWidgets.QGraphicsRectItem):
-
-    def __init__(self, *args, **kwargs):
-        super(TimeSlider, self).__init__(*args, **kwargs)
-        self.setBrush(QtGui.QBrush(QtGui.QColor(64, 78, 87, 255)))
-        pen = QtGui.QPen()
-        pen.setWidth(0)
-        self.setPen(pen)
-        self._ruler = None
-
-    def mousePressEvent(self, mouse_event):
-        pos = self.mapToScene(mouse_event.pos())
-        self._ruler.setPos(QtCore.QPointF(pos.x(),
-                                          TIME_SLIDER_HEIGHT - MARKER_SIZE))
-        self._ruler.update_frame()
-
-        super(TimeSlider, self).mousePressEvent(mouse_event)
-
-    def add_ruler(self, ruler):
-        self._ruler = ruler
-
-
-class FrameNumber(QtWidgets.QGraphicsRectItem):
-
-    def __init__(self, text, position, *args, **kwargs):
-        super(FrameNumber, self).__init__(*args, **kwargs)
-        self.frameNumber = QtWidgets.QGraphicsSimpleTextItem(self)
-        self.frameNumber.setText("%s" % text)
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(5, 55, 0, 255))
-        )
-        self.setPen(
-            QtCore.Qt.NoPen
-        )
-        self.frameNumber.setBrush(
-            QtGui.QBrush(QtGui.QColor(25, 255, 10, 255))
-        )
-        # if position < 0 then the frameNumber will appear on the left side
-        # of the ruler
-        self.position = position
-
-    def setText(self, txt, highlight=False):
-        if txt:
-            self.show()
-            self.frameNumber.setText("%s" % txt)
-            rect = self.frameNumber.boundingRect()
-            self.setRect(self.frameNumber.boundingRect())
-            if highlight:
-                # paint with a different color when on
-                # the first frame of a clip
-                self.setBrush(
-                    QtGui.QBrush(QtGui.QColor(55, 5, 0, 120))
-                )
-                self.frameNumber.setBrush(
-                    QtGui.QBrush(QtGui.QColor(255, 250, 250, 255))
-                )
-            else:
-                self.frameNumber.setBrush(
-                    QtGui.QBrush(QtGui.QColor(25, 255, 10, 255))
-                )
-                self.setBrush(
-                    QtGui.QBrush(QtGui.QColor(5, 55, 0, 120))
-                )
-            if self.position < 0:
-                self.setX(-rect.width()-2)
-            else:
-                self.setX(2)
-        else:
-            self.hide()
-
-
-class Ruler(QtWidgets.QGraphicsPolygonItem):
-    #  @TODO pending on Global Space implementation
-    #  ("external_space", "External Space"),
-    time_space = OrderedDict([("media_space", "Media Space"),
-                              ("trimmed_space", "Trimmed Space")])
-
-    time_space_default = "media_space"
-
-    def __init__(self, height, composition, *args, **kwargs):
-
-        poly = QtGui.QPolygonF()
-        poly.append(QtCore.QPointF(0.5 * RULER_SIZE, -0.5 * RULER_SIZE))
-        poly.append(QtCore.QPointF(0.5 * RULER_SIZE, 0.5 * RULER_SIZE))
-        poly.append(QtCore.QPointF(0, RULER_SIZE))
-        poly.append(QtCore.QPointF(0, height))
-        poly.append(QtCore.QPointF(0, RULER_SIZE))
-        poly.append(QtCore.QPointF(-0.5 * RULER_SIZE, 0.5 * RULER_SIZE))
-        poly.append(QtCore.QPointF(-0.5 * RULER_SIZE, -0.5 * RULER_SIZE))
-        super(Ruler, self).__init__(poly, *args, **kwargs)
-
-        # to retrieve tracks and its children
-        self.composition = composition
-        self.setBrush(
-            QtGui.QBrush(QtGui.QColor(50, 255, 20, 255))
-        )
-
-        self.setAcceptHoverEvents(True)
-        self.setFlag(QtWidgets.QGraphicsItem.ItemIsSelectable, True)
-        self.setFlag(QtWidgets.QGraphicsItem.ItemIsFocusable, True)
-
-        self.labels = list()
-        self._time_space = self.time_space_default
-        self._bounded_data = namedtuple("bounded_data", ["f",
-                                                         "is_bounded",
-                                                         "is_tail",
-                                                         "is_head"])
-        self.init()
-
-    def contextMenuEvent(self, event):
-        menu = QtWidgets.QMenu()
-        for name, label in self.time_space.items():
-            callback = lambda name_str = name: \
-                self.set_time_space_callback(name_str)
-            menu.addAction(label, callback)
-        menu.exec_(event.screenPos())
-
-        super(Ruler, self).contextMenuEvent(event)
-
-    def set_time_space_callback(self, time_space):
-        self._time_space = time_space
-        self.update_frame()
-
-    def mouseMoveEvent(self, mouse_event):
-        pos = self.mapToScene(mouse_event.pos())
-        self.setPos(QtCore.QPointF(pos.x(),
-                                   TIME_SLIDER_HEIGHT - MARKER_SIZE))
-        self.update_frame()
-
-        super(Ruler, self).mouseMoveEvent(mouse_event)
-
-    def hoverEnterEvent(self, event):
-        self.setSelected(True)
-        super(Ruler, self).hoverEnterEvent(event)
-
-    def hoverLeaveEvent(self, event):
-        self.setSelected(False)
-        super(Ruler, self).hoverLeaveEvent(event)
-
-    def init(self):
-        for track_item in self.composition.items():
-            if isinstance(track_item, Track):
-                frameNumber_tail = FrameNumber("", position=-1)
-                frameNumber_tail.setParentItem(self)
-                frameNumber_head = FrameNumber("", position=1)
-                frameNumber_head.setParentItem(self)
-                frameNumber_tail.setY(track_item.pos().y())
-                frameNumber_head.setY(track_item.pos().y())
-                items = list()
-                for item in track_item.childItems():
-                    if not (isinstance(item, ClipItem) or
-                            isinstance(item, NestedItem)):
-                        continue
-                    items.append(item)
-                items.sort(key=lambda x: x.x())
-                self.labels.append([items, frameNumber_tail, frameNumber_head])
-
-        self.update_frame()
-
-    def setParentItem(self, timeSlider):
-        '''
-        subclass in order to add the rule to the timeSlider item.
-        '''
-        timeSlider.add_ruler(self)
-        super(Ruler, self).setParentItem(timeSlider)
-
-    def map_to_time_space(self, item):
-        '''
-        Temporary implementation.
-        @TODO: modify this function once Time Coordinates Spaces
-        feature is implemented.
-        '''
-
-        is_bounded = False
-        is_head = False
-        is_tail = False
-        f = "-?-"
-
-        ratio = (self.x() - item.x()) / float(item.rect().width())
-
-        # The 'if' condition should be : ratio < 0 or ration >= 1
-        # However, we are cheating in order to display the last frame of
-        # a clip (tail) and the first frame of the following clip (head)
-        # when we know that we cannot be on 2 frames at the same time
-        if ratio < 0 or ratio > 1:
-            return self._bounded_data(f, is_bounded, is_tail, is_head)
-
-        is_bounded = True
-        trimmed_range = item.item.trimmed_range()
-        duration = trimmed_range.duration.value
-        start_time = trimmed_range.start_time.value
-
-        f_nb = ratio * duration + start_time
-        if self._time_space == "trimmed_space":
-            f = ratio * duration
-        elif self._time_space == "media_space":
-            f = duration * ratio + start_time
-
-        f = math.floor(f)
-        f_nb = math.floor(f_nb)
-        if f_nb == start_time:
-            is_head = True
-
-        last_item_frame = start_time + duration - 1
-        if f_nb >= (last_item_frame):
-            is_tail = True
-            # As we cheated in the first place by saying that the ruler
-            # was within the boundary of this item when it is not...
-            if ratio == 1.0:
-                f -= 1
-
-        return self._bounded_data(f, is_bounded, is_tail, is_head)
-
-    def update_frame(self):
-
-        for track_widgets, frameNumber_tail, frameNumber_head in self.labels:
-            f_tail = ""
-            f_head = ""
-            highlight_head = False
-            for item_widget in track_widgets:
-                bounded_data = self.map_to_time_space(item_widget)
-                # check if ruler is within an item boundary
-                # in other word, start_frame <= ruler < end_frame
-                if not bounded_data.is_bounded:
-                    continue
-                f = int(round(bounded_data.f))
-                if bounded_data.is_head:
-                    highlight_head = True
-                if bounded_data.is_tail:
-                    f_tail = f
-                else:
-                    f_head = f
-                    break
-            frameNumber_head.setText("%s" % f_head, highlight_head)
-            frameNumber_tail.setText("%s" % f_tail)
-
-    def snap(self, direction, scene_width):
-        ruler_pos = self.x() + direction
-        closest_left = scene_width - ruler_pos
-        closest_right = 0 - ruler_pos
-        move_to_item = None
-
-        for track_widgets, frameNumber_tail, frameNumber_head in self.labels:
-            for item in track_widgets:
-                d = item.x() - ruler_pos
-                if direction > 0 and d > 0 and d < closest_left:
-                    closest_left = d
-                    move_to_item = item
-                elif direction < 0 and d < 0 and d > closest_right:
-                    closest_right = d
-                    move_to_item = item
-
-        if move_to_item:
-            self.setX(move_to_item.x())
-            self.update_frame()
-
-    def paint(self, *args, **kwargs):
-        new_args = [args[0],
-                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
-        super(Ruler, self).paint(*new_args, **kwargs)
-
-    def itemChange(self, change, value):
-        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
-            self.setPen(
-                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
-                else QtGui.QColor(0, 0, 0, 255)
-            )
-        return super(Ruler, self).itemChange(change, value)
-
-    def counteract_zoom(self, zoom_level=1.0):
-        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
+            inclusive_filters.append(item)
+    return inclusive_filters, exclusive_filters
 
 
 class CompositionWidget(QtWidgets.QGraphicsScene):
@@ -743,38 +141,39 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
             )
 
         height = (
-            TIME_SLIDER_HEIGHT +
+            track_widgets.TIME_SLIDER_HEIGHT +
             (
                 int(has_video_tracks and has_audio_tracks) *
-                MEDIA_TYPE_SEPARATOR_HEIGHT
+                track_widgets.MEDIA_TYPE_SEPARATOR_HEIGHT
             ) +
-            len(self.composition) * TRACK_HEIGHT
+            len(self.composition) * track_widgets.TRACK_HEIGHT
         )
 
         self.setSceneRect(
-            start_time * TIME_MULTIPLIER,
+            start_time * track_widgets.TIME_MULTIPLIER,
             0,
-            duration * TIME_MULTIPLIER,
+            duration * track_widgets.TIME_MULTIPLIER,
             height
         )
 
     def _add_time_slider(self):
         scene_rect = self.sceneRect()
         scene_rect.setWidth(scene_rect.width() * 10)
-        scene_rect.setHeight(TIME_SLIDER_HEIGHT)
-        self._time_slider = TimeSlider(scene_rect)
+        scene_rect.setHeight(track_widgets.TIME_SLIDER_HEIGHT)
+        self._time_slider = track_widgets.TimeSlider(scene_rect)
         self.addItem(self._time_slider)
 
     def _add_track(self, track, y_pos):
         scene_rect = self.sceneRect()
-        rect = QtCore.QRectF(0, 0, scene_rect.width() * 10, TRACK_HEIGHT)
-        new_track = Track(track, rect)
+        rect = QtCore.QRectF(0, 0, scene_rect.width() * 10,
+                             track_widgets.TRACK_HEIGHT)
+        new_track = track_widgets.Track(track, rect)
         self.addItem(new_track)
         new_track.setPos(scene_rect.x(), y_pos)
 
     def _add_tracks(self):
-        video_tracks_top = TIME_SLIDER_HEIGHT
-        audio_tracks_top = TIME_SLIDER_HEIGHT
+        video_tracks_top = track_widgets.TIME_SLIDER_HEIGHT
+        audio_tracks_top = track_widgets.TIME_SLIDER_HEIGHT
 
         video_tracks = []
         audio_tracks = []
@@ -818,38 +217,42 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
 
             video_tracks.extend(other_tracks)
 
-        video_tracks_top = TIME_SLIDER_HEIGHT
+        video_tracks_top = track_widgets.TIME_SLIDER_HEIGHT
         audio_tracks_top = (
-            TIME_SLIDER_HEIGHT +
-            len(video_tracks) * TRACK_HEIGHT +
+            track_widgets.TIME_SLIDER_HEIGHT +
+            len(video_tracks) * track_widgets.TRACK_HEIGHT +
             int(
                 bool(video_tracks) and bool(audio_tracks)
-            ) * MEDIA_TYPE_SEPARATOR_HEIGHT
+            ) * track_widgets.MEDIA_TYPE_SEPARATOR_HEIGHT
         )
 
         for i, track in enumerate(audio_tracks):
-            self._add_track(track, audio_tracks_top + i * TRACK_HEIGHT)
+            self._add_track(track, audio_tracks_top + i *
+                            track_widgets.TRACK_HEIGHT)
 
         for i, track in enumerate(video_tracks):
-            self._add_track(track, video_tracks_top + i * TRACK_HEIGHT)
+            self._add_track(track, video_tracks_top + i *
+                            track_widgets.TRACK_HEIGHT)
 
     def _add_markers(self):
         for m in self.composition.markers:
-            marker = Marker(m, None)
+            marker = track_widgets.Marker(m, None)
             marker.setX(
                 otio.opentime.to_seconds(m.marked_range.start_time) *
-                TIME_MULTIPLIER
+                track_widgets.TIME_MULTIPLIER
             )
-            marker.setY(TIME_SLIDER_HEIGHT - MARKER_SIZE)
+            marker.setY(track_widgets.TIME_SLIDER_HEIGHT -
+                        track_widgets.MARKER_SIZE)
             marker.setParentItem(self._time_slider)
             marker.counteract_zoom()
 
     def _add_ruler(self):
         scene_rect = self.sceneRect()
-        ruler = Ruler(scene_rect.height(), composition=self)
+        ruler = ruler_widget.Ruler(scene_rect.height(), composition=self)
         ruler.setParentItem(self._time_slider)
         ruler.setX(scene_rect.width() / 2)
-        ruler.setY(TIME_SLIDER_HEIGHT - MARKER_SIZE)
+        ruler.setY(track_widgets.TIME_SLIDER_HEIGHT -
+                   track_widgets.MARKER_SIZE)
 
         ruler.counteract_zoom()
         return ruler
@@ -857,6 +260,141 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
     def get_ruler(self):
         return self._ruler
 
+<<<<<<< HEAD
+=======
+    def get_next_item(self, item, key):
+        otio_item = item.item
+        next_item = None
+        if key in [QtCore.Qt.Key_Right, QtCore.Qt.Key_Left]:
+            head, tail = otio_item.parent().neighbors_of(otio_item)
+            next_item = head if key == QtCore.Qt.Key_Left else tail
+        elif key in [QtCore.Qt.Key_Up, QtCore.Qt.Key_Down]:
+            track = item.parentItem()
+            if self._data_cache[track][key]:
+                next_track = self._data_cache[track][key]
+            else:
+                # No more track in that direction.
+                return item
+            at_time = otio_item.trimmed_range_in_parent().start_time
+
+            # If at_time is out of track_range, then get the latest item
+            # in the track.
+            at_time = min(at_time,
+                          self._data_cache[next_track]["end_time_inclusive"])
+
+            next_item = next_track.track.child_at_time(at_time)
+
+        # need the widget, not the otio instance.
+        if next_item:
+            next_item = self._data_cache["map_to_widget"][next_item]
+
+        return next_item
+
+    def _get_closest_item(self, item, start_time, filters):
+        next_item = item
+        tail = self.get_next_item_filters(item, QtCore.Qt.Key_Right, filters)
+        head = self.get_next_item_filters(item, QtCore.Qt.Key_Left, filters)
+
+        # 3 cases
+        # 1. tail and head are both valid => get the closest one
+        if not tail == item and not head == item:
+            tail_start_time = tail.item.trimmed_range_in_parent().start_time
+            head_end_time = head.item.trimmed_range_in_parent().\
+                end_time_inclusive()
+
+            time_to_tail = tail_start_time - start_time
+            time_to_head = start_time - head_end_time
+
+            next_item = tail if time_to_tail < time_to_head else head
+
+        # 2. only tail is valid
+        elif not tail == item and head == item:
+            next_item = tail
+
+        # 3. only head is valid
+        elif tail == item and not head == item:
+            next_item = head
+
+        return next_item
+
+    def get_next_item_filters(self, item, key, filters):
+        original_item = item
+        next_item = None
+        while not match_filters(next_item, filters):
+            next_item = self.get_next_item(item, key)
+
+            if key in [QtCore.Qt.Key_Up, QtCore.Qt.Key_Down] and \
+               not match_filters(next_item, filters):
+                start_time = item.item.trimmed_range_in_parent().start_time
+                next_item = self._get_closest_item(next_item, start_time,
+                                                   filters)
+
+            if next_item is None or next_item == item:
+                next_item = original_item
+                break
+
+            item = next_item
+
+        return next_item
+
+    def _cache_tracks(self):
+        '''
+        Create a doubly linked list to navigate from track to track:
+            track->get_next_up & track->get_next_up
+        "map_to_wodget" : Create a map to retrieve the pyside widget from
+        the otio item
+        '''
+        data_cache = dict()
+        tracks = list()
+        data_cache["map_to_widget"] = dict()
+        for track_item in self.items():
+            if not isinstance(track_item, track_widgets.Track):
+                continue
+            tracks.append(track_item)
+            track_range = track_item.track.available_range()
+            data_cache[track_item] = {QtCore.Qt.Key_Up: None,
+                                      QtCore.Qt.Key_Down: None,
+                                      "end_time_inclusive":
+                                      track_range.end_time_inclusive()
+                                      }
+
+            for item in track_item.childItems():
+                data_cache["map_to_widget"][item.item] = item
+
+        tracks.sort(key=lambda y: y.pos().y())
+        index_last_track = len(tracks) - 1
+        for i, track_item in enumerate(tracks):
+            data_cache[track_item][QtCore.Qt.Key_Up] = \
+                tracks[i-1] if i > 0 else None
+            data_cache[track_item][QtCore.Qt.Key_Down] = \
+                tracks[i+1] if i < index_last_track else None
+
+        return data_cache
+
+
+def match_filters(item, filters=None):
+    if not item:
+        return None
+    if filters is None:
+        return item
+
+    otio_children = list()
+    if isinstance(item, track_widgets.BaseItem):
+        otio_children = item.get_otio_sub_items()
+
+    for filter in filters.exclusive:
+        excl_item = [i for i in otio_children
+                     if isinstance(i, filter.otioItem)]
+        if not excl_item:
+            return None
+
+    for filter in filters.inclusive:
+        if isinstance(item, filter.otioItem):
+            return item
+
+    return None
+
+>>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
 
 class CompositionView(QtWidgets.QGraphicsView):
 
@@ -878,7 +416,7 @@ class CompositionView(QtWidgets.QGraphicsView):
             return
         # Exclude ruler from selection
         for item in selection:
-            if isinstance(item, Ruler):
+            if isinstance(item, ruler_widget.Ruler):
                 continue
             self.selection_changed.emit(item.item)
             break
@@ -907,9 +445,9 @@ class CompositionView(QtWidgets.QGraphicsView):
         # inverse the effect of the zoom
         items_to_scale = [
             i for i in self.scene().items()
-            if isinstance(i, _BaseItem) or
-            isinstance(i, Marker) or
-            isinstance(i, Ruler)
+            if isinstance(i, track_widgets.BaseItem) or
+            isinstance(i, track_widgets.Marker) or
+            isinstance(i, ruler_widget.Ruler)
         ]
 
         for item in items_to_scale:
@@ -917,7 +455,7 @@ class CompositionView(QtWidgets.QGraphicsView):
 
     def _get_first_item(self):
         newXpos = 0
-        newYpos = TIME_SLIDER_HEIGHT
+        newYpos = track_widgets.TIME_SLIDER_HEIGHT
 
         newPosition = QtCore.QPointF(newXpos, newYpos)
 
@@ -1029,7 +567,8 @@ class CompositionView(QtWidgets.QGraphicsView):
         # Validate new item for edge cases
         # If valid, set selected
         if (
-            not isinstance(newSelectedItem, Track) and newSelectedItem
+            not isinstance(newSelectedItem, track_widgets.Track) and
+            newSelectedItem
         ):
             self._deselect_all_items()
             newSelectedItem.setSelected(True)
@@ -1045,6 +584,7 @@ class CompositionView(QtWidgets.QGraphicsView):
                 QtCore.Qt.Key_Down,
                 QtCore.Qt.Key_Return,
                 QtCore.Qt.Key_Enter
+<<<<<<< HEAD
         ) and not (modifier & QtCore.Qt.ControlModifier):
             if key == QtCore.Qt.Key_Left:
                 newSelectedItem = self._get_left_item(curSelectedItem)
@@ -1060,6 +600,40 @@ class CompositionView(QtWidgets.QGraphicsView):
                     newSelectedItem = None
         else:
             newSelectedItem = None
+=======
+        ) and not (modifier & QtCore.Qt.ControlModifier)):
+            return None
+
+        if key in [QtCore.Qt.Key_Left, QtCore.Qt.Key_Right,
+                   QtCore.Qt.Key_Up, QtCore.Qt.Key_Down]:
+
+            # check if last key was the opposite direction of current one
+            if KEY_SYM[key] == self._last_item_cache["key"] and \
+               curSelectedItem == self._last_item_cache["item"] and \
+               not curSelectedItem == self._last_item_cache["previous_item"]:
+                newSelectedItem = self._last_item_cache["previous_item"]
+            else:
+                filters = self.get_filters()
+                # make sure that the selected item is a BaseItem
+                while (not
+                       isinstance(curSelectedItem, track_widgets.BaseItem) and
+                       curSelectedItem):
+                    curSelectedItem = curSelectedItem.parentItem()
+                if not curSelectedItem:
+                    return None
+
+                newSelectedItem = self.scene().get_next_item_filters(
+                                curSelectedItem, key, filters)
+
+            # self._last_item_cache["item"] = curSelectedItem
+            self._last_item_cache["item"] = newSelectedItem
+            self._last_item_cache["previous_item"] = curSelectedItem
+            self._last_item_cache["key"] = key
+        elif key in [QtCore.Qt.Key_Return, QtCore.Qt.Key_Return]:
+            if isinstance(curSelectedItem, track_widgets.NestedItem):
+                curSelectedItem.keyPressEvent(key_event)
+                newSelectedItem = None
+>>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
 
         return newSelectedItem
 
@@ -1067,6 +641,12 @@ class CompositionView(QtWidgets.QGraphicsView):
         super(CompositionView, self).keyPressEvent(key_event)
         self.setInteractive(True)
 
+<<<<<<< HEAD
+=======
+        # Remove ruler_widget.Ruler instance from selection
+        selections = filter(lambda x: not isinstance(x, ruler_widget.Ruler),
+                            self.scene().selectedItems())
+>>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
         # No item selected, so select the first item
         if len(self.scene().selectedItems()) <= 0:
             newSelectedItem = self._get_first_item()
@@ -1120,9 +700,9 @@ class CompositionView(QtWidgets.QGraphicsView):
         items_to_scale = [
             i for i in self.scene().items()
             if (
-                isinstance(i, _BaseItem) or
-                isinstance(i, Marker) or
-                isinstance(i, Ruler)
+                isinstance(i, track_widgets.BaseItem) or
+                isinstance(i, track_widgets.Marker) or
+                isinstance(i, ruler_widget.Ruler)
             )
         ]
         # some items we do want to keep the same visual size. So we need to
@@ -1131,6 +711,23 @@ class CompositionView(QtWidgets.QGraphicsView):
         for item in items_to_scale:
             item.counteract_zoom(zoom_level)
 
+<<<<<<< HEAD
+=======
+    def navigationfilter_changed(self, bitmask):
+        '''
+        Update the navigation filter according to the filters checked in the
+        navigation menu. Reset _last_item_cache
+        '''
+        nav_d = namedtuple("navigation_filter", ["inclusive", "exclusive"])
+        incl_filter, excl_filter = group_filters(bitmask)
+        self._navigation_filter = nav_d(incl_filter, excl_filter)
+        self._last_item_cache = {"key": None, "item": None,
+                                 "previous_item": None}
+
+    def get_filters(self):
+        return self._navigation_filter
+
+>>>>>>> 0c551c3... refactor timeline_widget.py. Extract track_widgets classes and ruler class in its own module.
 
 class Timeline(QtWidgets.QTabWidget):
 

--- a/opentimelineview/timeline_widget.py
+++ b/opentimelineview/timeline_widget.py
@@ -67,14 +67,14 @@ def get_filters(filter_dict, bitmask):
     return filters
 
 
-def build_menu(navegation_menu):
+def build_menu(navigation_menu):
     filter_dict = get_nav_menu_data()
     actions = list()
     for label, nav in filter_dict.items():
         if label == "Only with Marker":
-            navegation_menu.addSeparator()
+            navigation_menu.addSeparator()
 
-        action = navegation_menu.addAction(label)
+        action = navigation_menu.addAction(label)
         action.setCheckable(True)
         action.setChecked(nav.default)
         actions.append(action)

--- a/opentimelineview/track_widgets.py
+++ b/opentimelineview/track_widgets.py
@@ -1,0 +1,462 @@
+#
+# Copyright 2017 Pixar Animation Studios
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+from PySide2 import QtGui, QtCore, QtWidgets
+import opentimelineio as otio
+
+
+TIME_SLIDER_HEIGHT = 20
+MEDIA_TYPE_SEPARATOR_HEIGHT = 5
+TRACK_HEIGHT = 45
+TRANSITION_HEIGHT = 10
+TIME_MULTIPLIER = 25
+LABEL_MARGIN = 5
+MARKER_SIZE = 10
+EFFECT_HEIGHT = 1/3.0 * TRACK_HEIGHT
+HIGHLIGHT_WIDTH = 5
+
+
+class BaseItem(QtWidgets.QGraphicsRectItem):
+
+    def __init__(self, item, timeline_range, *args, **kwargs):
+        super(BaseItem, self).__init__(*args, **kwargs)
+        self.item = item
+        self.timeline_range = timeline_range
+
+        # List of otio.core.SerializableObject
+        # it excludes decorator widgets as QLabel ...
+        self._otio_sub_items = list()
+
+        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(180, 180, 180, 255))
+        )
+
+        pen = QtGui.QPen()
+        pen.setWidth(0)
+        pen.setCosmetic(True)
+        self.setPen(pen)
+
+        self.source_in_label = QtWidgets.QGraphicsSimpleTextItem(self)
+        self.source_out_label = QtWidgets.QGraphicsSimpleTextItem(self)
+        self.source_name_label = QtWidgets.QGraphicsSimpleTextItem(self)
+
+        self._add_markers()
+        self._add_effects()
+        self._set_labels()
+        self._set_tooltip()
+
+    def paint(self, *args, **kwargs):
+        new_args = [args[0],
+                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
+        super(BaseItem, self).paint(*new_args, **kwargs)
+
+    def itemChange(self, change, value):
+        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
+            pen = self.pen()
+            pen.setColor(
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                else QtGui.QColor(0, 0, 0, 255)
+            )
+            pen.setWidth(HIGHLIGHT_WIDTH if self.isSelected() else 0)
+            self.setPen(pen)
+            self.setZValue(
+                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
+            )
+            self.parentItem().setZValue(
+                self.parentItem().zValue() + 1 if self.isSelected() else
+                self.parentItem().zValue() - 1
+            )
+
+        return super(BaseItem, self).itemChange(change, value)
+
+    def _add_markers(self):
+        trimmed_range = self.item.trimmed_range()
+
+        for m in self.item.markers:
+            marked_time = m.marked_range.start_time
+            if not trimmed_range.overlaps(marked_time):
+                continue
+
+            # @TODO: set the marker color if its set from the OTIO object
+            marker = Marker(m, None)
+            marker.setY(0.5 * MARKER_SIZE)
+            marker.setX(
+                (
+                    otio.opentime.to_seconds(m.marked_range.start_time) -
+                    otio.opentime.to_seconds(trimmed_range.start_time)
+                ) * TIME_MULTIPLIER
+            )
+            marker.setParentItem(self)
+            self._add_otio_sub_item(marker)
+
+    def _add_effects(self):
+        if not hasattr(self.item, "effects"):
+            return
+        if not self.item.effects:
+            return
+        effect = EffectItem(self.item.effects, self.rect())
+        effect.setParentItem(self)
+        self._add_otio_sub_item(effect)
+
+    def _add_otio_sub_item(self, item):
+        self._otio_sub_items.append(item)
+
+    def get_otio_sub_items(self):
+        return self._otio_sub_items
+
+    def _position_labels(self):
+        self.source_in_label.setY(LABEL_MARGIN)
+        self.source_out_label.setY(LABEL_MARGIN)
+        self.source_name_label.setY(
+            (TRACK_HEIGHT -
+             self.source_name_label.boundingRect().height()) / 2.0
+        )
+
+    def _set_labels_rational_time(self):
+        trimmed_range = self.item.trimmed_range()
+        self.source_in_label.setText(
+            '{value}\n@{rate}'.format(
+                value=trimmed_range.start_time.value,
+                rate=trimmed_range.start_time.rate
+            )
+        )
+        self.source_out_label.setText(
+            '{value}\n@{rate}'.format(
+                value=trimmed_range.end_time_inclusive().value,
+                rate=trimmed_range.end_time_inclusive().rate
+            )
+        )
+
+    def _set_labels_timecode(self):
+        self.source_in_label.setText(
+            '{timeline}\n{source}'.format(
+                timeline=otio.opentime.to_timecode(
+                    self.timeline_range.start_time,
+                    self.timeline_range.start_time.rate
+                ),
+                source=otio.opentime.to_timecode(
+                    self.item.trimmed_range.start_time,
+                    self.item.trimmed_range.start_time.rate
+                )
+            )
+        )
+
+        self.source_out_label.setText(
+            '{timeline}\n{source}'.format(
+                timeline=otio.opentime.to_timecode(
+                    self.timeline_range.end_time_exclusive(),
+                    self.timeline_range.end_time_exclusive().rate
+                ),
+                source=otio.opentime.to_timecode(
+                    self.item.trimmed_range.end_time_exclusive(),
+                    self.item.trimmed_range.end_time_exclusive().rate
+                )
+            )
+        )
+
+    def _set_labels(self):
+        self._set_labels_rational_time()
+        self.source_name_label.setText('PLACEHOLDER')
+        self._position_labels()
+
+    def _set_tooltip(self):
+        self.setToolTip(self.item.name)
+
+    def counteract_zoom(self, zoom_level=1.0):
+        for label in (
+            self.source_name_label,
+            self.source_in_label,
+            self.source_out_label
+        ):
+            label.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
+
+        self_rect = self.boundingRect()
+        name_width = self.source_name_label.boundingRect().width() * zoom_level
+        in_width = self.source_in_label.boundingRect().width() * zoom_level
+        out_width = self.source_out_label.boundingRect().width() * zoom_level
+
+        frames_space = in_width + out_width + 3 * LABEL_MARGIN * zoom_level
+
+        if frames_space > self_rect.width():
+            self.source_in_label.setVisible(False)
+            self.source_out_label.setVisible(False)
+        else:
+            self.source_in_label.setVisible(True)
+            self.source_out_label.setVisible(True)
+
+            self.source_in_label.setX(LABEL_MARGIN * zoom_level)
+
+            self.source_out_label.setX(
+                self_rect.width() - LABEL_MARGIN * zoom_level - out_width
+            )
+
+        total_width = (name_width + frames_space + LABEL_MARGIN * zoom_level)
+        if total_width > self_rect.width():
+            self.source_name_label.setVisible(False)
+        else:
+            self.source_name_label.setVisible(True)
+            self.source_name_label.setX(0.5 * (self_rect.width() - name_width))
+
+
+class GapItem(BaseItem):
+
+    def __init__(self, *args, **kwargs):
+        super(GapItem, self).__init__(*args, **kwargs)
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(100, 100, 100, 255))
+        )
+        self.source_name_label.setText('GAP')
+
+
+class EffectItem(QtWidgets.QGraphicsRectItem):
+
+    def __init__(self, item, rect, *args, **kwargs):
+        super(EffectItem, self).__init__(rect, *args, **kwargs)
+        self.item = item
+        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
+        self.init()
+        self._set_tooltip()
+
+    def init(self):
+        rect = self.rect()
+        rect.setY(TRACK_HEIGHT - EFFECT_HEIGHT)
+        rect.setHeight(EFFECT_HEIGHT)
+        self.setRect(rect)
+
+        dark = QtGui.QColor(0, 0, 0, 150)
+        colour = QtGui.QColor(255, 255, 255, 200)
+        gradient = QtGui.QLinearGradient(
+                   QtCore.QPointF(0,
+                                  self.boundingRect().top()),
+                   QtCore.QPointF(0,
+                                  self.boundingRect().bottom()))
+        gradient.setColorAt(0.2, QtCore.Qt.transparent)
+        gradient.setColorAt(0.45, colour)
+        gradient.setColorAt(0.7, QtCore.Qt.transparent)
+        gradient.setColorAt(1.0, dark)
+        self.setBrush(QtGui.QBrush(gradient))
+
+        pen = self.pen()
+        pen.setColor(QtGui.QColor(0, 0, 0, 80))
+        pen.setWidth(0)
+        self.setPen(pen)
+
+    def _set_tooltip(self):
+        tool_tips = list()
+        for effect in self.item:
+            name = effect.name if effect.name else ""
+            effect_name = effect.effect_name if effect.effect_name else ""
+            tool_tips.append("{} {}".format(name, effect_name))
+        self.setToolTip("\n".join(tool_tips))
+
+    def paint(self, *args, **kwargs):
+        new_args = [args[0],
+                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
+        super(EffectItem, self).paint(*new_args, **kwargs)
+
+    def itemChange(self, change, value):
+        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
+            pen = self.pen()
+            pen.setColor(
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                else QtGui.QColor(0, 0, 0, 80)
+            )
+            self.setPen(pen)
+            self.setZValue(
+                self.zValue() + 1 if self.isSelected() else self.zValue() - 1
+            )
+
+        return super(EffectItem, self).itemChange(change, value)
+
+
+class TransitionItem(BaseItem):
+
+    def __init__(self, item, timeline_range, rect, *args, **kwargs):
+        rect.setHeight(TRANSITION_HEIGHT)
+        super(TransitionItem, self).__init__(
+            item,
+            timeline_range,
+            rect,
+            *args,
+            **kwargs
+        )
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(237, 228, 148, 255))
+        )
+        self.setY(TRACK_HEIGHT - TRANSITION_HEIGHT)
+        self.setZValue(2)
+
+        # add extra bit of shading
+        shading_poly_f = QtGui.QPolygonF()
+        shading_poly_f.append(QtCore.QPointF(0, 0))
+        shading_poly_f.append(QtCore.QPointF(rect.width(), 0))
+        shading_poly_f.append(QtCore.QPointF(0, rect.height()))
+
+        shading_poly = QtWidgets.QGraphicsPolygonItem(
+            shading_poly_f, parent=self)
+        shading_poly.setBrush(QtGui.QBrush(QtGui.QColor(0, 0, 0, 30)))
+
+        try:
+            shading_poly.setPen(QtCore.Qt.NoPen)
+        except TypeError:
+            shading_poly.setPen(QtCore.Qt.transparent)
+
+    def _add_markers(self):
+        return
+
+    def _set_labels(self):
+        return
+
+
+class ClipItem(BaseItem):
+
+    def __init__(self, *args, **kwargs):
+        super(ClipItem, self).__init__(*args, **kwargs)
+        self.setBrush(QtGui.QBrush(QtGui.QColor(168, 197, 255, 255)))
+        self.source_name_label.setText(self.item.name)
+
+
+class NestedItem(BaseItem):
+
+    def __init__(self, *args, **kwargs):
+        super(NestedItem, self).__init__(*args, **kwargs)
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(255, 113, 91, 255))
+        )
+
+        self.source_name_label.setText(self.item.name)
+
+    def mouseDoubleClickEvent(self, event):
+        super(NestedItem, self).mouseDoubleClickEvent(event)
+        self.scene().views()[0].open_stack.emit(self.item)
+
+    def keyPressEvent(self, key_event):
+        super(NestedItem, self).keyPressEvent(key_event)
+        key = key_event.key()
+
+        if key == QtCore.Qt.Key_Return:
+            self.scene().views()[0].open_stack.emit(self.item)
+
+
+class Track(QtWidgets.QGraphicsRectItem):
+
+    def __init__(self, track, *args, **kwargs):
+        super(Track, self).__init__(*args, **kwargs)
+        self.track = track
+
+        self.setBrush(QtGui.QBrush(QtGui.QColor(43, 52, 59, 255)))
+        self._populate()
+
+    def _populate(self):
+        track_map = self.track.range_of_all_children()
+        for n, item in enumerate(self.track):
+            timeline_range = track_map[item]
+
+            rect = QtCore.QRectF(
+                0,
+                0,
+                otio.opentime.to_seconds(timeline_range.duration) *
+                TIME_MULTIPLIER,
+                TRACK_HEIGHT
+            )
+
+            if isinstance(item, otio.schema.Clip):
+                new_item = ClipItem(item, timeline_range, rect)
+            elif isinstance(item, otio.schema.Stack):
+                new_item = NestedItem(item, timeline_range, rect)
+            elif isinstance(item, otio.schema.Track):
+                new_item = NestedItem(item, timeline_range, rect)
+            elif isinstance(item, otio.schema.Gap):
+                new_item = GapItem(item, timeline_range, rect)
+            elif isinstance(item, otio.schema.Transition):
+                new_item = TransitionItem(item, timeline_range, rect)
+            else:
+                print("Warning: could not add item {} to UI.".format(item))
+                continue
+
+            new_item.setParentItem(self)
+            new_item.setX(
+                otio.opentime.to_seconds(timeline_range.start_time) *
+                TIME_MULTIPLIER
+            )
+            new_item.counteract_zoom()
+
+
+class Marker(QtWidgets.QGraphicsPolygonItem):
+
+    def __init__(self, marker, *args, **kwargs):
+        self.item = marker
+
+        poly = QtGui.QPolygonF()
+        poly.append(QtCore.QPointF(0.5 * MARKER_SIZE, -0.5 * MARKER_SIZE))
+        poly.append(QtCore.QPointF(0.5 * MARKER_SIZE, 0.5 * MARKER_SIZE))
+        poly.append(QtCore.QPointF(0, MARKER_SIZE))
+        poly.append(QtCore.QPointF(-0.5 * MARKER_SIZE, 0.5 * MARKER_SIZE))
+        poly.append(QtCore.QPointF(-0.5 * MARKER_SIZE, -0.5 * MARKER_SIZE))
+        super(Marker, self).__init__(poly, *args, **kwargs)
+
+        self.setFlags(QtWidgets.QGraphicsItem.ItemIsSelectable)
+        self.setBrush(
+            QtGui.QBrush(QtGui.QColor(121, 212, 177, 255))
+        )
+
+    def paint(self, *args, **kwargs):
+        new_args = [args[0],
+                    QtWidgets.QStyleOptionGraphicsItem()] + list(args[2:])
+        super(Marker, self).paint(*new_args, **kwargs)
+
+    def itemChange(self, change, value):
+        if change == QtWidgets.QGraphicsItem.ItemSelectedHasChanged:
+            self.setPen(
+                QtGui.QColor(0, 255, 0, 255) if self.isSelected()
+                else QtGui.QColor(0, 0, 0, 255)
+            )
+        return super(Marker, self).itemChange(change, value)
+
+    def counteract_zoom(self, zoom_level=1.0):
+        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
+
+
+class TimeSlider(QtWidgets.QGraphicsRectItem):
+
+    def __init__(self, *args, **kwargs):
+        super(TimeSlider, self).__init__(*args, **kwargs)
+        self.setBrush(QtGui.QBrush(QtGui.QColor(64, 78, 87, 255)))
+        pen = QtGui.QPen()
+        pen.setWidth(0)
+        self.setPen(pen)
+        self._ruler = None
+
+    def mousePressEvent(self, mouse_event):
+        pos = self.mapToScene(mouse_event.pos())
+        self._ruler.setPos(QtCore.QPointF(pos.x(),
+                                          TIME_SLIDER_HEIGHT -
+                                          MARKER_SIZE))
+        self._ruler.update_frame()
+
+        super(TimeSlider, self).mousePressEvent(mouse_event)
+
+    def add_ruler(self, ruler):
+        self._ruler = ruler


### PR DESCRIPTION
#### New Feature
- The **navigation** menu allows specifying which elements the arrow keys will snap on.
- **Highlight**. When an element is selected, its border becomes green. Now, the thickness of the border is thicker for better readability in mac. The thickness of the border is set by default to 5.
```python
HIGHLIGHT_WIDTH = 5
```

#### Changes
- Refactor how the navigation works. It does not rely on the pyside call *QtWidgets.QGraphicsScene.itemAt* any more but uses the otio methods to navigate from a otio item to another one.
- in *timeline_widget._BaseItem*, the pen is set to pen.setCosmetic(True) so the thickness of the border is not affected by the zoom.
- Ensure that a selected *timeline_widget._BaseItem* is always on the front.
- Minor changes in *timeline_widget.Ruler*. A lambda has been redefined as a function to follow pep8 indications. Also *mouseReleaseEvent* has been subclassed to unselect the ruler so that it does not mess up with the currentSelection.
- Ensure that the ruler is always on the front.


