### PR TITLE
move to relative imports for fetching names from the C++ code.

### DIFF
--- a/src/py-opentimelineio/opentimelineio/core/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/core/__init__.py
@@ -1,10 +1,38 @@
-from opentimelineio._otio import *
-from opentimelineio._otio import _testing
-from opentimelineio import _otio
+from .. import _otio
+from .. _otio import _testing
 
-from . _core_utils import (add_method, _value_to_any, _value_to_so_vector,
-                          _add_mutable_mapping_methods, _add_mutable_sequence_methods)
-from . import mediaReference, composition, composable, item
+from .. _otio import (
+    SerializableObject,
+    register_serializable_object_type,
+    SerializableObjectWithMetadata,
+    deserialize_json_from_file,
+    deserialize_json_from_string,
+    set_type_record,
+    CannotComputeAvailableRangeError,
+    Composable,
+    Composition,
+    instance_from_schema,
+    flatten_stack,
+    install_external_keepalive_monitor,
+    register_upgrade_function,
+    Item,
+    MediaReference,
+    Track,
+)
+
+from . _core_utils import (
+    add_method,
+    _value_to_any,
+    _value_to_so_vector,
+    _add_mutable_mapping_methods,
+    _add_mutable_sequence_methods
+)
+from . import (
+    mediaReference,
+    composition,
+    composable,
+    item
+)
 
 def serialize_json_to_string(root, indent=4):
     return _otio._serialize_json_to_string(_value_to_any(root), indent)

