### PR TITLE
FCP XML: Adds a check on the NTSC element before reading its value

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -205,7 +205,8 @@ def _rate_for_element(element):
     """
     # rate is encoded as a timebase (int) which can be drop-frame
     base = float(element.find("./timebase").text)
-    if _bool_value(element.find("./ntsc")):
+    ntsc = element.find("./ntsc")
+    if ntsc is not None and _bool_value(ntsc):
         base *= 1000.0 / 1001
 
     return base

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -225,6 +225,18 @@ class TestFcp7XmlUtilities(unittest.TestCase, test_utils.OTIOAssertions):
 
         self.assertEqual(rate, 30)
 
+    def test_rate_for_element_no_ntsc(self):
+        rate_element = cElementTree.fromstring(
+            """
+            <rate>
+                <timebase>30</timebase>
+            </rate>
+            """
+        )
+        rate = self.adapter._rate_for_element(rate_element)
+
+        self.assertEqual(rate, 30)
+
     def test_rate_from_context(self):
         sequence_elem = cElementTree.fromstring(
             """


### PR DESCRIPTION
Some softwares don't add the `<NTSC>` element to the `<rate>` element if the framerate
is not NTSC. Check if the element can be found before trying to
check it's value.