### PR TITLE
Add function to explicitly load SchemaDef plugins

### DIFF
--- a/docs/tutorials/write-a-schemadef.md
+++ b/docs/tutorials/write-a-schemadef.md
@@ -91,8 +91,20 @@ Then you need to add this manifest to your `$OTIO_PLUGIN_MANIFEST_PATH` environm
 
 Now that we've defined a new otio schema, how can we create an instance of the
 schema class in our code (for instance, in an adapter or media linker)?
-SchemaDef plugins are magically loaded into a namespace called ``otio.schemadef``,
-so you can create a class instance just like this:
+
+SchemaDef plugins are loaded in a deferred way.  The load is triggered either
+by reading a file that contains the schema or by manually asking the plugin for
+its module object.  For example, if you have a `my_thing` schemadef module:
+
+```python
+import opentimelineio as otio
+
+my_thing = otio.schema.schemadef.module_from_name('my_thing')
+```
+
+Once the plugin has been loaded, SchemaDef plugin modules are magically inserted 
+into a namespace called ``otio.schemadef``, so you can create a class instance 
+just like this:
 
 ```
 import opentimelineio as otio

--- a/opentimelineio/schema/schemadef.py
+++ b/opentimelineio/schema/schemadef.py
@@ -42,7 +42,7 @@ def available_schemadef_names():
 
 
 def from_name(name):
-    """Fetch the schemadef object by the name of the schema directly."""
+    """Fetch the schemadef plugin object by the name of the schema directly."""
 
     try:
         return plugins.ActiveManifest().from_name(name, kind_list="schemadefs")
@@ -53,3 +53,13 @@ def from_name(name):
                 available_schemadef_names()
             )
         )
+
+
+def module_from_name(name):
+    """Fetch the plugin's module by the name of the schemadef.
+
+    Will load the plugin if it has not already been loaded.  Reading a file that
+    contains the schemadef will also trigger a load of the plugin.
+    """
+    plugin = from_name(name)
+    return plugin.module()


### PR DESCRIPTION
- Currently, schemadefs are only loaded implicitly, either by reading a file that contains the schemadef or by calling `ActiveManifest()` or `otio.schema.schemadef.from_name().module()`.
- This PR adds a function `otio.schema.schemadef.module_from_name()` that makes it easy to explicitly load a plugin.
- This also clarifies the unit tests around how schemadefs get loaded and adds some documentation about how to use this function.