### PR TITLE
Make sure OpenTimelineIO is on the pythonpath in the rv adapter

### DIFF
--- a/opentimelineio_contrib/adapters/rv.py
+++ b/opentimelineio_contrib/adapters/rv.py
@@ -52,7 +52,12 @@ def write_to_file(input_otio, filepath):
         os.pathsep.join(
             [
                 base_environment.setdefault('PYTHONPATH', ''),
-                os.path.dirname(__file__)
+
+                # add extern_rv.py to the path
+                os.path.dirname(__file__),
+
+                # add OpenTimelineIO to the python
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
             ]
         )
     )


### PR DESCRIPTION
In extern_rv, find the path to the OpenTimelineIO directory and add it to the path in case it isn't through pythonpath.  In the case of a virtual the site-packages is how it gets found.

I'm not 100% sure we want to do this.  Any thoughts from the community?