### PR TITLE
Necessary name change to match the target name in CMakeLists.txt

### DIFF
--- a/src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp
@@ -1,7 +1,7 @@
 #include <pybind11/pybind11.h>
 #include "opentime_bindings.h"
 
-PYBIND11_MODULE(_opentime, m) {
+PYBIND11_MODULE(__opentime, m) {
     m.doc() = "Bindings to C++ OTIO implementation";
     opentime_rationalTime_bindings(m);
     opentime_timeRange_bindings(m);

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -42,12 +42,12 @@ static bool register_upgrade_function(std::string const& schema_name,
                                       py::object const& upgrade_function_obj) {
     std::function<void (AnyDictionary* d)> upgrade_function =  [upgrade_function_obj](AnyDictionary* d) {
         py::gil_scoped_acquire acquire;
-        
+
         auto ptr = d->get_or_create_mutation_stamp();
         py::object dobj = py::cast((AnyDictionaryProxy*)ptr);
         upgrade_function_obj(dobj);
     };
-    
+
     return TypeRegistry::instance().register_upgrade_function(schema_name, version_to_upgrade_to,
                                                              upgrade_function);
 }
@@ -64,7 +64,7 @@ static SerializableObject* instance_from_schema(std::string schema_name,
     return result;
 }
 
-PYBIND11_MODULE(_otio, m) {
+PYBIND11_MODULE(__otio, m) {
     m.doc() = "Bindings to C++ OTIO implementation";
     otio_exception_bindings(m);
     otio_any_dictionary_bindings(m);
@@ -123,7 +123,7 @@ PYBIND11_MODULE(_otio, m) {
         }, "in_stack"_a);
     m.def("flatten_stack", [](py::object tracks) {
             return flatten_stack(py_to_vector<Track*>(tracks), ErrorStatusHandler());
-        }, "tracks"_a);        
+        }, "tracks"_a);
 
     void _build_any_to_py_dispatch_table();
     _build_any_to_py_dispatch_table();


### PR DESCRIPTION
Would it be possible to change the name of the binding to the name of the target?