### PR TITLE
Clean up auto-docstrings.

### DIFF
--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -221,12 +221,9 @@ parameters:
 ```
 
 parameters:
-- *offset*: Represents an instantaneous point in time, value * (1/rate) seconds
-from time 0seconds.
-- *rate*: None
-- *scale*: float(x) -> floating point number
-
-Convert a string or number to a floating point number, if possible.
+- *offset*: 
+- *rate*: 
+- *scale*: 
 
 ## Module: opentimelineio.plugins
 

--- a/opentimelineio/console/autogen_serialized_datamodel.py
+++ b/opentimelineio/console/autogen_serialized_datamodel.py
@@ -107,7 +107,7 @@ PROP_HEADER_NO_HELP = """- *{propkey}*
 PROP_FETCHERS = (
     lambda cl, k: inspect.getdoc(getattr(cl, k)),
     lambda cl, k: inspect.getdoc(getattr(cl, "_" + k)),
-    lambda cl, k: inspect.getdoc(getattr(cl(), k)),
+    lambda cl, k: inspect.getdoc(getattr(cl(), k)) and "" or "",
 )
 
 


### PR DESCRIPTION
Docstrings for attributes in python don't really exist.  Instead of
fetching them, the autodoc generator now just uses "" as the docstring
for properties that it has to read off the instantiated object.