### PR TITLE
Remove `console` and `test_utils` from the default import

### DIFF
--- a/opentimelineio/__init__.py
+++ b/opentimelineio/__init__.py
@@ -43,6 +43,4 @@ from . import (
     adapters,
     hooks,
     algorithms,
-    test_utils,
-    console,
 )

--- a/opentimelineio/adapters/cmx_3600.py
+++ b/opentimelineio/adapters/cmx_3600.py
@@ -38,10 +38,14 @@ import re
 import math
 import collections
 
-import opentimelineio as otio
+from .. import (
+    exceptions,
+    schema,
+    opentime,
+)
 
 
-class EDLParseError(otio.exceptions.OTIOError):
+class EDLParseError(exceptions.OTIOError):
     pass
 
 
@@ -88,7 +92,7 @@ VALID_EDL_STYLES = ['avid', 'nucoda']
 
 class EDLParser(object):
     def __init__(self, edl_string, rate=24, ignore_timecode_mismatch=False):
-        self.timeline = otio.schema.Timeline()
+        self.timeline = schema.Timeline()
 
         # Start with no tracks. They will be added as we encounter them.
         # This dict maps a track name (e.g "A2" or "V") to an OTIO Track.
@@ -133,11 +137,11 @@ class EDLParser(object):
         for track in tracks:
 
             edl_rate = clip_handler.edl_rate
-            record_in = otio.opentime.from_timecode(
+            record_in = opentime.from_timecode(
                 clip_handler.record_tc_in,
                 edl_rate
             )
-            record_out = otio.opentime.from_timecode(
+            record_out = opentime.from_timecode(
                 clip_handler.record_tc_out,
                 edl_rate
             )
@@ -149,13 +153,13 @@ class EDLParser(object):
                 freeze = comment_handler.handled.get('freeze_frame')
                 if motion is not None or freeze is not None:
                     # Adjust the clip to match the record duration
-                    clip.source_range = otio.opentime.TimeRange(
+                    clip.source_range = opentime.TimeRange(
                         start_time=clip.source_range.start_time,
                         duration=rec_duration
                     )
 
                     if freeze is not None:
-                        clip.effects.append(otio.schema.FreezeFrame())
+                        clip.effects.append(schema.FreezeFrame())
                         # XXX remove 'FF' suffix (writing edl will add it back)
                         if clip.name.endswith(' FF'):
                             clip.name = clip.name[:-3]
@@ -165,7 +169,7 @@ class EDLParser(object):
                         )
                         time_scalar = fps / rate
                         clip.effects.append(
-                            otio.schema.LinearTimeWarp(time_scalar=time_scalar)
+                            schema.LinearTimeWarp(time_scalar=time_scalar)
                         )
 
                 elif self.ignore_timecode_mismatch:
@@ -187,8 +191,8 @@ class EDLParser(object):
                         ))
 
             if track.source_range is None:
