### PR TITLE
Suggested fix for #476

### DIFF
--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -623,7 +623,7 @@ def from_timecode(timecode_str, rate):
                 timecode_str, nominal_fps - 1))
 
     dropframes = 0
-    if rate_is_dropframe and treat_as_df:
+    if treat_as_df:
         if rate == 29.97:
             dropframes = 2
 

--- a/opentimelineio/opentime.py
+++ b/opentimelineio/opentime.py
@@ -595,6 +595,9 @@ def from_timecode(timecode_str, rate):
     # Check if rate is drop frame
     rate_is_dropframe = rate in VALID_DROPFRAME_TIMECODE_RATES
 
+    # Make sure only DF timecodes are treated as such
+    treat_as_df = rate_is_dropframe and ';' in timecode_str
+
     # Check if timecode indicates drop frame
     if ';' in timecode_str:
         if not rate_is_dropframe:
@@ -620,7 +623,7 @@ def from_timecode(timecode_str, rate):
                 timecode_str, nominal_fps - 1))
 
     dropframes = 0
-    if rate_is_dropframe:
+    if rate_is_dropframe and treat_as_df:
         if rate == 29.97:
             dropframes = 2
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -565,6 +565,28 @@ class TestTime(unittest.TestCase):
         with self.assertRaises(AttributeError):
             t1.value = 12
 
+    def test_passing_ndf_tc_at_df_rate(self):
+        DF_TC = "01:00:02;05"
+        NDF_TC = "00:59:58:17"
+        frames = 107957
+
+        tc1 = otio.opentime.to_timecode(
+            otio.opentime.RationalTime(frames, 29.97)
+        )
+        self.assertEqual(tc1, DF_TC)
+
+        tc2 = otio.opentime.to_timecode(
+            otio.opentime.RationalTime(frames, 29.97),
+            30
+        )
+        self.assertEqual(tc2, NDF_TC)
+
+        t1 = otio.opentime.from_timecode(DF_TC, 29.97)
+        self.assertEqual(t1.value, frames)
+
+        t2 = otio.opentime.from_timecode(NDF_TC, 29.97)
+        self.assertEqual(t2.value, frames)
+
 
 class TestTimeTransform(unittest.TestCase):
 


### PR DESCRIPTION
Hey!
This PR should produce the result @reinecke is after in #476 

When passing an NDF timecode with a DF frame Rate to `opentime.from_timecode` calculation respects the NDF TC and does not remove frames.