### PR TITLE
AAF Writer: Making precheck() more robust

### DIFF
--- a/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
+++ b/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
@@ -184,13 +184,10 @@ def validate_metadata(timeline):
             checks = [
                 _check(child, "duration().rate").equals(edit_rate),
                 _check(child, "metadata['AAF']['PointList']"),
-                _check(
-                    child,
-                    "metadata['AAF']['OperationGroup']"
-                    "['Operation']['DataDefinition']['Name']"),
-                _check(
-                    child,
-                    "metadata['AAF']['OperationGroup']['Operation']['Description']"),
+                _check(child, "metadata['AAF']['OperationGroup']['Operation']"
+                       "['DataDefinition']['Name']"),
+                _check(child, "metadata['AAF']['OperationGroup']['Operation']"
+                       "['Description']"),
                 _check(child, "metadata['AAF']['OperationGroup']['Operation']['Name']"),
                 _check(child, "metadata['AAF']['CutPoint']")
             ]

--- a/opentimelineio_contrib/adapters/tests/sample_data/precheckfail.otio
+++ b/opentimelineio_contrib/adapters/tests/sample_data/precheckfail.otio
@@ -1,0 +1,234 @@
+{
+    "OTIO_SCHEMA": "Timeline.1",
+    "global_start_time": {
+        "OTIO_SCHEMA": "RationalTime.1",
+        "rate": 24.0,
+        "value": 86400
+    },
+    "metadata": {
+        "AAF": {
+            "ClassName": "CompositionMob",
+            "CreationTime": "2019-03-29 18:55:55",
+            "LastModified": "2019-03-29 18:55:14",
+            "MobAttributeList": {
+                "AudioPluginWindowTrack": 1,
+                "PRJ_BOUNDARY_FRAMES": 1,
+                "SEQUERNCE_FORMAT_STRING": "HD 1080p/24",
+                "SEQUERNCE_FORMAT_TYPE": 10,
+                "_IMAGE_BOUNDS_OVERRIDE": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><Bounds>  <Source>-800/1 -450/1 1600/1 900/1</Source></Bounds>",
+                "_USER_POS": 10,
+                "_VERSION": 2
+            },
+            "MobID": "urn:smpte:umid:060a2b34.01010101.01010f00.13000000.060e2b34.7f7f2a80.5c9e6a3b.ace913a2",
+            "Name": "OTIO_Test_ppjoshm1.Exported.01",
+            "Slots": {},
+            "UsageCode": "Usage_TopLevel"
+        }
+    },
+    "name": "OTIO_Test_ppjoshm1.Exported.01",
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1",
+        "children": [
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.1",
+                        "effects": [],
+                        "markers": [],
+                        "media_reference": {
+                            "OTIO_SCHEMA": "MissingReference.1",
+                            "available_range": null,
+                            "metadata": {
+                                "AAF": {
+                                    "ClassName": "MasterMob",
+                                    "ConvertFrameRate": false,
+                                    "CreationTime": "2019-03-29 18:52:18",
+                                    "LastModified": "2019-03-29 18:54:01",
+                                    "MobAttributeList": {
+                                        "_GEN": 1553885640,
+                                        "_IMPORTSETTING": "__AttributeList",
+                                        "_SAVED_AAF_AUDIO_LENGTH": 0,
+                                        "_SAVED_AAF_AUDIO_RATE_DEN": 1,
+                                        "_SAVED_AAF_AUDIO_RATE_NUM": 24,
+                                        "_USER_POS": 0,
+                                        "_VERSION": 2
+                                    },
+                                    "MobID": "urn:smpte:umid:060a2b34.01010101.01010f00.13000000.060e2b34.7f7f2a80.5c9e6962.cd005cc5",
+                                    "Name": "ppjoshm_1 (SIM1)",
+                                    "Slots": {}
+                                }
+                            },
+                            "name": null
+                        },
+                        "metadata": {
+                            "AAF": {
+                                "ClassName": "SourceClip",
+                                "ComponentAttributeList": {
+                                    "_IMAGE_BOUNDS_OVERRIDE": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><Bounds>  <Framing>-800/1 -450/1 1600/1 900/1</Framing>  <Valid>-800/1 -450/1 1600/1 900/1</Valid>  <Essence>-800/1 -450/1 1600/1 900/1</Essence>  <Source>-800/1 -450/1 1600/1 900/1</Source></Bounds>"
+                                },
+                                "DataDefinition": {
+                                    "Description": "Picture Essence",
+                                    "Identification": "01030202-0100-0000-060e-2b3404010101",
+                                    "Name": "Picture"
+                                },
+                                "Length": 10,
+                                "Name": "ppjoshm_1 (SIM1)",
+                                "SourceID": "urn:smpte:umid:060a2b34.01010101.01010f00.13000000.060e2b34.7f7f2a80.5c9e6962.cd005cc5",
+                                "SourceMobSlotID": 1,
+                                "StartTime": 0
+                            }
+                        },
+                        "name": "ppjoshm_1 (SIM1)",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 10
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 86501
+                            }
+                        }
+                    }
+                ],
+                "effects": [],
+                "kind": "Video",
+                "markers": [],
+                "metadata": {
+                    "AAF": {
+                        "ClassName": "TimelineMobSlot",
+                        "EditRate": "24",
+                        "MediaKind": "Picture",
+                        "Name": "TimelineMobSlot",
+                        "Origin": 0,
+                        "PhysicalTrackNumber": 1,
+                        "Segment": {
+                            "Components": {},
+                            "DataDefinition": {
+                                "Description": "Picture Essence",
+                                "Identification": "01030202-0100-0000-060e-2b3404010101",
+                                "Name": "Picture"
+                            },
+                            "Length": 10
+                        },
+                        "SlotID": 9,
+                        "SlotName": ""
+                    }
+                },
+                "name": "TimelineMobSlot",
+                "source_range": null
+            },
+            {
+                "OTIO_SCHEMA": "Track.1",
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.1",
+                        "effects": [],
+                        "markers": [],
+                        "media_reference": {
+                            "OTIO_SCHEMA": "MissingReference.1",
+                            "available_range": {
+                                "OTIO_SCHEMA": "TimeRange.1",
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 48.0,
+                                    "value": 10
+                                },
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 48.0,
+                                    "value": 0
+                                }
+                            },
+                            "metadata": {
+                                "AAF": {
+                                    "ClassName": "MasterMob",
+                                    "ConvertFrameRate": false,
+                                    "CreationTime": "2019-03-29 18:52:18",
+                                    "LastModified": "2019-03-29 18:54:01",
+                                    "MobAttributeList": {
+                                        "_GEN": 1553885640,
+                                        "_IMPORTSETTING": "__AttributeList",
+                                        "_SAVED_AAF_AUDIO_LENGTH": 0,
+                                        "_SAVED_AAF_AUDIO_RATE_DEN": 1,
+                                        "_SAVED_AAF_AUDIO_RATE_NUM": 24,
+                                        "_USER_POS": 0,
+                                        "_VERSION": 2
+                                    },
+                                    "MobID": "urn:smpte:umid:060a2b34.01010101.01010f00.13000000.060e2b34.7f7f2a80.5c9e6962.cd005cc5",
+                                    "Name": "ppjoshm_1 (SIM1)",
+                                    "Slots": {}
+                                }
+                            },
+                            "name": null
+                        },
+                        "metadata": {
+                            "AAF": {
+                                "ClassName": "SourceClip",
+                                "DataDefinition": {
+                                    "Description": "Sound Essence",
+                                    "Identification": "01030202-0200-0000-060e-2b3404010101",
+                                    "Name": "Sound"
+                                },
+                                "Length": 10,
+                                "Name": "ppjoshm_1 (SIM1)",
+                                "SourceID": "urn:smpte:umid:060a2b34.01010101.01010f00.13000000.060e2b34.7f7f2a80.5c9e6962.cd005cc5",
+                                "SourceMobSlotID": 2,
+                                "StartTime": 0
+                            }
+                        },
+                        "name": "ppjoshm_1 (SIM1)",
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1",
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 10
+                            },
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1",
+                                "rate": 24.0,
+                                "value": 0
+                            }
+                        }
+                    }
+                ],
+                "effects": [],
+                "kind": "Audio",
+                "markers": [],
+                "metadata": {
+                    "AAF": {
+                        "ClassName": "TimelineMobSlot",
+                        "EditRate": "24",
+                        "MediaKind": "Sound",
+                        "Name": "TimelineMobSlot",
+                        "Origin": 0,
+                        "PhysicalTrackNumber": 1,
+                        "Segment": {
+                            "Components": {},
+                            "DataDefinition": {
+                                "Description": "Sound Essence",
+                                "Identification": "01030202-0200-0000-060e-2b3404010101",
+                                "Name": "Sound"
+                            },
+                            "Length": 10
+                        },
+                        "SlotID": 10,
+                        "SlotName": ""
+                    }
+                },
+                "name": "TimelineMobSlot",
+                "source_range": null
+            }
+        ],
+        "effects": [],
+        "markers": [],
+        "metadata": {},
+        "name": "tracks",
+        "source_range": null
+    }
+}

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -853,7 +853,7 @@ class AAFWriterTests(unittest.TestCase):
             otio.adapters.write_to_file(otio_timeline, tmp_aaf_path)
         except AAFValidationError as e:
             # Four error messages are raised
