### PR TITLE
Pass track name to mobslot

### DIFF
--- a/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
+++ b/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
@@ -278,6 +278,7 @@ class _TrackTranscriber(object):
         self.otio_track = otio_track
         self.edit_rate = next(self.otio_track.each_clip()).duration().rate
         self.timeline_mobslot, self.sequence = self._create_timeline_mobslot()
+        self.timeline_mobslot.name = self.otio_track.name
 
     def transcribe(self, otio_child):
         """Transcribe otio child to corresponding AAF object"""


### PR DESCRIPTION
This value is shown as track name in the Media Composer.

pyaaf2 gave default name as `"Track-%03d" % slot_id`. Here we just pass whatever name a track has to mobslot.

If the name is None, the Media Composer does not show the name (after `/`), but still labels the track as V1, V2 for video tracks and A1, A2 for audio tracks.