### PR TITLE
Add global_start_time as a serializable_field.

### DIFF
--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -68,6 +68,11 @@ class Timeline(core.SerializableObject):
         dict,
         "Metadata dictionary."
     )
+    global_start_time = core.serializable_field(
+        "global_start_time",
+        opentime.RationalTime,
+        doc="Global starting time value and rate of the timeline."
+    )
 
     def __str__(self):
         return 'Timeline("{}", {})'.format(str(self.name), str(self.tracks))

--- a/opentimelineio/schema/timeline.py
+++ b/opentimelineio/schema/timeline.py
@@ -47,8 +47,6 @@ class Timeline(core.SerializableObject):
     ):
         super(Timeline, self).__init__()
         self.name = name
-        if global_start_time is None:
-            global_start_time = opentime.RationalTime(0, 24)
         self.global_start_time = copy.deepcopy(global_start_time)
 
         if tracks is None:

--- a/tests/baseline_reader.py
+++ b/tests/baseline_reader.py
@@ -32,13 +32,20 @@ MODPATH = os.path.dirname(__file__)
 
 def test_hook(dct):
     if "FROM_TEST_FILE" in dct:
-        return json_from_file_as_string(
+        # fetch the baseline
+        result = json_from_file_as_string(
             os.path.join(
                 MODPATH,
                 "baselines",
                 str(dct["FROM_TEST_FILE"])
             )
         )
+
+        # allow you to overlay values onto the baseline in the test, if they
+        # store non-default for the baseline values.
+        del dct["FROM_TEST_FILE"]
+        result.update(dct)
+        return result
 
     return dct
 

--- a/tests/baselines/empty_timeline.json
+++ b/tests/baselines/empty_timeline.json
@@ -1,5 +1,9 @@
 {
     "OTIO_SCHEMA" : "Timeline.1",
+    "global_start_time" : {
+        "FROM_TEST_FILE" : "empty_rationaltime.json",
+        "rate" : 24
+    },
     "metadata" : {
         "comments"   : "adding some stuff to metadata to try out",
         "a number"   : 1.0

--- a/tests/baselines/empty_timeline.json
+++ b/tests/baselines/empty_timeline.json
@@ -1,9 +1,6 @@
 {
     "OTIO_SCHEMA" : "Timeline.1",
-    "global_start_time" : {
-        "FROM_TEST_FILE" : "empty_rationaltime.json",
-        "rate" : 24
-    },
+    "global_start_time" : null,
     "metadata" : {
         "comments"   : "adding some stuff to metadata to try out",
         "a number"   : 1.0


### PR DESCRIPTION
- Also add the ability to layer over baselines in tests
- global_start_time has a default value with a rate of 24