### PR TITLE
Refactor FCP XML adapter - add generator and effect support

### DIFF
--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -973,6 +973,7 @@ class FCP7XMLParser:
             "file",
             "marker",
             "effect",
+            "rate",
             "sequence",
         }
         metadata_dict = _xml_tree_to_dict(
@@ -1571,7 +1572,6 @@ def _build_clip_item_without_media(
         )
 
     _append_new_sub_element(clip_item_e, 'name', text=clip_item.name)
-    clip_item_e.append(_build_rate(media_start_time.rate))
     clip_item_e.append(
         _build_empty_file(
             clip_item.media_reference, timeline_range, br_map

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -1838,6 +1838,11 @@ def _build_sequence_for_timeline(timeline, timeline_range, br_map):
         timeline.tracks, sequence_e, timeline_range, br_map
     )
 
+    # In the case of timelines, use the timeline name rather than the stack
+    # name.
+    if timeline.name:
+        sequence_e.find('./name').text = timeline.name
+
     # Add the sequence global start
     if timeline.global_start_time is not None:
         seq_tc_metadata = timeline.metadata.get(META_NAMESPACE, {}).get(

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -455,8 +455,9 @@ def _dict_to_xml_tree(data_dict, tag):
                 element.text = str(python_value)
             return [element]
 
-    # Determine the appropriate keys to ignore for this tag type
-    default_ignore_keys = {"timecode", "rate"}
+    # Drop timecode, rate, and link elements from roundtripping because they
+    # may become stale with timeline updates.
+    default_ignore_keys = {"timecode", "rate", "link"}
     specific_ignore_keys = {"samplecharacteristics": {"timecode"}}
     ignore_keys = specific_ignore_keys.get(tag, default_ignore_keys)
 

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -62,12 +62,6 @@ META_NAMESPACE = 'fcp_xml'
 ID_RE = re.compile(r"^(?P<tag>[a-zA-Z]*)-(?P<id>\d*)$")
 
 
-"""
-Adapter TODOs:
-    - Support start timecode on sequences
-    - Support top-level objects other than sequences: project, bin, clip
-"""
-
 # ---------
 # utilities
 # ---------
@@ -1488,7 +1482,8 @@ def _build_file(media_reference, br_map):
         if has_video and file_media_e.find("video") is None:
             _append_new_sub_element(file_media_e, "video")
 
-        # All files have audio?
+        # TODO: This is assuming all files have an audio track. Not sure what
+        # the implications of that are.
         if file_media_e.find("audio") is None:
             _append_new_sub_element(file_media_e, "audio")
 

--- a/opentimelineio/adapters/fcp_xml.py
+++ b/opentimelineio/adapters/fcp_xml.py
@@ -24,45 +24,946 @@
 
 """OpenTimelineIO Final Cut Pro 7 XML Adapter."""
 
-import os
-import math
-import functools
 import collections
+import functools
+import itertools
+import math
+import os
 from xml.etree import cElementTree
 from xml.dom import minidom
 
-# deal with renaming of default library from python 2 / 3
+# urlparse's name changes in Python 3
 try:
+    # Python 2.7
     import urlparse as urllib_parse
 except ImportError:
+    # Python 3
     import urllib.parse as urllib_parse
+
+# Same with the ABC classes from collections
+try:
+    # Python 3
+    from collections.abc import Mapping
+except ImportError:
+    # Python 2.7
+    from collections import Mapping
 
 import opentimelineio as otio
 
 META_NAMESPACE = 'fcp_xml'  # namespace to use for metadata
 
 
+"""
+Adapter TODOs:
+    - Support start timecode on sequences
+    - Support top-level objects other than sequences: project, bin, clip
+"""
+
 # ---------
 # utilities
 # ---------
+
+
+class _Context(Mapping):
+    """
+    An inherited value context.
+
+    In FCP XML there is a concept of inheritance down the element heirarchy.
+    For instance, a ``clip`` element may not specify the ``rate`` locally, but
+    instead inherit it from the parent ``track`` element.
+
+    This object models that as a stack of elements. When a value needs to be
+    queried from the context, it will be gathered by walking from the top of
+    the stack until the value is found.
+
+    For example, to find the ``rate`` element as an immediate child most
+    appropriate to the current context, you would do something like::
+        ``my_current_context["./rate"]``
+
+    This object can be thought of as immutable. You get a new context when you
+    push an element. This prevents inadvertant tampering with parent contexts
+    that may be used at levels above.
+
+    This DOES NOT support ``id`` attribute dereferencing, please make sure to
+    do that prior to using this structure.
+
+    .. seealso:: https://developer.apple.com/library/archive/documentation\
+            /AppleApplications/Reference/FinalCutPro_XML/Basics/Basics.html#\
+            //apple_ref/doc/uid/TP30001154-TPXREF102
+    """
+
+    def __init__(self, element=None, parent_elements=None):
+        if parent_elements is not None:
+            self.elements = parent_elements[:]
+        else:
+            self.elements = []
+
+        if element is not None:
+            self.elements.append(element)
+
+    def _all_keys(self):
+        """
+        Returns a set of all the keys available in the context stack.
+        """
+        return set(
+            itertools.chain.fromiterable(e.keys() for e in self.elements)
+        )
+
+    def __getitem__(self, key):
+        # Walk down the contexts until the item is found
+        for element in reversed(self.elements):
+            found_element = element.find(key)
+            if found_element is not None:
+                return found_element
+
+        raise KeyError(key)
+
+    def __iter__(self):
+        # This is unlikely to be used, so we'll do it the expensive way
+        return iter(self._all_keys)
+
+    def __len__(self):
+        # This is unlikely to be used, so we'll do it the expensive way
+        return len(self._all_keys)
+
+    def context_pushing_element(self, element):
+        """
+        Pushes an element to the top of the stack.
+
+        :param element: Element to push to the stack.
+        :return: The new context with the provided element pushed to the top
+            of the stack.
+        :raises: :class:`ValueError` if the element is already in the stack.
+        """
+        for context_element in self.elements:
+            if context_element == element:
+                raise ValueError(
+                    "element {} already in context".format(element)
+                )
+
+        return _Context(element, self.elements)
+
 
 def _url_to_path(url):
     parsed = urllib_parse.urlparse(url)
     return parsed.path
 
 
-def _populate_element_map(elem, element_map):
-    if 'id' in elem.attrib and list(elem):
-        element_map[elem.tag].setdefault(elem.attrib['id'], elem)
-    for sub_elem in elem:
-        _populate_element_map(sub_elem, element_map)
+def _bool_value(element):
+    """
+    Given an xml element, returns the tag text converted to a bool.
+
+    :param element: The element to fetch the value from.
+
+    :return: A boolean.
+    """
+    return (element.text.lower() == "true")
 
 
-def _resolved_backreference(elem, tag, element_map):
-    if 'id' in elem.attrib:
-        elem = element_map[tag].setdefault(elem.attrib['id'], elem)
+def _element_identification_string(element):
+    """
+    Gets a string that will hopefully help in identifing an element when there
+    is an error.
+    """
+    info_string = "tag: {}".format(element.tag)
+    try:
+        elem_id = element.attrib["id"]
+        info_string += " id: {}".format(elem_id)
+    except KeyError:
+        pass
 
-    return elem
+    return info_string
+
+
+def _name_from_element(element):
+    """
+    Fetches the name from the ``name`` element child of the provided element.
+    If no element exists, returns ``None``.
+
+    :param element: The element to find the name for.
+
+    :return: The name string or ``None``
+    """
+    name_elem = element.find("./name")
+    if name_elem is not None:
+        return name_elem.text
+
+    return None
+
+
+def _rate_for_element(element):
+    """
+    Takes an FCP rate element and returns a rate to use with otio.
+
+    :param element: An FCP rate element.
+
+    :return: The float rate.
+    """
+    # rate is encoded as a timebase (int) which can be drop-frame
+    base = float(element.find("./timebase").text)
+    if _bool_value(element.find("./ntsc")):
+        base *= 1000.0 / 1001
+
+    return base
+
+
+def _rate_from_context(context):
+    """
+    Given the context object, gets the appropriate rate.
+
+    :param context: The :class:`_Context` instance to find the rate in.
+
+    :return: The rate value or ``None`` if no rate is available in the context.
+    """
+    try:
+        rate_element = context["./rate"]
+    except KeyError:
+        return None
+
+    return _rate_for_element(rate_element)
+
+
+def _time_from_timecode_element(tc_element, context=None):
+    """
+    Given a timecode xml element, returns the time that represents.
+
+    .. todo:: Non Drop-Frame timecode is not yet supported by OTIO.
+
+    :param tc_element: The ``timecode`` element.
+    :param context: The context dict under which this timecode is being gotten.
+
+    :return: The :class:`otio.opentime.RationalTime` representation of the
+        timecode.
+    """
+    if context is not None:
+        local_context = context.context_pushing_element(tc_element)
+    else:
+        local_context = _Context(tc_element)
+
+    # Resolve the rate
+    rate = _rate_from_context(local_context)
+
+    # Try using the display format and frame number
+    display_format = tc_element.find("./displayformat")
+    frame = tc_element.find("./frame")
+
+    # Use frame number, if available
+    if frame is not None:
+        frame_num = int(frame.text)
+        return otio.opentime.RationalTime(frame_num, rate)
+
+    # If a TC string is provided, parse rate from it
+    tc_string_element = tc_element.find("./string")
+    if tc_string_element is None:
+        raise ValueError("Timecode element missing required elements")
+
+    tc_string = tc_string_element.text
+
+    # Determine if it's drop, non-drop, or unspecified
+    is_non_drop = None
+    if display_format is not None:
+        is_non_drop = (display_format.text.lower() == "ndf")
+
+    # There is currently a bug where OTIO does not properly support NDF for
+    # fractional framerates
+    if round(rate) != rate and is_non_drop:
+        raise ValueError("Only drop TC supported: {}".format(tc_string))
+
+    return otio.opentime.from_timecode(tc_string, rate)
+
+
+def _track_kind_from_element(media_element):
+    """
+    Given an FCP XML media sub-element, returns an appropriate
+    :class:`otio.schema.TrackKind` value corresponding to that media type.
+
+    :param media_element: An XML element that is a child of the ``media`` tag.
+
+    :return: The corresponding :class`otio.schema.TrackKind` value.
+    :raises: :class:`ValueError` When the media type is unsupported.
+    """
+    element_tag = media_element.tag.lower()
+    if element_tag == "audio":
+        return otio.schema.TrackKind.Audio
+    elif element_tag == "video":
+        return otio.schema.TrackKind.Video
+
+    raise ValueError("Unsupported media kind: {}".format(media_element.tag))
+
+
+def _is_primary_audio_channel(track):
+    """
+    Determines whether or not this is the "primary" audio track.
+
+    audio may be structured in stereo where each channel occupies a separate
+    track. This importer keeps stereo pairs ganged together as a single track.
+
+    :param track: An XML track element.
+
+    :return: A boolean ``True`` if this is the first track.
+    """
+    exploded_index = track.attrib.get('currentExplodedTrackIndex', '0')
+    exploded_count = track.attrib.get('totalExplodedTrackCount', '1')
+
+    return (exploded_index == '0' or exploded_count == '1')
+
+
+def _transition_cut_point(transition_item, context):
+    """
+    Returns the end time at which the transition progresses from one clip to
+    the next.
+
+    :param transition_item: The XML element for the transition.
+    :param context: The context dictionary applying to this transition.
+
+    :return: The :class:`otio.opentime.RationalTime` the transition cuts at.
+    """
+    alignment = transition_item.find('./alignment').text
+    start = int(transition_item.find('./start').text)
+    end = int(transition_item.find('./end').text)
+
+    # start/end time is in the parent context's rate
+    local_context = context.context_pushing_element(transition_item)
+    rate = _rate_from_context(local_context)
+
+    if alignment in ('end', 'end-black'):
+        value = end
+    elif alignment in ('start', 'start-black'):
+        value = start
+    elif alignment in ('center',):
+        value = int((start + end) / 2)
+    else:
+        value = int((start + end) / 2)
+
+    return otio.opentime.RationalTime(value, rate)
+
+
+def _xml_tree_to_dict(node, ignore_tags=None, ignore_recursive=False):
+    """
+    Translates the tree under a provided node mapping to a dictionary/list
+    representation. XML tag attributes are placed in the dictionary with an
+    ``@`` prefix.
+
+    :param node: The root xml element to express childeren of in the
+        dictionary.
+    :param ignore_tags: A collection of tagnames to skip when converting.
+    :param ignore_recursive: If ``True``, will use ``ignore_tags`` not only at
+        the top-level, but all the way down the heirarchy.
+
+    :return: The dictionary representation.
+    """
+    out_dict = {}
+
+    # Handle the attributes
+    out_dict.update(
+        {"@{}".format(k): v for k, v in node.attrib.items()}
+    )
+
+    # Now traverse the child tags
+    encountered_tags = set()
+    list_tags = set()
+    for info_node in node:
+        # Skip tags we explicitly parse
+        node_tag = info_node.tag
+        if ignore_tags and node_tag in ignore_tags:
+            continue
+
+        # If there are children, make this a sub-dictionary by recursing
+        if len(info_node):
+            node_value = _xml_tree_to_dict(info_node)
+        else:
+            node_value = info_node.text
+
+        # If we've seen this node before, then treat it as a list
+        if node_tag in list_tags:
+            # We've established that this tag is a list, append to that
+            out_dict[node_tag].append(node_value)
+        elif node_tag in encountered_tags:
+            # This appears to be a list we didn't know about, convert
+            out_dict[node_tag] = [
+                out_dict[node_tag], node_value
+            ]
+            list_tags.add(node_tag)
+        else:
+            # Store the value
+            out_dict[node_tag] = node_value
+            encountered_tags.add(node_tag)
+
+    return out_dict
+
+
+def _make_pretty_string(tree_e):
+    # most of the parsing in this adapter is done with cElementTree because it
+    # is simpler and faster. However, the string representation it returns is
+    # far from elegant. Therefor we feed it through minidom to provide an xml
+    # with indentations.
+    string = cElementTree.tostring(tree_e, encoding="UTF-8", method="xml")
+    dom = minidom.parseString(string)
+    return dom.toprettyxml(indent='    ')
+
+
+def marker_for_element(marker_element, rate):
+    """
+    Creates an :class:`otio.schema.Marker` for the provided element.
+
+    :param marker_element: The XML element for the marker.
+    :param rate: The rate for the object the marker is attached to.
+
+    :return: The :class:`otio.schema.Marker` instance.
+    """
+    # TODO: The spec doc indicates that in and out are required, but doesn't
+    #       say they have to be locally specified, so is it possible they
+    #       could be inherited?
+    marker_in = otio.opentime.RationalTime(
+        float(marker_element.find("./in").text), rate
+    )
+    marker_out_value = float(marker_element.find("./out").text)
+    if marker_out_value > 0:
+        marker_out = otio.opentime.RationalTime(
+            marker_out_value, rate
+        )
+        marker_duration = (marker_out - marker_in)
+    else:
+        marker_duration = otio.opentime.RationalTime(rate=rate)
+
+    marker_range = otio.opentime.TimeRange(marker_in, marker_duration)
+
+    md_dict = _xml_tree_to_dict(marker_element, {"in", "out", "name"})
+    metadata = {META_NAMESPACE: md_dict} if md_dict else None
+
+    return otio.schema.Marker(
+        name=_name_from_element(marker_element),
+        marked_range=marker_range,
+        metadata=metadata
+    )
+
+
+def markers_from_element(element, context=None):
+    """
+    Given an element, returns the list of markers attached to it.
+
+    :param element: An element with one or more ``marker`` child elements.
+    :param context: The context for this element.
+
+    :return: A :class:`list` of :class:`otio.schema.Marker` instances attached
+        to the provided element.
+    """
+    if context is not None:
+        local_context = context.context_pushing_element(element)
+    else:
+        local_context = _Context(element)
+    rate = _rate_from_context(local_context)
+
+    return [marker_for_element(e, rate) for e in element.iterfind("./marker")]
+
+
+class FCP7XMLParser:
+    """
+    Implements parsing of an FCP XML file into an OTIO timeline.
+
+    Parsing FCP XML elements include two concepts that require carrying state:
+        1. Inheritance
+        2. The id Attribute
+
+    .. seealso:: https://developer.apple.com/library/archive/documentation/\
+            AppleApplications/Reference/FinalCutPro_XML/Basics/Basics.html\
+            #//apple_ref/doc/uid/TP30001154-TPXREF102
+
+    Inheritance is implemented using a _Context object that is pushed down
+    through layers of parsing. A given parsing method is passed the element to
+    parse into an otio object along with the context that element exists under
+    (e.x. a track element parsing method is given the track element and the
+    sequence context for that track).
+
+    The id attribute dereferencing is handled through a lookup table stored on
+    parser instances and using the ``_derefed_`` methods to take an element and
+    find dereference elements.
+    """
+
+    _etree = None
+    """ The root etree for the FCP XML. """
+
+    _id_map = None
+    """ A mapping of id to the first element encountered with that id. """
+
+    def __init__(self, element_tree):
+        """
+        Constructor, must be init with an xml etree.
+        """
+        self._etree = element_tree
+
+        self._id_map = {}
+
+    def _derefed_element(self, element):
+        """
+        Given an element, dereferences it by it's id attribute if needed. If
+        the element has an id attribute and it's our first time encountering
+        it, store the id.
+        """
+        if element is None:
+            return element
+
+        try:
+            elem_id = element.attrib["id"]
+        except KeyError:
+            return element
+
+        return self._id_map.setdefault(elem_id, element)
+
+    def _derefed_iterfind(self, element, path):
+        """
+        Given an elemnt, finds elements with the provided path below and
+        returns an iterator of the dereferenced versions of those.
+
+        :param element: The XML etree element.
+        :param path: The path to find subelements.
+
+        :return: iterator of subelements dereferenced by id.
+        """
+        return (
+            self._derefed_element(e) for e in element.iterfind(path)
+        )
+
+    def top_level_sequences(self):
+        """"
+        Returns a list of timelines for the top-level sequences in the file.
+        """
+        context = _Context()
+
+        # If the tree has just sequences at the top level, this will catch them
+        top_iter = self._derefed_iterfind(self._etree, "./sequence")
+
+        # If there is a project or bin at the top level, this should cath them
+        project_and_bin_iter = self._derefed_iterfind(
+            self._etree, ".//children/sequence"
+        )
+
+        # Make an iterator that will exhaust both the above
+        sequence_iter = itertools.chain(top_iter, project_and_bin_iter)
+
+        return [self.timeline_for_sequence(s, context) for s in sequence_iter]
+
+    def timeline_for_sequence(self, sequence_element, context):
+        """
+        Returns either an :class`otio.schema.Timeline` parsed from a sequence
+        element.
+
+        :param sequence_element: The sequence element.
+        :param context: The context dictionary.
+
+        :return: The appropriate OTIO object for the element.
+        """
+        local_context = context.context_pushing_element(sequence_element)
+
+        name = _name_from_element(sequence_element)
+        parsed_tags = {"name", "media", "marker", "duration"}
+        md_dict = _xml_tree_to_dict(sequence_element, parsed_tags)
+
+        sequence_timecode = self._derefed_element(
+            sequence_element.find("./timecode")
+        )
+        if sequence_timecode is not None:
+            seq_start_time = _time_from_timecode_element(
+                sequence_timecode, local_context
+            )
+        else:
+            seq_start_time = None
+
+        media_element = self._derefed_element(sequence_element.find("./media"))
+        if media_element is None:
+            tracks = None
+        else:
+            # Reach down into the media block and escalate metadata to the
+            # sequence
+            for media_type in media_element:
+                media_info_dict = _xml_tree_to_dict(media_type, {"track"})
+                if media_info_dict:
+                    media_dict = md_dict.setdefault("media", {})
+                    media_dict[media_type.tag] = media_info_dict
+
+            tracks = self.stack_for_element(media_element, local_context)
+            tracks.name = name
+
+        # TODO: Should we be parsing the duration tag and pad out a track with
+        #       gap to match?
+
+        timeline = otio.schema.Timeline(
+            name=name,
+            global_start_time=seq_start_time,
+            metadata={META_NAMESPACE: md_dict} if md_dict else {},
+        )
+        timeline.tracks = tracks
+
+        # Push the sequence markers onto the top stack
+        markers = markers_from_element(sequence_element, context)
+        timeline.tracks.markers.extend(markers)
+
+        return timeline
+
+    def stack_for_element(self, element, context):
+        """
+        Given an element, parses out track information as a stack.
+
+        :param element: The element under which to find the tracks (typically
+            a ``media`` element.
+        :param context: The current parser context.
+
+        :return: A :class:`otio.schema.Stack` of the tracks.
+        """
+        # Determine the context
+        local_context = context.context_pushing_element(element)
+
+        tracks = []
+        media_type_elements = self._derefed_iterfind(element, "./")
+        for media_type_element in media_type_elements:
+            try:
+                track_kind = _track_kind_from_element(media_type_element)
+            except ValueError:
+                # Unexpected element
+                continue
+
+            is_audio = (track_kind == otio.schema.TrackKind.Audio)
+            track_elements = self._derefed_iterfind(
+                media_type_element, "./track"
+            )
+            for track_element in track_elements:
+                if is_audio and not _is_primary_audio_channel(track_element):
+                    continue
+
+                tracks.append(
+                    self.track_for_element(
+                        track_element, track_kind, local_context
+                    )
+                )
+
+        markers = markers_from_element(element, context)
+
+        stack = otio.schema.Stack(
+            children=tracks,
+            markers=markers,
+            name=_name_from_element(element),
+        )
+
+        return stack
+
+    def track_for_element(self, track_element, track_kind, context):
+        """
+        Given a track element, constructs the OTIO track.
+
+        :param track_element: The track XML element.
+        :param track_kind: The :class:`otio.schema.TrackKind` for the track.
+        :param context: The context dict for this track.
+        """
+        local_context = context.context_pushing_element(track_element)
+        name_element = track_element.find("./name")
+        track_name = (name_element.text if name_element is not None else None)
+
+        timeline_item_tags = {"clipitem", "generatoritem", "transitionitem"}
+
+        md_dict = _xml_tree_to_dict(track_element, timeline_item_tags)
+        track_metadata = {META_NAMESPACE: md_dict} if md_dict else None
+
+        track = otio.schema.Track(
+            name=track_name,
+            kind=track_kind,
+            metadata=track_metadata,
+        )
+
+        # Iterate through and parse track items
+        track_rate = _rate_from_context(local_context)
+        current_timeline_time = otio.opentime.RationalTime(0, track_rate)
+        head_transition_element = None
+        for i, item_element in enumerate(track_element):
+            if item_element.tag not in timeline_item_tags:
+                continue
+
+            item_element = self._derefed_element(item_element)
+
+            # Do a lookahead to try and find the tail transition item
+            try:
+                tail_transition_element = track_element[i + 1]
+                if tail_transition_element.tag != "transitionitem":
+                    tail_transition_element = None
+                else:
+                    tail_transition_element = self._derefed_element(
+                        tail_transition_element
+                    )
+            except IndexError:
+                tail_transition_element = None
+
+            track_item, item_range = self.item_and_timing_for_element(
+                item_element,
+                head_transition_element,
+                tail_transition_element,
+                local_context,
+            )
+
+            # Insert gap between timeline cursor and the new item if needed.
+            if current_timeline_time < item_range.start_time:
+                gap_duration = (item_range.start_time - current_timeline_time)
+                gap_range = otio.opentime.TimeRange(
+                    duration=gap_duration.rescaled_to(track_rate)
+                )
+                track.append(otio.schema.Gap(source_range=gap_range))
+
+            # Add the item and advance the timeline cursor
+            track.append(track_item)
+            current_timeline_time = item_range.end_time_exclusive()
+
+            # Stash the element for the next iteration if it's a transition
+            if item_element.tag == "transitionitem":
+                head_transition_element = item_element
+
+        return track
+
+    def media_reference_for_file_element(self, file_element, context):
+        """
+        Given a file XML element, returns the
+        :class`otio.schema.ExternalReference`.
+
+        :param file_element: The file xml element.
+        :param context: The parent context dictionary.
+
+        :return: An :class:`otio.schema.ExternalReference`.
+        """
+        local_context = context.context_pushing_element(file_element)
+        media_ref_rate = _rate_from_context(local_context)
+
+        name = _name_from_element(file_element)
+
+        # Get the full metadata
+        metadata_ignore_keys = {"duration", "name", "pathurl"}
+        md_dict = _xml_tree_to_dict(file_element, metadata_ignore_keys)
+        metadata_dict = {META_NAMESPACE: md_dict} if md_dict else None
+
+        # Determine the file path
+        path_element = file_element.find("./pathurl")
+        if path_element is not None:
+            path = path_element.text
+        else:
+            # TODO: Support others declared in mediaSource tag (like Slug)
+            return otio.schema.MissingReference(
+                name=name,
+                metadata=metadata_dict,
+            )
+
+        # Find the timing
+        timecode_element = file_element.find("./timecode")
+        if timecode_element is not None:
+            start_time = _time_from_timecode_element(timecode_element)
+        else:
+            start_time = otio.opentime.RationalTime()
+
+        duration_element = file_element.find("./duration")
+        if duration_element is not None:
+            duration = otio.opentime.RationalTime(
+                float(duration_element.text), media_ref_rate
+            )
+            available_range = otio.opentime.TimeRange(
+                start_time.rescaled_to(media_ref_rate), duration
+            )
+        else:
+            available_range = None
+
+        media_reference = otio.schema.ExternalReference(
+            target_url=path,
+            available_range=available_range,
+            metadata=metadata_dict,
+        )
+        media_reference.name = name
+
+        return media_reference
+
+    def item_and_timing_for_element(
+        self, item_element, head_transition, tail_transition, context
+    ):
+        """
+        Given a track item, returns a tuple with the appropriate OpenTimelineIO
+        schema item as the first element and an
+        :class:`otio.opentime.TimeRange`of theresolved timeline range the clip
+        occupies.
+
+        :param item_element: The track item XML node.
+        :param head_transition: The xml element for the transition immediately
+            before or ``None``.
+        :param tail_transition: The xml element for the transition immediately
+            after or ``None``.
+        :param context: The context dictionary.
+
+        :return: An :class:`otio.core.Item` subclass instance and
+            :class:`otio.opentime.TimeRange` for the item.
+        """
+        parent_rate = _rate_from_context(context)
+
+        # Establish the start/end time in the timeline
+        start_value = int(item_element.find("./start").text)
+        end_value = int(item_element.find("./end").text)
+
+        if start_value == -1:
+            # determine based on the cut point of the head transition
+            start = _transition_cut_point(head_transition, context)
+
+            # This offset is needed to determing how much to advance from the
+            # clip media's in time. Duration accounts for this offset for the
+            # out time.
+            transition_rate = _rate_from_context(
+                context.context_pushing_element(head_transition)
+            )
+            start_offset = start - otio.opentime.RationalTime(
+                int(head_transition.find('./start').text), transition_rate
+            )
+        else:
+            start = otio.opentime.RationalTime(start_value, parent_rate)
+            start_offset = otio.opentime.RationalTime()
+
+        if end_value == -1:
+            # determine based on the cut point of the tail transition
+            end = _transition_cut_point(tail_transition, context)
+        else:
+            end = otio.opentime.RationalTime(end_value, parent_rate)
+
+        item_range = otio.opentime.TimeRange(start, (end - start))
+
+        # Get the metadata dictionary for the item
+        item_metadata_ignore_keys = {
+            "name",
+            "start",
+            "end",
+            "in",
+            "out",
+            "duration",
+            "file",
+            "marker",
+            "sequence",
+        }
+        metadata_dict = _xml_tree_to_dict(
+            item_element, item_metadata_ignore_keys
+        )
+
+        # deserialize the item
+        if item_element.tag == "clipitem":
+            item = self.clip_for_element(item_element, item_range, context)
+        # TODO: Add generator support
+        # elif item_element.tag == "generatoritem":
+        #     item = self.generator_for_element(
+        #         item_element, item_range, context
+        #     )
+        elif item_element.tag == "transitionitem":
+            item = self.transition_for_element(item_element, context)
+        else:
+            name = "unknown-{}".format(item_element.tag)
+            item = otio.core.Item(name=name, source_range=item_range)
+
+        if metadata_dict:
+            item.metadata.setdefault(META_NAMESPACE, {}).update(metadata_dict)
+
+        return (item, item_range)
+
+    def clip_for_element(
+        self, clipitem_element, item_range, start_offset, context
+    ):
+        """
+        Given a clipitem xml element, returns an :class:`otio.schema.Clip`.
+
+        :param clipitem_element: The element to create a clip for.
+        :param item_range: The time range in the timeline the clip occupies.
+        :param start_offset: The amount by which the ``in`` time of the clip
+            source should be advanced (usually due to a transition).
+        :param context: The parent context for the clip.
+
+        :return: The :class:`otio.schema.Clip` instance.
+        """
+        local_context = context.context_pushing_element(clipitem_element)
+
+        name = _name_from_element(clipitem_element)
+
+        file_element = self._derefed_element(clipitem_element.find("./file"))
+        sequence_element = self._derefed_element(
+            clipitem_element.find("./sequence")
+        )
+        media_start_time = otio.opentime.RationalTime()
+        if file_element is not None:
+            media_reference = self.media_reference_for_file_element(
+                file_element, local_context
+            )
+            markers = markers_from_element(clipitem_element, context)
+            item = otio.schema.Clip(
+                name=name,
+                media_reference=media_reference,
+                markers=markers,
+            )
+
+            # See if we have a start offset
+            timecode_element = file_element.find("./timecode")
+            if timecode_element is not None:
+                media_start_time = _time_from_timecode_element(
+                    timecode_element
+                )
+
+        elif sequence_element is not None:
+            item = self.stack_for_element(sequence_element, local_context)
+            # TODO: is there an applicable media start time we should be
+            #       using from nested sequences?
+        else:
+            raise TypeError(
+                'Type of clip item is not supported {}'.format(
+                    _element_identification_string(clipitem_element)
+                )
+            )
+
+        # Find the in time (source time relative to media start)
+        clip_rate = _rate_from_context(local_context)
+        in_value = float(clipitem_element.find('./in').text)
+        in_time = otio.opentime.RationalTime(in_value, clip_rate)
+
+        # Offset the "in" time by the start offset of the media
+        soure_start_time = in_time + media_start_time + start_offset
+        duration = item_range.duration
+
+        # Source Range is the item range expressed in the clip's rate (for now)
+        source_range = otio.opentime.TimeRange(
+            soure_start_time.rescaled_to(clip_rate),
+            duration.rescaled_to(clip_rate),
+        )
+
+        item.source_range = source_range
+
+        return item
+
+    def transition_for_element(self, item_element, context):
+        """
+        Creates an OTIO transition for the provided transition element.
+
+        :param item_element: The element to create a transition for.
+        :param context: The parent context for the element.
+
+        :return: The :class:`otio.schema.Transition` instance.
+        """
+        # start and end times are in the parent's rate
+        rate = _rate_from_context(context)
+        start = otio.opentime.RationalTime(
+            int(item_element.find('./start').text),
+            rate
+        )
+        end = otio.opentime.RationalTime(
+            int(item_element.find('./end').text),
+            rate
+        )
+        cut_point = _transition_cut_point(item_element, context)
+
+        transition = otio.schema.Transition(
+            name=item_element.find('./effect/name').text,
+            transition_type=otio.schema.TransitionTypes.SMPTE_Dissolve,
+            in_offset=cut_point - start,
+            out_offset=end - cut_point,
+        )
+
+        return transition
+
+
+# ------------------------
+# building single track
+# ------------------------
 
 
 def _populate_backreference_map(item, br_map):
@@ -141,402 +1042,6 @@ def _insert_new_sub_element(into_parent, tag, attrib=None, text=''):
     elem.text = text
     return elem
 
-
-def _get_top_level_tracks(elem):
-    top_level_tracks = elem.findall('./sequence')
-    for sub_elem in elem:
-        if sub_elem.tag in ('sequence', 'clip'):
-            continue
-        top_level_tracks.extend(_get_top_level_tracks(sub_elem))
-    return top_level_tracks
-
-
-def _make_pretty_string(tree_e):
-    # most of the parsing in this adapter is done with cElementTree because it
-    # is simpler and faster. However, the string representation it returns is
-    # far from elegant. Therefor we feed it through minidom to provide an xml
-    # with indentations.
-    string = cElementTree.tostring(tree_e, encoding="UTF-8", method="xml")
-    dom = minidom.parseString(string)
-    return dom.toprettyxml(indent='    ')
-
-
-def _is_primary_audio_channel(track):
-    # audio may be structured in stereo where each channel occupies a separate
-    # track. Some xml logic combines these into a single track upon import.
-    # Here we check whether we`re dealing with the first audio channel
-    return track.attrib.get('currentExplodedTrackIndex', '0') == '0' or \
-        track.attrib.get('totalExplodedTrackCount', '1') == '1'
-
-
-def _get_transition_cut_point(transition_item, element_map):
-    alignment = transition_item.find('./alignment').text
-    start = int(transition_item.find('./start').text)
-    end = int(transition_item.find('./end').text)
-    rate = _parse_rate(transition_item, element_map)
-
-    if alignment in ('end', 'end-black'):
-        value = end
-    elif alignment in ('start', 'start-black'):
-        value = start
-    elif alignment in ('center',):
-        value = int((start + end) / 2)
-    else:
-        value = int((start + end) / 2)
-
-    return otio.opentime.RationalTime(value, rate)
-
-
-# -----------------------
-# parsing single track
-# -----------------------
-
-def _parse_rate(elem, element_map):
-    elem = _resolved_backreference(elem, 'all_elements', element_map)
-
-    rate = elem.find('./rate')
-    # rate is encoded as a timebase (int) which can be drop-frame
-    base = float(rate.find('./timebase').text)
-    if rate.find('./ntsc').text == 'TRUE':
-        base *= .999
-    return base
-
-
-def _parse_media_reference(file_e, element_map):
-    file_e = _resolved_backreference(file_e, 'file', element_map)
-
-    url = file_e.find('./pathurl').text
-    file_rate = _parse_rate(file_e, element_map)
-    timecode_rate = _parse_rate(file_e.find('./timecode'), element_map)
-
-    frame_e = file_e.find('./timecode/frame')
-    if frame_e is not None:
-        start_time = otio.opentime.RationalTime(
-            int(frame_e.text),
-            timecode_rate)
-    else:
-        start_time = otio.opentime.from_timecode(
-            file_e.find('./timecode/string').text,
-            timecode_rate)
-
-    duration_e = file_e.find('./duration')
-    if duration_e is not None:
-        duration = otio.opentime.RationalTime(
-            int(duration_e.text),
-            file_rate)
-    else:
-        duration = otio.opentime.RationalTime(0, file_rate)
-
-    available_range = otio.opentime.TimeRange(
-        start_time=start_time,
-        duration=duration
-    )
-
-    return otio.schema.ExternalReference(
-        target_url=url.strip(),
-        available_range=available_range
-    )
-
-
-def _parse_clip_item_without_media(clip_item, track_rate,
-                                   transition_offsets, element_map):
-    markers = clip_item.findall('./marker')
-    rate = _parse_rate(clip_item, element_map)
-
-    # transition offsets are provided in timeline rate. If they deviate they
-    # need to be rescaled to clip item rate
-    context_transition_offsets = [
-        transition_offsets[0].rescaled_to(rate),
-        transition_offsets[1].rescaled_to(rate)
-    ]
-
-    in_value = int(float(clip_item.find('./in').text))
-    in_frame = in_value + int(round(context_transition_offsets[0].value))
-
-    out_value = int(float(clip_item.find('./out').text))
-    out_frame = out_value - int(round(context_transition_offsets[1].value))
-
-    source_range = otio.opentime.TimeRange(
-        start_time=otio.opentime.RationalTime(in_frame, track_rate),
-        duration=otio.opentime.RationalTime(
-            out_frame - in_frame,
-            track_rate
-        )
-    )
-
-    name_item = clip_item.find('name')
-    if name_item is not None:
-        name = name_item.text
-    else:
-        name = None
-
-    clip = otio.schema.Clip(name=name, source_range=source_range)
-    clip.markers.extend(
-        [_parse_marker(m, rate) for m in markers]
-    )
-    return clip
-
-
-def _parse_clip_item(clip_item, transition_offsets, element_map):
-    markers = clip_item.findall('./marker')
-
-    media_reference = _parse_media_reference(
-        clip_item.find('./file'),
-        element_map
-    )
-    item_rate = _parse_rate(clip_item, element_map)
-
-    # transition offsets are provided in timeline rate. If they deviate they
-    # need to be rescaled to clip item rate
-    context_transition_offsets = [
-        transition_offsets[0].rescaled_to(item_rate),
-        transition_offsets[1].rescaled_to(item_rate)
-    ]
-
-    in_value = int(float(clip_item.find('./in').text))
-    in_frame = in_value + int(round(context_transition_offsets[0].value))
-
-    out_value = int(float(clip_item.find('./out').text))
-    out_frame = out_value - int(round(context_transition_offsets[1].value))
-    timecode = media_reference.available_range.start_time
-
-    # source_start in xml is taken relative to the start of the media, whereas
-    # we want the absolute start time, taking into account the timecode
-    start_time = otio.opentime.RationalTime(in_frame, item_rate) + timecode
-
-    source_range = otio.opentime.TimeRange(
-        start_time=start_time.rescaled_to(item_rate),
-        duration=otio.opentime.RationalTime(out_frame - in_frame, item_rate)
-    )
-
-    # get the clip name from the media reference if not defined on the clip
-    name_item = clip_item.find('name')
-    if name_item is not None:
-        name = name_item.text
-    else:
-        url_path = _url_to_path(media_reference.target_url)
-        name = os.path.basename(url_path)
-
-    clip = otio.schema.Clip(
-        name=name,
-        media_reference=media_reference,
-        source_range=source_range
-    )
-
-    clip.markers.extend([_parse_marker(m, item_rate) for m in markers])
-
-    return clip
-
-
-def _parse_transition_item(transition_item, element_map):
-    rate = _parse_rate(transition_item, element_map)
-    start = otio.opentime.RationalTime(
-        int(transition_item.find('./start').text),
-        rate
-    )
-    end = otio.opentime.RationalTime(
-        int(transition_item.find('./end').text),
-        rate
-    )
-    cut_point = _get_transition_cut_point(transition_item, element_map)
-    metadata = {
-        META_NAMESPACE: {
-            'effectid': transition_item.find('./effect/effectid').text,
-        }
-    }
-
-    transition = otio.schema.Transition(
-        name=transition_item.find('./effect/name').text,
-        transition_type=otio.schema.TransitionTypes.SMPTE_Dissolve,
-        in_offset=cut_point - start,
-        out_offset=end - cut_point,
-        metadata=metadata
-    )
-    return transition
-
-
-def _parse_track_item(track_item, transition_offsets, element_map):
-    track = _parse_track(track_item.find('./sequence'), element_map)
-    source_rate = _parse_rate(track_item.find('./sequence'), element_map)
-
-    # transition offsets are provided in timeline rate. If they deviate they
-    # need to be rescaled to clip item rate
-    context_transition_offsets = [
-        transition_offsets[0].rescaled_to(source_rate),
-        transition_offsets[1].rescaled_to(source_rate)
-    ]
-
-    in_value = int(track_item.find('./in').text)
-    in_frame = in_value + int(round(context_transition_offsets[0].value, 0))
-
-    out_value = int(track_item.find('./out').text)
-    out_frame = out_value - int(round(context_transition_offsets[1].value))
-
-    track.source_range = otio.opentime.TimeRange(
-        start_time=otio.opentime.RationalTime(in_frame, source_rate),
-        duration=otio.opentime.RationalTime(out_frame - in_frame, source_rate)
-    )
-    return track
-
-
-def _parse_item(track_item, track_rate, transition_offsets, element_map):
-    # depending on the content of the clip-item, we return either a clip, a
-    # stack or a transition.
-    if track_item.tag == 'transitionitem':
-        return _parse_transition_item(track_item, element_map)
-
-    file_e = track_item.find('./file')
-    if file_e is not None:
-        file_e = _resolved_backreference(file_e, 'file', element_map)
-
-    if file_e is not None:
-        if file_e.find('./pathurl') is None:
-            return _parse_clip_item_without_media(
-                track_item, track_rate, transition_offsets, element_map)
-        else:
-            return _parse_clip_item(
-                track_item, transition_offsets, element_map)
-    elif track_item.find('./sequence') is not None:
-        return _parse_track_item(
-            track_item, transition_offsets, element_map)
-
-    raise TypeError(
-        'Type of clip item is not supported {item_id}'.format(
-            item_id=track_item.attrib['id']
-        )
-    )
-
-
-def _parse_top_level_track(track_e, kind, rate, element_map):
-    track = otio.schema.Track(kind=kind)
-    track_items = [
-        item for item in track_e if item.tag in ('clipitem', 'transitionitem')
-    ]
-
-    if not track_items:
-        return track
-
-    trackname_e = track_e.find('./name')
-    if trackname_e is not None:
-        track.name = trackname_e.text
-
-    last_clip_end = otio.opentime.RationalTime(rate=rate)
-    for track_item in track_items:
-        clip_item_index = list(track_e).index(track_item)
-        start = otio.opentime.RationalTime(
-            int(track_item.find('./start').text),
-            rate
-        )
-        end = otio.opentime.RationalTime(
-            int(track_item.find('./end').text),
-            rate
-        )
-
-        # start time and end time on the timeline can be set to -1. This means
-        # that there is a transition at that end of the clip-item. So the time
-        # on the timeline has to be taken from that object.
-        transition_offsets = [
-            otio.opentime.RationalTime(rate=rate),
-            otio.opentime.RationalTime(rate=rate)
-        ]
-
-        if track_item.tag == 'clipitem':
-            if start.value == -1:
-                in_transition = list(track_e)[clip_item_index - 1]
-                start = _get_transition_cut_point(in_transition, element_map)
-                transition_offsets[0] = start - otio.opentime.RationalTime(
-                    int(in_transition.find('./start').text),
-                    _parse_rate(in_transition, element_map)
-                )
-            if end.value == -1:
-                out_transition = list(track_e)[clip_item_index + 1]
-                end = _get_transition_cut_point(out_transition, element_map)
-                transition_offsets[1] = otio.opentime.RationalTime(
-                    int(out_transition.find('./end').text),
-                    _parse_rate(out_transition, element_map)
-                ) - end
-
-        # see if we need to add a gap before this clip-item
-        gap_time = start - last_clip_end
-        last_clip_end = end
-        if gap_time.value > 0:
-            gap_range = otio.opentime.TimeRange(
-                duration=gap_time.rescaled_to(rate)
-            )
-            track.append(otio.schema.Gap(source_range=gap_range))
-
-        # finally add the track-item itself
-        track.append(
-            _parse_item(track_item, rate, transition_offsets, element_map)
-        )
-
-    return track
-
-
-def _parse_marker(marker, rate):
-    marker_range = otio.opentime.TimeRange(
-        start_time=otio.opentime.RationalTime(
-            int(marker.find('./in').text), rate
-        )
-    )
-    metadata = {META_NAMESPACE: {'comment': marker.find('./comment').text}}
-    return otio.schema.Marker(
-        name=marker.find('./name').text,
-        marked_range=marker_range,
-        metadata=metadata
-    )
-
-
-def _parse_track(track, element_map):
-    track = _resolved_backreference(track, 'sequence', element_map)
-
-    track_rate = _parse_rate(track, element_map)
-
-    video_tracks = track.findall('./media/video/track')
-    audio_tracks = track.findall('./media/audio/track')
-    markers = track.findall('./marker')
-
-    stack = otio.schema.Stack(name=track.find('./name').text)
-
-    stack.extend(
-        _parse_top_level_track(
-            t,
-            otio.schema.TrackKind.Video, track_rate, element_map
-        )
-        for t in video_tracks
-    )
-    stack.extend(
-        _parse_top_level_track(
-            t,
-            otio.schema.TrackKind.Audio,
-            track_rate, element_map
-        )
-        for t in audio_tracks
-        if _is_primary_audio_channel(t)
-    )
-    stack.markers.extend(_parse_marker(m, track_rate) for m in markers)
-
-    return stack
-
-
-def _parse_timeline(track, element_map):
-    track = _resolved_backreference(track, 'sequence', element_map)
-    track_rate = _parse_rate(track, element_map)
-    timeline = otio.schema.Timeline(name=track.find('./name').text)
-    timeline.global_start_time = otio.opentime.RationalTime(0, track_rate)
-    timeline.tracks = _parse_track(track, element_map)
-    return timeline
-
-
-def _parse_collection(tracks, element_map):
-    collection = otio.schema.SerializableCollection(name='tracks')
-    collection.extend([_parse_timeline(s, element_map) for s in tracks])
-    return collection
-
-
-# ------------------------
-# building single track
-# ------------------------
 
 def _build_rate(time):
     rate = math.ceil(time.rate)
@@ -922,18 +1427,18 @@ def _build_collection(collection, br_map):
 def read_from_string(input_str):
     tree = cElementTree.fromstring(input_str)
 
-    # element_map encodes the backreference context
-    element_map = collections.defaultdict(dict)
-    _populate_element_map(tree, element_map)
+    parser = FCP7XMLParser(tree)
+    sequences = parser.top_level_sequences()
 
-    top_level_tracks = _get_top_level_tracks(tree)
-
-    if len(top_level_tracks) == 1:
-        return _parse_timeline(top_level_tracks[0], element_map)
-    elif len(top_level_tracks) > 1:
-        return _parse_collection(top_level_tracks, element_map)
+    if len(sequences) == 1:
+        return sequences[0]
+    elif len(sequences) > 1:
+        return otio.schema.SerializableCollection(
+            name="Sequences",
+            children=sequences,
+        )
     else:
-        raise ValueError('No top-level tracks found')
+        raise ValueError('No top-level sequences found')
 
 
 def write_to_string(input_otio):

--- a/tests/sample_data/premiere_example_filter.json
+++ b/tests/sample_data/premiere_example_filter.json
@@ -1,0 +1,76 @@
+{
+  "effect": {
+    "name": "Time Remap",
+    "effectid": "timeremap",
+    "effectcategory": "motion",
+    "effecttype": "motion",
+    "mediatype": "video",
+    "parameter": [
+      {
+        "@authoringApp": "PremierePro",
+        "parameterid": "variablespeed",
+        "name": "variablespeed",
+        "valuemin": "0",
+        "valuemax": "1",
+        "value": "0"
+      },
+      {
+        "@authoringApp": "PremierePro",
+        "parameterid": "speed",
+        "name": "speed",
+        "valuemin": "-100000",
+        "valuemax": "100000",
+        "value": "100"
+      },
+      {
+        "@authoringApp": "PremierePro",
+        "parameterid": "reverse",
+        "name": "reverse",
+        "value": "TRUE"
+      },
+      {
+        "@authoringApp": "PremierePro",
+        "parameterid": "frameblending",
+        "name": "frameblending",
+        "value": "FALSE"
+      },
+      {
+        "@authoringApp": "PremierePro",
+        "parameterid": "graphdict",
+        "name": "graphdict",
+        "valuemin": "0",
+        "valuemax": "37127",
+        "value": "0",
+        "keyframe": [
+          {
+            "when": "0",
+            "value": "37127",
+            "speedvirtualkf": "TRUE",
+            "speedkfstart": "TRUE"
+          },
+          {
+            "when": "15299",
+            "value": "21828",
+            "speedvirtualkf": "TRUE",
+            "speedkfin": "TRUE"
+          },
+          {
+            "when": "15305",
+            "value": "21822",
+            "speedvirtualkf": "TRUE",
+            "speedkfout": "TRUE"
+          },
+          {
+            "when": "37127",
+            "value": "1",
+            "speedvirtualkf": "TRUE",
+            "speedkfend": "TRUE"
+          }
+        ],
+        "interpolation": {
+          "name": "FCPCurve"
+        }
+      }
+    ]
+  }
+}

--- a/tests/sample_data/premiere_example_filter.xml
+++ b/tests/sample_data/premiere_example_filter.xml
@@ -1,0 +1,67 @@
+<filter>
+    <effect>
+        <name>Time Remap</name>
+        <effectid>timeremap</effectid>
+        <effectcategory>motion</effectcategory>
+        <effecttype>motion</effecttype>
+        <mediatype>video</mediatype>
+        <parameter authoringApp="PremierePro">
+            <parameterid>variablespeed</parameterid>
+            <name>variablespeed</name>
+            <valuemin>0</valuemin>
+            <valuemax>1</valuemax>
+            <value>0</value>
+        </parameter>
+        <parameter authoringApp="PremierePro">
+            <parameterid>speed</parameterid>
+            <name>speed</name>
+            <valuemin>-100000</valuemin>
+            <valuemax>100000</valuemax>
+            <value>100</value>
+        </parameter>
+        <parameter authoringApp="PremierePro">
+            <parameterid>reverse</parameterid>
+            <name>reverse</name>
+            <value>TRUE</value>
+        </parameter>
+        <parameter authoringApp="PremierePro">
+            <parameterid>frameblending</parameterid>
+            <name>frameblending</name>
+            <value>FALSE</value>
+        </parameter>
+        <parameter authoringApp="PremierePro">
+            <parameterid>graphdict</parameterid>
+            <name>graphdict</name>
+            <valuemin>0</valuemin>
+            <valuemax>37127</valuemax>
+            <value>0</value>
+            <keyframe>
+                <when>0</when>
+                <value>37127</value>
+                <speedvirtualkf>TRUE</speedvirtualkf>
+                <speedkfstart>TRUE</speedkfstart>
+            </keyframe>
+            <keyframe>
+                <when>15299</when>
+                <value>21828</value>
+                <speedvirtualkf>TRUE</speedvirtualkf>
+                <speedkfin>TRUE</speedkfin>
+            </keyframe>
+            <keyframe>
+                <when>15305</when>
+                <value>21822</value>
+                <speedvirtualkf>TRUE</speedvirtualkf>
+                <speedkfout>TRUE</speedkfout>
+            </keyframe>
+            <keyframe>
+                <when>37127</when>
+                <value>1</value>
+                <speedvirtualkf>TRUE</speedvirtualkf>
+                <speedkfend>TRUE</speedkfend>
+            </keyframe>
+            <interpolation>
+                <name>FCPCurve</name>
+            </interpolation>
+        </parameter>
+    </effect>
+</filter>

--- a/tests/sample_data/premiere_example_filter.xml
+++ b/tests/sample_data/premiere_example_filter.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" ?>
 <filter>
     <effect>
         <name>Time Remap</name>

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -1061,7 +1061,6 @@ class AdaptersFcp7XmlTest(unittest.TestCase, test_utils.OTIOAssertions):
 
     def test_roundtrip_mem2disk2mem(self):
         timeline = schema.Timeline('test_timeline')
-        timeline.tracks.name = 'test_timeline'
 
         RATE = 48.0
 
@@ -1215,6 +1214,12 @@ class AdaptersFcp7XmlTest(unittest.TestCase, test_utils.OTIOAssertions):
             result,
             adapter_name='fcp_xml'
         )
+
+        # Since FCP XML's "sequence" is a marriage of the timeline and the
+        # main tracks stack, the tracks stack loses its name
+        new_timeline.tracks.name = timeline.tracks.name
+
+        self.assertEqual(new_timeline.name, 'test_timeline')
 
         # Before comparing, scrub ignorable metadata introduced in
         # serialization (things like unique ids minted by the adapter)

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -1246,14 +1246,17 @@ class AdaptersFcp7XmlTest(unittest.TestCase, test_utils.OTIOAssertions):
 
         # Scrub the Drop-frame vs. Non-Drop from the comparison. There is work
         # That needs to be done, see _build_timecode in the adapter for more
-        # notes on how to correct this
+        # notes on how to correct this.
+        # Also, OTIO doesn't support linking items for the moment, so the
+        # adapter reads links to the metadata, but doesn't write them.
 
         def scrub_md_dicts(timeline):
             def scrub_displayformat(md_dict):
-                try:
-                    del(md_dict["displayformat"])
-                except KeyError:
-                    pass
+                for ignore_key in {"displayformat", "link"}:
+                    try:
+                        del(md_dict[ignore_key])
+                    except KeyError:
+                        pass
 
                 for _, value in list(md_dict.items()):
                     if isinstance(value, dict):

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -37,7 +37,6 @@ from opentimelineio import (
     schema,
     test_utils,
 )
-import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 FCP7_XML_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "premiere_example.xml")

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -272,7 +272,7 @@ class TestFcp7XmlUtilities(unittest.TestCase, test_utils.OTIOAssertions):
         # level up
         clip_context = track_context.context_pushing_element(clip_norate_elem)
         clip_inherit_rate = self.adapter._rate_from_context(clip_context)
-        self.assertEqual(clip_inherit_rate, (24000 / 1001))
+        self.assertEqual(clip_inherit_rate, (24000 / 1001.0))
 
     def test_time_frome_timecode_element(self):
         tc_element = cElementTree.fromstring(


### PR DESCRIPTION
This is a refactor of the FCP XML adapter adapter. The goal of this refactor was to:
- Address some timing accuracy issues that could be encountered
- Add support for handling effects and generators
- Add support for parsing and roundtripping FCP XML metadata

This is expected to address the following issues (I would love confirmation from the relevant parties):
- #468 
- #265 
- #334 
- #287 
- #485