-                zero = otio.opentime.RationalTime(0, edl_rate)
-                track.source_range = otio.opentime.TimeRange(
+                zero = opentime.RationalTime(0, edl_rate)
+                track.source_range = opentime.TimeRange(
                     start_time=zero - record_in,
                     duration=zero
                 )
@@ -212,29 +216,29 @@ class EDLParser(object):
             # timecodes that are sparse (e.g. from a single track of a
             # multi-track composition).
             if record_in > track_end and len(track) > 0:
-                gap = otio.schema.Gap()
-                gap.source_range = otio.opentime.TimeRange(
-                    start_time=otio.opentime.RationalTime(0, edl_rate),
+                gap = schema.Gap()
+                gap.source_range = opentime.TimeRange(
+                    start_time=opentime.RationalTime(0, edl_rate),
                     duration=record_in - track_end
                 )
                 track.append(gap)
-                track.source_range = otio.opentime.TimeRange(
+                track.source_range = opentime.TimeRange(
                     start_time=track.source_range.start_time,
                     duration=track.source_range.duration + gap.duration()
                 )
 
             track.append(clip)
-            track.source_range = otio.opentime.TimeRange(
+            track.source_range = opentime.TimeRange(
                 start_time=track.source_range.start_time,
                 duration=track.source_range.duration + clip.duration()
             )
 
     def guess_kind_for_track_name(self, name):
         if name.startswith("V"):
-            return otio.schema.TrackKind.Video
+            return schema.TrackKind.Video
         if name.startswith("A"):
-            return otio.schema.TrackKind.Audio
-        return otio.schema.TrackKind.Video
+            return schema.TrackKind.Audio
+        return schema.TrackKind.Video
 
     def tracks_for_channel(self, channel_code):
         # Expand channel shorthand into a list of track names.
@@ -246,7 +250,7 @@ class EDLParser(object):
         # Create any channels we don't already have
         for track_name in track_names:
             if track_name not in self.tracks_by_name:
-                track = otio.schema.Track(
+                track = schema.Track(
                     name=track_name,
                     kind=self.guess_kind_for_track_name(track_name)
                 )
@@ -367,27 +371,27 @@ class ClipHandler(object):
         self.clip = self.make_clip(comment_data)
 
     def make_clip(self, comment_data):
-        clip = otio.schema.Clip()
+        clip = schema.Clip()
         clip.name = str(self.clip_num)
 
         # BLACK/BL and BARS are called out as "Special Source Identifiers" in
         # the documents referenced here:
         # https://github.com/PixarAnimationStudios/OpenTimelineIO#cmx3600-edl
         if self.reel in ['BL', 'BLACK']:
-            clip.media_reference = otio.schema.GeneratorReference()
+            clip.media_reference = schema.GeneratorReference()
             # TODO: Replace with enum, once one exists
             clip.media_reference.generator_kind = 'black'
         elif self.reel == 'BARS':
-            clip.media_reference = otio.schema.GeneratorReference()
+            clip.media_reference = schema.GeneratorReference()
             # TODO: Replace with enum, once one exists
             clip.media_reference.generator_kind = 'SMPTEBars'
         elif 'media_reference' in comment_data:
-            clip.media_reference = otio.schema.ExternalReference()
+            clip.media_reference = schema.ExternalReference()
             clip.media_reference.target_url = comment_data[
                 'media_reference'
             ]
         else:
-            clip.media_reference = otio.schema.MissingReference()
+            clip.media_reference = schema.MissingReference()
 
         # this could currently break without a 'FROM CLIP' comment.
         # Without that there is no 'media_reference' Do we have a default
@@ -456,13 +460,13 @@ class ClipHandler(object):
                 comment_data["locator"]
             )
             if m:
-                marker = otio.schema.Marker()
-                marker.marked_range = otio.opentime.TimeRange(
-                    start_time=otio.opentime.from_timecode(
+                marker = schema.Marker()
+                marker.marked_range = opentime.TimeRange(
+                    start_time=opentime.from_timecode(
                         m.group(1),
                         self.edl_rate
                     ),
-                    duration=otio.opentime.RationalTime()
+                    duration=opentime.RationalTime()
                 )
 
                 # always write the source value into metadata, in case it
@@ -477,12 +481,12 @@ class ClipHandler(object):
 
                 # @TODO: if it is a valid
                 if hasattr(
-                    otio.schema.MarkerColor,
+                    schema.MarkerColor,
                     color_parsed_from_file.upper()
                 ):
                     marker.color = color_parsed_from_file.upper()
                 else:
-                    marker.color = otio.schema.MarkerColor.RED
+                    marker.color = schema.MarkerColor.RED
 
                 marker.name = m.group(3)
                 clip.markers.append(marker)
@@ -490,9 +494,9 @@ class ClipHandler(object):
                 # TODO: Should we report this as a warning somehow?
                 pass
 
-        clip.source_range = otio.opentime.range_from_start_end_time(
-            otio.opentime.from_timecode(self.source_tc_in, self.edl_rate),
-            otio.opentime.from_timecode(self.source_tc_out, self.edl_rate)
+        clip.source_range = opentime.range_from_start_end_time(
+            opentime.from_timecode(self.source_tc_in, self.edl_rate),
+            opentime.from_timecode(self.source_tc_out, self.edl_rate)
         )
 
         return clip
@@ -549,8 +553,8 @@ class ClipHandler(object):
                 setattr(
                     self,
                     prop,
-                    otio.opentime.to_timecode(
-                        otio.opentime.from_frames(
+                    opentime.to_timecode(
+                        opentime.from_frames(
                             int(getattr(self, prop)),
                             self.edl_rate
                         ),
@@ -638,11 +642,11 @@ def _expand_transitions(timeline):
             # this arbitrarily puts it in the middle of the transition
             pre_cut = math.floor(transition_duration.value / 2)
             post_cut = transition_duration.value - pre_cut
-            mid_tran_cut_pre_duration = otio.opentime.RationalTime(
+            mid_tran_cut_pre_duration = opentime.RationalTime(
                 pre_cut,
                 transition_duration.rate
             )
-            mid_tran_cut_post_duration = otio.opentime.RationalTime(
+            mid_tran_cut_post_duration = opentime.RationalTime(
                 post_cut,
                 transition_duration.rate
             )
@@ -657,16 +661,16 @@ def _expand_transitions(timeline):
                     remove_list.append((track, prev))
 
             sr = expansion_clip.source_range
-            expansion_clip.source_range = otio.opentime.TimeRange(
+            expansion_clip.source_range = opentime.TimeRange(
                 start_time=sr.start_time,
                 duration=sr.duration + mid_tran_cut_pre_duration
             )
 
             # rebuild the clip as a transition
-            new_trx = otio.schema.Transition(
+            new_trx = schema.Transition(
                 name=clip.name,
                 # only supported type at the moment
-                transition_type=otio.schema.TransitionTypes.SMPTE_Dissolve,
+                transition_type=schema.TransitionTypes.SMPTE_Dissolve,
                 metadata=clip.metadata
             )
             new_trx.in_offset = mid_tran_cut_pre_duration
@@ -677,15 +681,15 @@ def _expand_transitions(timeline):
 
             # expand the next_clip
             if next_clip:
-                next_clip.source_range = otio.opentime.TimeRange(
+                next_clip.source_range = opentime.TimeRange(
                     next_clip.source_range.start_time - mid_tran_cut_post_duration,
                     next_clip.source_range.duration + mid_tran_cut_post_duration
                 )
             else:
-                fill = otio.schema.Gap(
-                    source_range=otio.opentime.TimeRange(
+                fill = schema.Gap(
+                    source_range=opentime.TimeRange(
                         duration=mid_tran_cut_post_duration,
-                        start_time=otio.opentime.RationalTime(
+                        start_time=opentime.RationalTime(
                             0,
                             transition_duration.rate
                         )
@@ -750,23 +754,23 @@ def write_to_string(input_otio, rate=None, style='avid', reelname_len=8):
     # also only works for a single video track at the moment
 
     video_tracks = [t for t in input_otio.tracks
-                    if t.kind == otio.schema.TrackKind.Video]
+                    if t.kind == schema.TrackKind.Video]
     audio_tracks = [t for t in input_otio.tracks
-                    if t.kind == otio.schema.TrackKind.Audio]
+                    if t.kind == schema.TrackKind.Audio]
 
     if len(video_tracks) != 1:
-        raise otio.exceptions.NotSupportedError(
+        raise exceptions.NotSupportedError(
             "Only a single video track is supported, got: {}".format(
                 len(video_tracks)
             )
         )
 
     if len(audio_tracks) > 2:
-        raise otio.exceptions.NotSupportedError(
+        raise exceptions.NotSupportedError(
             "No more than 2 audio tracks are supported."
         )
     # if audio_tracks:
-    #     raise otio.exceptions.NotSupportedError(
+    #     raise exceptions.NotSupportedError(
     #         "No audio tracks are currently supported."
     #     )
 
@@ -792,7 +796,7 @@ class EDLWriter(object):
         self._reelname_len = reelname_len
 
         if style not in VALID_EDL_STYLES:
-            raise otio.exceptions.NotSupportedError(
+            raise exceptions.NotSupportedError(
                 "The EDL style '{}' is not supported.".format(
                     style
                 )
@@ -802,11 +806,11 @@ class EDLWriter(object):
         track = self._tracks[idx]
 
         # Add a gap if the last child is a transition.
-        if isinstance(track[-1], otio.schema.Transition):
-            gap = otio.schema.Gap(
-                source_range=otio.opentime.TimeRange(
+        if isinstance(track[-1], schema.Transition):
+            gap = schema.Gap(
+                source_range=opentime.TimeRange(
                     start_time=track[-1].duration(),
-                    duration=otio.opentime.RationalTime(0.0, self._rate)
+                    duration=opentime.RationalTime(0.0, self._rate)
                 )
             )
             track.append(gap)
@@ -823,38 +827,38 @@ class EDLWriter(object):
 
         # Adjust cut points to match EDL event representation.
         for idx, child in enumerate(track):
-            if isinstance(child, otio.schema.Transition):
+            if isinstance(child, schema.Transition):
                 if idx != 0:
                     # Shorten the a-side
                     sr = track[idx - 1].source_range
-                    track[idx - 1].source_range = otio.opentime.TimeRange(
+                    track[idx - 1].source_range = opentime.TimeRange(
                         start_time=sr.start_time,
                         duration=sr.duration - child.in_offset
                     )
 
                 # Lengthen the b-side
                 sr = track[idx + 1].source_range
-                track[idx + 1].source_range = otio.opentime.TimeRange(
+                track[idx + 1].source_range = opentime.TimeRange(
                     start_time=sr.start_time - child.in_offset,
                     duration=sr.duration + child.in_offset
                 )
 
                 # Just clean up the transition for goodness sake
                 in_offset = child.in_offset
-                child.in_offset = otio.opentime.RationalTime(0.0, self._rate)
+                child.in_offset = opentime.RationalTime(0.0, self._rate)
                 child.out_offset += in_offset
 
         # Group events into either simple clip/a-side or transition and b-side
         # to match EDL edit/event representation and edit numbers.
         events = []
         for idx, child in enumerate(track):
-            if isinstance(child, otio.schema.Transition):
+            if isinstance(child, schema.Transition):
                 # Transition will be captured in subsequent iteration.
                 continue
 
             prv = track[idx - 1] if idx > 0 else None
 
-            if isinstance(prv, otio.schema.Transition):
+            if isinstance(prv, schema.Transition):
                 events.append(
                     DissolveEvent(
                         events[-1] if len(events) else None,
@@ -867,7 +871,7 @@ class EDLWriter(object):
                         self._reelname_len
                     )
                 )
-            elif isinstance(child, otio.schema.Clip):
+            elif isinstance(child, schema.Clip):
                 events.append(
                     Event(
                         child,
@@ -878,7 +882,7 @@ class EDLWriter(object):
                         self._reelname_len
                     )
                 )
-            elif isinstance(child, otio.schema.Gap):
+            elif isinstance(child, schema.Gap):
                 # Gaps are represented as missing record timecode, no event
                 # needed.
                 pass
@@ -896,7 +900,7 @@ class EDLWriter(object):
 def _supported_timing_effects(clip):
     return [
         fx for fx in clip.effects
-        if isinstance(fx, otio.schema.LinearTimeWarp)
+        if isinstance(fx, schema.LinearTimeWarp)
     ]
 
 
@@ -906,8 +910,8 @@ def _relevant_timing_effect(clip):
 
     if effects != clip.effects:
         for thing in clip.effects:
-            if thing not in effects and isinstance(thing, otio.schema.TimeEffect):
-                raise otio.exceptions.NotSupportedError(
+            if thing not in effects and isinstance(thing, schema.TimeEffect):
+                raise exceptions.NotSupportedError(
                     "Clip contains timing effects not supported by the EDL"
                     " adapter.\nClip: {}".format(str(clip)))
 
@@ -915,7 +919,7 @@ def _relevant_timing_effect(clip):
     if effects:
         timing_effect = effects[0]
     if len(effects) > 1:
-        raise otio.exceptions.NotSupportedError(
+        raise exceptions.NotSupportedError(
             "EDL Adapter only allows one timing effect / clip."
         )
 
@@ -941,14 +945,14 @@ class Event(object):
 
         if timing_effect:
             if timing_effect.effect_name == "FreezeFrame":
-                line.source_out = line.source_in + otio.opentime.RationalTime(
+                line.source_out = line.source_in + opentime.RationalTime(
                     1,
                     line.source_in.rate
                 )
             elif timing_effect.effect_name == "LinearTimeWarp":
                 value = clip.trimmed_range().duration.value / timing_effect.time_scalar
                 line.source_out = (
-                    line.source_in + otio.opentime.RationalTime(value, rate))
+                    line.source_in + opentime.RationalTime(value, rate))
 
         range_in_timeline = clip.transformed_time_range(
             clip.trimmed_range(),
@@ -1025,10 +1029,10 @@ class DissolveEvent(object):
             )
         else:
             cut_line.reel = 'BL'
-            cut_line.source_in = otio.opentime.RationalTime(0.0, rate)
-            cut_line.source_out = otio.opentime.RationalTime(0.0, rate)
-            cut_line.record_in = otio.opentime.RationalTime(0.0, rate)
-            cut_line.record_out = otio.opentime.RationalTime(0.0, rate)
+            cut_line.source_in = opentime.RationalTime(0.0, rate)
+            cut_line.source_out = opentime.RationalTime(0.0, rate)
+            cut_line.record_in = opentime.RationalTime(0.0, rate)
+            cut_line.record_out = opentime.RationalTime(0.0, rate)
 
         self.cut_line = cut_line
 
@@ -1113,27 +1117,27 @@ class DissolveEvent(object):
 class EventLine(object):
     def __init__(self, kind, rate, reel='AX'):
         self.reel = reel
-        self._kind = 'V' if kind == otio.schema.TrackKind.Video else 'A'
+        self._kind = 'V' if kind == schema.TrackKind.Video else 'A'
         self._rate = rate
 
-        self.source_in = otio.opentime.RationalTime(0.0, rate=rate)
-        self.source_out = otio.opentime.RationalTime(0.0, rate=rate)
-        self.record_in = otio.opentime.RationalTime(0.0, rate=rate)
-        self.record_out = otio.opentime.RationalTime(0.0, rate=rate)
+        self.source_in = opentime.RationalTime(0.0, rate=rate)
+        self.source_out = opentime.RationalTime(0.0, rate=rate)
+        self.record_in = opentime.RationalTime(0.0, rate=rate)
+        self.record_out = opentime.RationalTime(0.0, rate=rate)
 
-        self.dissolve_length = otio.opentime.RationalTime(0.0, rate)
+        self.dissolve_length = opentime.RationalTime(0.0, rate)
 
     def to_edl_format(self, edit_number):
         ser = {
             'edit': edit_number,
             'reel': self.reel,
             'kind': self._kind,
-            'src_in': otio.opentime.to_timecode(self.source_in, self._rate),
-            'src_out': otio.opentime.to_timecode(self.source_out, self._rate),
-            'rec_in': otio.opentime.to_timecode(self.record_in, self._rate),
-            'rec_out': otio.opentime.to_timecode(self.record_out, self._rate),
+            'src_in': opentime.to_timecode(self.source_in, self._rate),
+            'src_out': opentime.to_timecode(self.source_out, self._rate),
+            'rec_in': opentime.to_timecode(self.record_in, self._rate),
+            'rec_out': opentime.to_timecode(self.record_out, self._rate),
             'diss': int(
-                otio.opentime.to_frames(self.dissolve_length, self._rate)
+                opentime.to_frames(self.dissolve_length, self._rate)
             ),
         }
 
@@ -1158,7 +1162,7 @@ def _generate_comment_lines(
     lines = []
     url = None
 
-    if not clip or isinstance(clip, otio.schema.Gap):
+    if not clip or isinstance(clip, schema.Gap):
         return []
 
     suffix = ''
@@ -1174,18 +1178,18 @@ def _generate_comment_lines(
         url = clip.name
 
     if from_or_to not in ['FROM', 'TO']:
-        raise otio.exceptions.NotSupportedError(
+        raise exceptions.NotSupportedError(
             "The clip FROM or TO value '{}' is not supported.".format(
                 from_or_to
             )
         )
 
-    if timing_effect and isinstance(timing_effect, otio.schema.LinearTimeWarp):
+    if timing_effect and isinstance(timing_effect, schema.LinearTimeWarp):
         lines.append(
             'M2   {}\t\t{}\t\t\t{}'.format(
                 clip.name,
                 timing_effect.time_scalar * edl_rate,
-                otio.opentime.to_timecode(
+                opentime.to_timecode(
                     clip.trimmed_range().start_time,
                     edl_rate
                 )
@@ -1244,7 +1248,7 @@ def _generate_comment_lines(
 
     # Output any markers on this clip
     for marker in clip.markers:
-        timecode = otio.opentime.to_timecode(
+        timecode = opentime.to_timecode(
             marker.marked_range.start_time,
             edl_rate
         )
@@ -1270,7 +1274,7 @@ def _flip_windows_slashes(path):
 
 
 def _reel_from_clip(clip, reelname_len):
-    if isinstance(clip, otio.schema.Gap):
+    if isinstance(clip, schema.Gap):
         return 'BL'
 
     elif clip.metadata.get('cmx_3600', {}).get('reel'):
@@ -1278,7 +1282,7 @@ def _reel_from_clip(clip, reelname_len):
 
     _reel = clip.name or 'AX'
 
-    if isinstance(clip.media_reference, otio.schema.ExternalReference):
+    if isinstance(clip.media_reference, schema.ExternalReference):
         _reel = clip.media_reference.name or os.path.basename(
             clip.media_reference.target_url
         )

--- a/opentimelineio/algorithms/filter.py
+++ b/opentimelineio/algorithms/filter.py
@@ -26,7 +26,10 @@
 """Algorithms for filtering OTIO files.  """
 
 import copy
-import opentimelineio as otio
+
+from .. import (
+    schema
+)
 
 
 def _is_in(thing, container):
@@ -103,7 +106,7 @@ def filtered_composition(
 
     header_list = [mutable_object]
 
-    if isinstance(mutable_object, otio.schema.Timeline):
+    if isinstance(mutable_object, schema.Timeline):
         header_list.append(mutable_object.tracks)
 
     iter_list = header_list + list(mutable_object.each_child())
@@ -223,7 +226,7 @@ def filtered_with_sequence_context(
 
     header_list = [mutable_object]
 
-    if isinstance(mutable_object, otio.schema.Timeline):
+    if isinstance(mutable_object, schema.Timeline):
         header_list.append(mutable_object.tracks)
 
     iter_list = header_list + list(mutable_object.each_child())
@@ -231,7 +234,7 @@ def filtered_with_sequence_context(
     # expand to include prev, next when appropriate
     expanded_iter_list = []
     for child in iter_list:
-        if _safe_parent(child) and isinstance(child.parent(), otio.schema.Track):
+        if _safe_parent(child) and isinstance(child.parent(), schema.Track):
             prev_item, next_item = child.parent().neighbors_of(child)
             expanded_iter_list.append((prev_item, child, next_item))
         else:

--- a/opentimelineio/console/console_utils.py
+++ b/opentimelineio/console/console_utils.py
@@ -24,7 +24,9 @@
 
 import ast
 
-import opentimelineio as otio
+from .. import (
+    media_linker,
+)
 
 """Utilities for OpenTimelineIO commandline modules."""
 
@@ -61,9 +63,9 @@ def media_linker_name(ml_name_arg):
     media linker to use.
     """
     if ml_name_arg.lower() == 'default':
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.ForceDefaultLinker
+        media_linker_name = media_linker.MediaLinkingPolicy.ForceDefaultLinker
     elif ml_name_arg.lower() in ['none', '']:
-        media_linker_name = otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia
+        media_linker_name = media_linker.MediaLinkingPolicy.DoNotLinkMedia
     else:
         media_linker_name = ml_name_arg
 

--- a/opentimelineio/test_utils.py
+++ b/opentimelineio/test_utils.py
@@ -27,7 +27,9 @@
 
 import re
 
-import opentimelineio as otio
+from . import (
+    adapters
+)
 
 
 class OTIOAssertions(object):
@@ -35,8 +37,8 @@ class OTIOAssertions(object):
         """Convert to json and compare that (more readable)."""
         self.maxDiff = None
 
-        known_str = otio.adapters.write_to_string(known, 'otio_json')
-        test_str = otio.adapters.write_to_string(test_result, 'otio_json')
+        known_str = adapters.write_to_string(known, 'otio_json')
+        test_str = adapters.write_to_string(test_result, 'otio_json')
 
         def strip_trailing_decimal_zero(s):
             return re.sub(r'"(value|rate)": (\d+)\.0', r'"\1": \2', s)

--- a/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
+++ b/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
@@ -66,7 +66,7 @@ sourceGroup000000_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_501.LAY3.01']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_501.LAY3.01']}}"
     }
 }
 
@@ -98,7 +98,7 @@ sourceGroup000001_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_502A.LAY3.02']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_502A.LAY3.02']}}"
     }
 }
 
@@ -130,7 +130,7 @@ sourceGroup000002_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_503A.LAY1.01']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_503A.LAY1.01']}}"
     }
 }
 
@@ -162,7 +162,7 @@ sourceGroup000003_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_504C.LAY1.02']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_504C.LAY1.02']}}"
     }
 }
 
@@ -194,7 +194,7 @@ sourceGroup000004_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_504B.LAY1.02']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_504B.LAY1.02']}}"
     }
 }
 
@@ -226,7 +226,7 @@ sourceGroup000005_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_507C.LAY2.01']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_507C.LAY2.01']}}"
     }
 }
 
@@ -258,7 +258,7 @@ sourceGroup000006_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_508.LAY2.02']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_50', u'comments': [u'SOURCE FILE: ZZ100_508.LAY2.02']}}"
     }
 }
 
@@ -290,7 +290,7 @@ sourceGroup000007_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'SOURCE FILE: ZZ100_510.LAY1.02']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_51', u'comments': [u'SOURCE FILE: ZZ100_510.LAY1.02']}}"
     }
 }
 
@@ -322,6 +322,6 @@ sourceGroup000008_source : RVFileSource (1)
 
     attributes
     {
-        string otio_metadata = "{u'cmx_3600': {u'comments': [u'AVX2 EFFECT, RESIZE', u'SOURCE FILE: ZZ100_510B.LAY1.02']}}"
+        string otio_metadata = "{u'cmx_3600': {u'reel': u'ZZ100_51', u'comments': [u'AVX2 EFFECT, RESIZE', u'SOURCE FILE: ZZ100_510B.LAY1.02']}}"
     }
 }

--- a/opentimelineio_contrib/adapters/tests/test_fcpx_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_fcpx_adapter.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_XML = os.path.join(
     os.path.dirname(__file__),
@@ -9,7 +10,7 @@ SAMPLE_XML = os.path.join(
 )
 
 
-class AdaptersFcpXXmlTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class AdaptersFcpXXmlTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     """
     The test class for the FCP X XML adapter
     """

--- a/opentimelineio_contrib/adapters/tests/test_xges_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_xges_adapter.py
@@ -27,12 +27,13 @@ import tempfile
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 XGES_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "xges_example.xges")
 
 
-class AdaptersXGESTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class AdaptersXGESTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_read(self):
         timeline = otio.adapters.read_from_file(XGES_EXAMPLE_PATH)[0]

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -29,6 +29,7 @@ import tempfile
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 from opentimelineio.adapters import (
     otio_json,
@@ -38,7 +39,7 @@ SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
 
 
-class BuiltInAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_disk_io(self):
         edl_path = SCREENING_EXAMPLE_PATH

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -26,8 +26,9 @@ import unittest
 
 import opentimelineio as otio
 
+import opentimelineio.test_utils as otio_test_utils
 
-class ClipTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_cons(self):
         name = "test"

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -32,6 +32,7 @@ import unittest
 
 import opentimelineio as otio
 from opentimelineio.adapters import cmx_3600
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
@@ -49,7 +50,7 @@ SPEED_EFFECTS_TEST_SMALL = os.path.join(
 )
 
 
-class EDLAdapterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class EDLAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     maxDiff = None
 
     def test_edl_read(self):

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -27,9 +27,10 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 
-class ComposableTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class ComposableTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_constructor(self):
         seqi = otio.core.Composable(
             name="test",

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -28,12 +28,13 @@ import os
 import copy
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 TRANSITION_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "transition_test.otio")
 
 
-class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class CompositionTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_cons(self):
         it = otio.core.Item()
@@ -265,7 +266,7 @@ class CompositionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertIn(cl2, st)
 
 
-class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_cons(self):
         st = otio.schema.Stack(name="test")
@@ -652,7 +653,7 @@ class StackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
 
-class TrackTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class TrackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_serialize(self):
         sq = otio.schema.Track(name="foo", children=[])
@@ -1831,7 +1832,7 @@ class NestingTest(unittest.TestCase):
             )
 
 
-class MembershipTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class MembershipTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_remove_actually_removes(self):
         """Test that removed item is no longer 'in' composition."""

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -37,12 +37,14 @@ except ImportError:
     import io
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+import opentimelineio.console
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
 
 
-class ConsoleTester(otio.test_utils.OTIOAssertions):
+class ConsoleTester(otio_test_utils.OTIOAssertions):
     def setUp(self):
         self.saved_args = sys.argv
         self.old_stdout = sys.stdout
@@ -59,19 +61,19 @@ class ConsoleTester(otio.test_utils.OTIOAssertions):
 class OTIOStatTest(ConsoleTester, unittest.TestCase):
     def test_basic(self):
         sys.argv = ['otiostat', SCREENING_EXAMPLE_PATH]
-        otio.console.otiostat.main()
+        opentimelineio.console.otiostat.main()
         self.assertIn("top level object: Timeline.1", sys.stdout.getvalue())
 
 
 class OTIOCatTests(ConsoleTester, unittest.TestCase):
     def test_basic(self):
         sys.argv = ['otiocat', SCREENING_EXAMPLE_PATH, "-a", "rate=24.0"]
-        otio.console.otiocat.main()
+        opentimelineio.console.otiocat.main()
         self.assertIn('"name": "Example_Screening.01",', sys.stdout.getvalue())
 
     def test_no_media_linker(self):
         sys.argv = ['otiocat', SCREENING_EXAMPLE_PATH, "-m", "none"]
-        otio.console.otiocat.main()
+        opentimelineio.console.otiocat.main()
         self.assertIn('"name": "Example_Screening.01",', sys.stdout.getvalue())
 
     def test_input_argument_error(self):
@@ -82,7 +84,7 @@ class OTIOCatTests(ConsoleTester, unittest.TestCase):
         ]
 
         with self.assertRaises(SystemExit):
-            otio.console.otiocat.main()
+            opentimelineio.console.otiocat.main()
 
         # read results back in
         self.assertIn('error: adapter', sys.stderr.getvalue())
@@ -95,7 +97,7 @@ class OTIOCatTests(ConsoleTester, unittest.TestCase):
         ]
 
         with self.assertRaises(SystemExit):
-            otio.console.otiocat.main()
+            opentimelineio.console.otiocat.main()
 
         # read results back in
         self.assertIn('error: media linker', sys.stderr.getvalue())
@@ -112,7 +114,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 '--tracks', '0',
                 "-a", "rate=24",
             ]
-            otio.console.otioconvert.main()
+            opentimelineio.console.otioconvert.main()
 
             # read results back in
             with open(tf.name, 'r') as fi:
@@ -129,7 +131,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 "--begin", "foobar"
             ]
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             # end requires begin
             sys.argv = [
@@ -140,7 +142,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 "--end", "foobar"
             ]
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             # prune everything
             sys.argv = [
@@ -151,7 +153,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 "--begin", "0,24",
                 "--end", "0,24",
             ]
-            otio.console.otioconvert.main()
+            opentimelineio.console.otioconvert.main()
 
             # check that begin/end "," parsing is checked
             sys.argv = [
@@ -163,7 +165,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 "--end", "0,24",
             ]
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             sys.argv = [
                 'otioconvert',
@@ -174,7 +176,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
                 "--end", "0",
             ]
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             result = otio.adapters.read_from_file(tf.name, "otio_json")
             self.assertEquals(len(result.tracks[0]), 0)
@@ -190,7 +192,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             ]
 
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             # read results back in
             self.assertIn('error: input adapter', sys.stderr.getvalue())
@@ -206,7 +208,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             ]
 
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             # read results back in
             self.assertIn('error: output adapter', sys.stderr.getvalue())
@@ -224,7 +226,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             ]
 
             with self.assertRaises(SystemExit):
-                otio.console.otioconvert.main()
+                opentimelineio.console.otioconvert.main()
 
             # read results back in
             self.assertIn('error: media linker', sys.stderr.getvalue())

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -25,9 +25,10 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 
-class EffectTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class EffectTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_cons(self):
         ef = otio.schema.Effect(

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -33,6 +33,7 @@ from xml.etree import cElementTree
 
 import opentimelineio as otio
 from opentimelineio.exceptions import CannotComputeAvailableRangeError
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 FCP7_XML_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")
@@ -40,7 +41,7 @@ SIMPLE_XML_PATH = os.path.join(SAMPLE_DATA_DIR, "sample_just_track.xml")
 HIERO_XML_PATH = os.path.join(SAMPLE_DATA_DIR, "hiero_xml_export.xml")
 
 
-class AdaptersFcp7XmlTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class AdaptersFcp7XmlTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def __init__(self, *args, **kwargs):
         super(AdaptersFcp7XmlTest, self).__init__(*args, **kwargs)

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -29,9 +29,10 @@ import unittest
 import copy
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 
-class FilterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class FilterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     maxDiff = None
 
     def test_copy_track(self):
@@ -164,7 +165,7 @@ class FilterTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
         self.assertJsonEqual(tr, result)
 
 
-class ReduceTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class ReduceTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     maxDiff = None
 
     def test_copy_track(self):

--- a/tests/test_generator_reference.py
+++ b/tests/test_generator_reference.py
@@ -4,12 +4,13 @@ import unittest
 import os
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 GEN_REF_TEST = os.path.join(SAMPLE_DATA_DIR, "generator_reference_test.otio")
 
 
-class GeneratorRefTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def setUp(self):
         self.gen = otio.schema.GeneratorReference(
             name="SMPTEBars",

--- a/tests/test_hooks_plugins.py
+++ b/tests/test_hooks_plugins.py
@@ -27,6 +27,9 @@ import os
 # import sys
 
 import opentimelineio as otio
+
+import opentimelineio.test_utils as otio_test_utils
+
 from tests import (
     baseline_reader,
     utils,
@@ -38,7 +41,7 @@ POST_RUN_NAME = "hook ran and did stuff"
 TEST_METADATA = {'extra_data': True}
 
 
-class HookScriptTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class HookScriptTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     """Tests for the hook function plugins."""
     def setUp(self):
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -28,12 +28,13 @@ import unittest
 
 import opentimelineio as otio
 
+import opentimelineio.test_utils as otio_test_utils
 
 # add Item to the type registry for the purposes of unit testing
 otio.core.register_type(otio.core.Item)
 
 
-class GapTester(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class GapTester(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_str_gap(self):
         gp = otio.schema.Gap()
@@ -98,7 +99,7 @@ class GapTester(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
 
-class ItemTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class ItemTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_constructor(self):
         tr = otio.opentime.TimeRange(

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -28,12 +28,13 @@ import unittest
 import json
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 # local to test dir
 from tests import baseline_reader
 
 
-class TestJsonFormat(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class TestJsonFormat(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def setUp(self):
         self.maxDiff = None

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -26,8 +26,9 @@ import unittest
 
 import opentimelineio as otio
 
+import opentimelineio.test_utils as otio_test_utils
 
-class MarkerTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class MarkerTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_cons(self):
         tr = otio.opentime.TimeRange(

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -28,8 +28,9 @@ import opentimelineio as otio
 
 import unittest
 
+import opentimelineio.test_utils as otio_test_utils
 
-class MediaReferenceTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class MediaReferenceTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_cons(self):
         tr = otio.opentime.TimeRange(

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -25,9 +25,9 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
-
-class SerializableColTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class SerializableColTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def setUp(self):
         self.children = [
             otio.schema.Clip(name="testClip"),

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -24,6 +24,7 @@
 #
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 import unittest
 
@@ -48,7 +49,7 @@ class OpenTimeTypeSerializerTest(unittest.TestCase):
         self.assertEqual(tt, decoded)
 
 
-class SerializableObjTest(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_cons(self):
         so = otio.core.SerializableObject()
         so._data['foo'] = 'bar'

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -29,13 +29,14 @@ import unittest
 import os
 import opentimelineio as otio
 
+import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 MULTITRACK_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "multitrack.otio")
 PREFLATTENED_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "preflattened.otio")
 
 
-class StackAlgoTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class StackAlgoTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     """ test harness for stack algo functions """
 
     def setUp(self):

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -25,9 +25,10 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 
-class TimelineTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
     def test_init(self):
         rt = otio.opentime.RationalTime(12, 24)

--- a/tests/test_timeline_algo.py
+++ b/tests/test_timeline_algo.py
@@ -28,9 +28,10 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 
-class TimelineTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class TimelineTrimmingTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     """ test harness for timeline trimming function """
 
     def make_sample_timeline(self):

--- a/tests/test_track_algo.py
+++ b/tests/test_track_algo.py
@@ -30,6 +30,8 @@ import copy
 
 import opentimelineio as otio
 
+import opentimelineio.test_utils as otio_test_utils
+
 # for debugging
 # def print_expanded_tree(seq):
 #     for thing in seq:
@@ -238,7 +240,7 @@ class TransitionExpansionTests(unittest.TestCase):
         )
 
 
-class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class TrackTrimmingTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     """ test harness for track trimming function """
 
     def make_sample_track(self):

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -27,9 +27,10 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 
-class TransitionTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class TransitionTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_constructor(self):
         trx = otio.schema.Transition(
             name="AtoB",

--- a/tests/test_unknown_schema.py
+++ b/tests/test_unknown_schema.py
@@ -25,6 +25,7 @@
 import unittest
 
 import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
 
 has_undefined_schema = """
 {
@@ -65,7 +66,7 @@ has_undefined_schema = """
 """
 
 
-class UnknownSchemaTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
+class UnknownSchemaTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def setUp(self):
         # make an OTIO data structure containing an undefined schema object
         self.orig = otio.adapters.otio_json.read_from_string(has_undefined_schema)


### PR DESCRIPTION
- These imports were coming in by default, which was causing problems in certain situations
- Specifically, console was importing `otioconvert` which does a cute trick of fetching all the adapter names to put into its docstring
- Fetching the adapter names causes the adapter modules to be loaded, but *before* OTIO is done being initially loaded
- This mostly works fine, except in cases where the `opentimelineio` module is being relocated in `sys.modules` after being imported.
- Regardless, the *intent* of the adapter system was to defer loading the plugin modules until needed, so this fix is more in line with that goal.

Addresses #471 