### PR TITLE
fcpx: Decode output of ffprobe before using it as string

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
+++ b/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
@@ -83,7 +83,7 @@ def format_name(frame_rate, path):
                 "csv=s=x:p=0",
                 path
             ]
-        )
+        ).decode("utf-8")
     except (subprocess.CalledProcessError, OSError):
         frame_size = ""
 

--- a/contrib/opentimelineio_contrib/adapters/tests/test_fcpx_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_fcpx_adapter.py
@@ -1,7 +1,23 @@
 import os
+import subprocess
+import sys
 import unittest
 import opentimelineio as otio
 import opentimelineio.test_utils as otio_test_utils
+from opentimelineio_contrib.adapters.fcpx_xml import format_name
+
+try:
+    # Python 3.3 forward includes the mock module
+    from unittest import mock
+    could_import_mock = True
+except ImportError:
+    # Fallback for older python (not included in standard library)
+    try:
+        import mock
+        could_import_mock = True
+    except ImportError:
+        # Mock appears to not be installed
+        could_import_mock = False
 
 SAMPLE_LIBRARY_XML = os.path.join(
     os.path.dirname(__file__),
@@ -152,6 +168,17 @@ class AdaptersFcpXXmlTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         new_timeline = otio.adapters.read_from_string(fcpx_xml, "fcpx_xml")
         self.assertJsonEqual(container, new_timeline)
+
+    @unittest.skipIf(
+        not could_import_mock,
+        "mock module not found. Install mock from pypi or use python >= 3.3."
+    )
+    def test_format_name(self):
+        rvalue = subprocess.check_output([sys.executable, '-c', 'print("640x360")'])
+        with mock.patch.object(subprocess, 'check_output', return_value=rvalue):
+            with mock.patch.object(os.path, 'exists', return_value=True):
+                self.assertEqual(format_name(
+                    25, "file:///dummy.me"), 'FFVideoFormat640x360p25')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Getting this stack trace otherwise:

```
Traceback (most recent call last):
  File "gesotioformatter.py", line 44, in do_save_to_uri
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio/adapters/__init__.py", line 194, in write_to_file
    **adapter_argument_map
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio/adapters/adapter.py", line 179, in write_to_file
    result = self.write_to_string(input_otio, **adapter_argument_map)
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio/adapters/adapter.py", line 243, in write_to_string
    **adapter_argument_map
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio/plugins/python_plugin.py", line 128, in _execute_function
    return (getattr(self.module(), func_name)(**kwargs))
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 1182, in write_to_string
    return FcpxOtio(input_otio).to_xml()
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 193, in to_xml
    top_sequence = self._stack_to_sequence(project.tracks)
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 265, in _stack_to_sequence
    self._track_for_spine(track, idx, spine, compound_clip)
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 279, in _track_for_spine
    compound=compound
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 379, in _element_for_item
    asset_id = self._add_asset(item, compound_only=compound)
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 560, in _add_asset
    format_element = self._find_or_create_format_from(clip)
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 556, in _find_or_create_format_from
    format_element.set("name", self._clip_format_name(clip))
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 537, in _clip_format_name
    clip.media_reference.target_url
  File "/home/thiblahute/devel/gstreamer/gst-build/subprojects/OpenTimelineIO/opentimelineio_contrib/adapters/fcpx_xml.py", line 95, in format_name
    if "1920" in frame_size:
TypeError: a bytes-like object is required, not 'str'
```