### PR TITLE
AAF Reader: simplify source_range and available_range in transcribe() of SourceClip

### DIFF
--- a/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -260,16 +260,22 @@ def _transcribe(item, parents, editRate, masterMobs):
             media_start, media_length = timecode_info
             source_start += media_start
 
+        # The goal here is to find a source range. Actual editorial opinions are found on SourceClips in the
+        # CompositionMobs. To figure out whether this clip is directly in the CompositionMob, we detect if our
+        # parent mobs are only CompositionMobs. If they were anything else - a MasterMob, a SourceMob, we would
+        # know that this is in some indirect relationship.
         parent_mobs = filter(lambda parent: isinstance(parent, aaf2.mobs.Mob), parents)
         is_directly_in_composition = all(isinstance(mob, aaf2.mobs.CompositionMob) for mob in parent_mobs)
-
         if is_directly_in_composition:
-            # A SourceClip in the CompositioMob is an actual edited opinion and has a sourc
             result.source_range = otio.opentime.TimeRange(
                 otio.opentime.RationalTime(source_start, editRate),
                 otio.opentime.RationalTime(source_length, editRate)
             )
 
+        # The goal here is to find an available range. Media ranges are stored in the related MasterMob, and there
+        # should only be one - hence the name "Master" mob. Somewhere down our chain (either a child or our parents)
+        # is a MasterMob. For SourceClips in the CompositionMob, it is our child. For everything else, it is a
+        # previously encountered parent. Find the MasterMob in our chain, and then extract the information from that.
         child_mastermob = item.mob if isinstance(item.mob, aaf2.mobs.MasterMob) else None
         parent_mastermobs = [parent for parent in parents if isinstance(parent, aaf2.mobs.MasterMob)]
         parent_mastermob = parent_mastermobs[0] if len(parent_mastermobs) > 1 else None


### PR DESCRIPTION
During _transcribe(), we store just one parent. This is great, but it would be even better to have the entire parent chain available - both for debugging and perhaps for logic. I believe there is at least one if statement which really wants to say "am I a clip in the CompositionMob", which would now be made a lot easier by this change.