-            self.assertEqual(4, len(filter(bool, e.message.split("\n"))))
+            self.assertEqual(4, len(filter(bool, str(e).split("\n"))))
             with self.assertRaises(AAFValidationError):
                 raise e
 

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -32,7 +32,10 @@ import unittest
 import tempfile
 
 import opentimelineio as otio
-from opentimelineio_contrib.adapters.aaf_adapter.aaf_writer import AAFAdapterError
+from opentimelineio_contrib.adapters.aaf_adapter.aaf_writer import (
+    AAFAdapterError,
+    AAFValidationError
+)
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SIMPLE_EXAMPLE_PATH = os.path.join(
@@ -70,6 +73,10 @@ NESTING_PREFLATTENED_EXAMPLE_PATH = os.path.join(
 MISC_SPEED_EFFECTS_EXAMPLE_PATH = os.path.join(
     SAMPLE_DATA_DIR,
     "misc_speed_effects.aaf"
+)
+PRECHECK_FAIL_OTIO = os.path.join(
+    SAMPLE_DATA_DIR,
+    "precheckfail.otio"
 )
 LINEAR_SPEED_EFFECTS_EXAMPLE_PATH = os.path.join(
     SAMPLE_DATA_DIR,
@@ -837,6 +844,18 @@ class AAFWriterTests(unittest.TestCase):
         fd, tmp_aaf_path = tempfile.mkstemp(suffix='.aaf')
         otio.adapters.write_to_file(otio_timeline, tmp_aaf_path, use_empty_mob_ids=True)
         self._verify_aaf(tmp_aaf_path)
+
+    def test_fail_on_precheck(self):
+        # Expect exception to raise on null available_range and rate mismatch
+        otio_timeline = otio.adapters.read_from_file(PRECHECK_FAIL_OTIO)
+        fd, tmp_aaf_path = tempfile.mkstemp(suffix='.aaf')
+        try:
+            otio.adapters.write_to_file(otio_timeline, tmp_aaf_path)
+        except AAFValidationError as e:
+            # Four error messages are raised
+            self.assertEqual(4, len(filter(bool, e.message.split("\n"))))
+            with self.assertRaises(AAFValidationError):
+                raise e
 
     def test_aaf_roundtrip_first_clip(self):
         def _target_url_fixup(timeline):

--- a/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -853,7 +853,7 @@ class AAFWriterTests(unittest.TestCase):
             otio.adapters.write_to_file(otio_timeline, tmp_aaf_path)
         except AAFValidationError as e:
             # Four error messages are raised
-            self.assertEqual(4, len(filter(bool, str(e).split("\n"))))
+            self.assertEqual(4, len(list(filter(bool, str(e).split("\n")))))
             with self.assertRaises(AAFValidationError):
                 raise e
 


### PR DESCRIPTION
This addresses #484 (not fixing it, but making the failure more elegant).

The validate_metadata() function requires access and verification of certain fields in objects that may or not be there. I thought that using a "promise" like pattern led to a much more elegant, robust result. Hopefully this isn't too much overkill, it does allow our precheck to be a lot more expressive.