--- a/src/py-opentimelineio/opentimelineio/core/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/core/__init__.py
@@ -1,23 +1,27 @@
-from .. import _otio
-from .. _otio import _testing
-
 from .. _otio import (
-    SerializableObject,
-    register_serializable_object_type,
-    SerializableObjectWithMetadata,
-    deserialize_json_from_file,
-    deserialize_json_from_string,
-    set_type_record,
+    # errors
     CannotComputeAvailableRangeError,
+
+    # classes
     Composable,
     Composition,
-    instance_from_schema,
-    flatten_stack,
-    install_external_keepalive_monitor,
-    register_upgrade_function,
     Item,
     MediaReference,
+    SerializableObject,
+    SerializableObjectWithMetadata,
     Track,
+
+    # functions
+    deserialize_json_from_file,
+    deserialize_json_from_string,
+    flatten_stack,
+    install_external_keepalive_monitor,
+    instance_from_schema,
+    register_serializable_object_type,
+    register_upgrade_function,
+    set_type_record,
+    _serialize_json_to_string,
+    _serialize_json_to_file,
 )
 
 from . _core_utils import (
@@ -25,20 +29,20 @@ from . _core_utils import (
     _value_to_any,
     _value_to_so_vector,
     _add_mutable_mapping_methods,
-    _add_mutable_sequence_methods
+    _add_mutable_sequence_methods,
 )
 from . import (
     mediaReference,
     composition,
     composable,
-    item
+    item,
 )
 
 def serialize_json_to_string(root, indent=4):
-    return _otio._serialize_json_to_string(_value_to_any(root), indent)
+    return _serialize_json_to_string(_value_to_any(root), indent)
     
 def serialize_json_to_file(root, filename, indent=4):
-    return _otio._serialize_json_to_file(_value_to_any(root), filename, indent)
+    return _serialize_json_to_file(_value_to_any(root), filename, indent)
 
 def register_type(classobj, schemaname=None):
     label = classobj._serializable_label

--- a/src/py-opentimelineio/opentimelineio/core/composable.py
+++ b/src/py-opentimelineio/opentimelineio/core/composable.py
@@ -1,5 +1,5 @@
 from . _core_utils import add_method
-from opentimelineio import _otio
+from .. import _otio
 
 @add_method(_otio.Composable)
 def __repr__(self):

--- a/src/py-opentimelineio/opentimelineio/core/composition.py
+++ b/src/py-opentimelineio/opentimelineio/core/composition.py
@@ -1,5 +1,5 @@
 from . _core_utils import add_method
-from opentimelineio import _otio
+from .. import _otio
 
 @add_method(_otio.Composition)
 def __str__(self):

--- a/src/py-opentimelineio/opentimelineio/core/item.py
+++ b/src/py-opentimelineio/opentimelineio/core/item.py
@@ -1,5 +1,5 @@
 from . _core_utils import add_method
-from opentimelineio import _otio
+from .. import _otio
 
 @add_method(_otio.Item)
 def __str__(self):

--- a/src/py-opentimelineio/opentimelineio/core/mediaReference.py
+++ b/src/py-opentimelineio/opentimelineio/core/mediaReference.py
@@ -1,5 +1,5 @@
 from . _core_utils import add_method
-from opentimelineio import _otio
+from .. import _otio
 
 @add_method(_otio.MediaReference)
 def __str__(self):

--- a/src/py-opentimelineio/opentimelineio/opentime.py
+++ b/src/py-opentimelineio/opentimelineio/opentime.py
@@ -1,5 +1,8 @@
-from . _opentime import *
-from . _opentime import _testing
+from . _opentime import (
+    RationalTime,
+    TimeRange,
+    TimeTransform,
+)
 
 from_frames = RationalTime.from_frames
 from_timecode = RationalTime.from_timecode

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -26,33 +26,45 @@
 
 """User facing classes."""
 
-from opentimelineio._otio import (Clip, Effect, TimeEffect, LinearTimeWarp,
-                                          ExternalReference, FreezeFrame, Gap, GeneratorReference, Marker,
-                                          MissingReference, SerializableCollection,
-                                          Stack, Timeline, Track, Transition)
-from opentimelineio import core
-MarkerColor = core._otio.Marker.Color
-TrackKind = core._otio.Track.Kind
-TransitionTypes = core._otio.Transition.Type
-NeighborGapPolicy = core._otio.Track.NeighborGapPolicy
+from .. _otio import (
+    Clip,
+    Effect,
+    TimeEffect,
+    LinearTimeWarp,
+    ExternalReference,
+    FreezeFrame,
+    Gap,
+    GeneratorReference,
+    Marker,
+    MissingReference,
+    SerializableCollection,
+    Stack,
+    Timeline,
+    Track,
+    Transition
+)
 
-from .schemadef import (
+MarkerColor = Marker.Color
+TrackKind = Track.Kind
+TransitionTypes = Transition.Type
+NeighborGapPolicy = Track.NeighborGapPolicy
+
+from . schemadef import (
     SchemaDef
 )
 
-from .foo import Foo
-from . import (clip, effect, external_reference,
-               generator_reference, marker,
-               serializable_collection,
-               stack, timeline, track,
-               transition)
+from . import (
+    clip, effect, external_reference,
+    generator_reference, marker,
+    serializable_collection,
+    stack, timeline, track,
+    transition
+)
 
 track.TrackKind = TrackKind
 
 def timeline_from_clips(clips):
     """Convenience for making a single track timeline from a list of clips."""
 
-    trck = core._otio.Track(children=clips)
-    return core._otio.Timeline(tracks=[trck])
-
-
+    trck = Track(children=clips)
+    return Timeline(tracks=[trck])

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -150,7 +150,12 @@ class TestTime(unittest.TestCase):
         )
 
         step_time = otio.opentime.RationalTime(value=1, rate=24)
-        cumulative_time = otio.opentime._testing.add_many(step_time, final_frame_number)
+
+        # fetching this test function from the c++ module directly
+        cumulative_time = otio._opentime._testing.add_many(
+            step_time,
+            final_frame_number
+        )
         self.assertEqual(cumulative_time, final_time)
 
         # Adding by a non-multiple of 24
@@ -393,7 +398,11 @@ class TestTime(unittest.TestCase):
         )
 
         step_time = otio.opentime.RationalTime(value=1, rate=24)
-        cumulative_time = otio.opentime._testing.add_many(step_time, final_frame_number)
+        cumulative_time = otio._opentime._testing.add_many(
+            step_time,
+            final_frame_number
+        )
+
         self.assertTrue(cumulative_time.almost_equal(final_time, delta=0.001))
 
         # Adding by a non-multiple of 24


### PR DESCRIPTION
Currently the C++ branch uses `from opentimelineio import _otio` to fetch the C++ modules.  This moves to using relative imports.