### PR TITLE
Use warnings module to handle overlapping transitions case during flatten

### DIFF
--- a/opentimelineio/exceptions.py
+++ b/opentimelineio/exceptions.py
@@ -81,9 +81,15 @@ class MisconfiguredPluginError(OTIOError):
     pass
 
 
-class CannotTrimTransitionsError(OTIOError):
+class NoDefaultMediaLinkerError(OTIOError):
     pass
 
 
-class NoDefaultMediaLinkerError(OTIOError):
+# Warnings
+
+class OTIOWarning(UserWarning):
+    pass
+
+
+class CannotTrimTransitionsWarning(OTIOWarning):
     pass

--- a/tests/test_timeline_algo.py
+++ b/tests/test_timeline_algo.py
@@ -252,8 +252,9 @@ class TimelineTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
             original_timeline.duration()
         )
 
-        # if you try to sever a Transition in the middle it should fail
-        with self.assertRaises(otio.exceptions.CannotTrimTransitionsError):
+
+        # if you try to sever a Transition in the middle it should complain
+        with self.assertWarns(otio.exceptions.CannotTrimTransitionsWarning):
             trimmed = otio.algorithms.timeline_trimmed_to_range(
                 original_timeline,
                 otio.opentime.TimeRange(
@@ -262,7 +263,7 @@ class TimelineTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
                 )
             )
 
-        with self.assertRaises(otio.exceptions.CannotTrimTransitionsError):
+        with self.assertWarns(otio.exceptions.CannotTrimTransitionsWarning):
             trimmed = otio.algorithms.timeline_trimmed_to_range(
                 original_timeline,
                 otio.opentime.TimeRange(

--- a/tests/test_track_algo.py
+++ b/tests/test_track_algo.py
@@ -436,7 +436,7 @@ class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         # if you try to sever a Transition in the middle it should fail
-        with self.assertRaises(otio.exceptions.CannotTrimTransitionsError):
+        with self.assertWarns(otio.exceptions.CannotTrimTransitionsWarning):
             trimmed = otio.algorithms.track_trimmed_to_range(
                 original_track,
                 otio.opentime.TimeRange(
@@ -445,7 +445,7 @@ class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
                 )
             )
 
-        with self.assertRaises(otio.exceptions.CannotTrimTransitionsError):
+        with self.assertWarns(otio.exceptions.CannotTrimTransitionsWarning):
             trimmed = otio.algorithms.track_trimmed_to_range(
                 original_track,
                 otio.opentime.TimeRange(

--- a/tests/test_track_algo.py
+++ b/tests/test_track_algo.py
@@ -25,8 +25,9 @@
 
 """Test file for the track algorithms library."""
 
-import unittest
 import copy
+import unittest
+import warnings
 
 import opentimelineio as otio
 
@@ -436,7 +437,8 @@ class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
         )
 
         # if you try to sever a Transition in the middle it should fail
-        with self.assertWarns(otio.exceptions.CannotTrimTransitionsWarning):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             trimmed = otio.algorithms.track_trimmed_to_range(
                 original_track,
                 otio.opentime.TimeRange(
@@ -444,8 +446,11 @@ class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
                     duration=otio.opentime.RationalTime(50, 24)
                 )
             )
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[-1].category, otio.exceptions.CannotTrimTransitionsWarning)
 
-        with self.assertWarns(otio.exceptions.CannotTrimTransitionsWarning):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             trimmed = otio.algorithms.track_trimmed_to_range(
                 original_track,
                 otio.opentime.TimeRange(
@@ -453,6 +458,8 @@ class TrackTrimmingTests(unittest.TestCase, otio.test_utils.OTIOAssertions):
                     duration=otio.opentime.RationalTime(50, 24)
                 )
             )
+            self.assertEqual(1, len(w))
+            self.assertEqual(w[-1].category, otio.exceptions.CannotTrimTransitionsWarning)
 
         trimmed = otio.algorithms.track_trimmed_to_range(
             original_track,


### PR DESCRIPTION
When flattening tracks or trimming a track, we sometimes encounter a transition that overlaps the edge of the trim. Instead of throwing an exception, we now produce a warning. The caller can choose how to handle the warning via the standard warnings module.