### PR TITLE
Fix missing source clip start offset

### DIFF
--- a/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
+++ b/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
@@ -363,9 +363,17 @@ class _TrackTranscriber(object):
         mastermob, mastermob_slot = self._create_mastermob(otio_clip,
                                                            filemob,
                                                            filemob_slot)
+
+        # We need both `start_time` and `duration`
+        # Here `start` is the offset between `first` and `in` values.
+
+        offset = otio_clip.visible_range().start_time - otio_clip.available_range().start_time
+        start = offset.value
         length = otio_clip.visible_range().duration.value
+
         compmob_clip = self.compositionmob.create_source_clip(
             slot_id=self.timeline_mobslot.slot_id,
+            start=start,
             length=length,
             media_kind=self.media_kind)
         compmob_clip.mob = mastermob

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -849,7 +849,7 @@ class AAFWriterTests(unittest.TestCase):
         otio.adapters.write_to_file(otio_timeline, tmp_aaf_path)
         self._verify_firstClip(otio_timeline, tmp_aaf_path)
 
-    def _verify_firstClip(self, original_timeline, aaf_path):
+    def _verify_first_clip(self, original_timeline, aaf_path):
         timeline_from_aaf = otio.adapters.read_from_file(aaf_path)
 
         original_clips = list(original_timeline.each_clip())

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -856,7 +856,7 @@ class AAFWriterTests(unittest.TestCase):
         aaf_clips = list(timeline_from_aaf.each_clip())
 
         self.assertTrue(len(original_clips) > 0)
-        self.assertTrue(len(aaf_clips) > 0)
+        self.assertEqual(len(aaf_clips), len(original_clips))
 
         first_clip_in_original_timeline = original_clips[0]
         first_clip_in_aaf_timeline = aaf_clips[0]

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -809,7 +809,7 @@ class AAFWriterTests(unittest.TestCase):
         def _target_url_fixup(timeline):
             # fixes up relative paths to be absolute to this test file
             test_dir = os.path.dirname(os.path.abspath(__file__))
-            for clip in otio_timeline.each_clip():
+            for clip in timeline.each_clip():
                 target_url_str = clip.media_reference.target_url
                 clip.media_reference.target_url = os.path.join(test_dir, target_url_str)
 
@@ -833,6 +833,44 @@ class AAFWriterTests(unittest.TestCase):
         fd, tmp_aaf_path = tempfile.mkstemp(suffix='.aaf')
         otio.adapters.write_to_file(otio_timeline, tmp_aaf_path, use_empty_mob_ids=True)
         self._verify_aaf(tmp_aaf_path)
+
+    def test_aaf_roundtrip_firstClip(self):
+        def _target_url_fixup(timeline):
+            # fixes up relative paths to be absolute to this test file
+            test_dir = os.path.dirname(os.path.abspath(__file__))
+            for clip in timeline.each_clip():
+                target_url_str = clip.media_reference.target_url
+                clip.media_reference.target_url = os.path.join(test_dir, target_url_str)
+
+        # Exercise getting Mob IDs from AAF files
+        otio_timeline = otio.adapters.read_from_file(NO_METADATA_OTIO_PATH)
+        _target_url_fixup(otio_timeline)
+        fd, tmp_aaf_path = tempfile.mkstemp(suffix='.aaf')
+        otio.adapters.write_to_file(otio_timeline, tmp_aaf_path)
+        self._verify_firstClip(otio_timeline, tmp_aaf_path)
+
+    def _verify_firstClip(self, original_timeline, aaf_path):
+        timeline_from_aaf = otio.adapters.read_from_file(aaf_path)
+
+        original_clips = list(original_timeline.each_clip())
+        aaf_clips = list(timeline_from_aaf.each_clip())
+
+        self.assertTrue(len(original_clips) > 0)
+        self.assertTrue(len(aaf_clips) > 0)
+
+        first_clip_in_original_timeline = original_clips[0]
+        first_clip_in_aaf_timeline = aaf_clips[0]
+
+        # Comparing stuff
+        for prop in ['source_range']:
+            self.assertEqual(getattr(first_clip_in_original_timeline, prop),
+                             getattr(first_clip_in_aaf_timeline, prop),
+                             "`{}` did not match".format(prop))
+
+        for method in ['visible_range', 'trimmed_range']:
+            self.assertEqual(getattr(first_clip_in_original_timeline, method)(),
+                             getattr(first_clip_in_aaf_timeline, method)(),
+                             "`{}` did not match".format(method))
 
     def test_aaf_writer_nesting(self):
         self._verify_aaf(NESTING_EXAMPLE_PATH)

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -834,7 +834,7 @@ class AAFWriterTests(unittest.TestCase):
         otio.adapters.write_to_file(otio_timeline, tmp_aaf_path, use_empty_mob_ids=True)
         self._verify_aaf(tmp_aaf_path)
 
-    def test_aaf_roundtrip_firstClip(self):
+    def test_aaf_roundtrip_first_clip(self):
         def _target_url_fixup(timeline):
             # fixes up relative paths to be absolute to this test file
             test_dir = os.path.dirname(os.path.abspath(__file__))

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -847,7 +847,7 @@ class AAFWriterTests(unittest.TestCase):
         _target_url_fixup(otio_timeline)
         fd, tmp_aaf_path = tempfile.mkstemp(suffix='.aaf')
         otio.adapters.write_to_file(otio_timeline, tmp_aaf_path)
-        self._verify_firstClip(otio_timeline, tmp_aaf_path)
+        self._verify_first_clip(otio_timeline, tmp_aaf_path)
 
     def _verify_first_clip(self, original_timeline, aaf_path):
         timeline_from_aaf = otio.adapters.read_from_file(aaf_path)


### PR DESCRIPTION
Without this, the resulting AAF always use the full available media of a clip even the start_time in source_range has different value than that of availabe_range.

I will make a test case for this fix.