### PR TITLE
#551 AAF Adapter creates ExternalReference for UNC Path

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -298,13 +298,20 @@ def _transcribe(item, parents, editRate, masterMobs):
         mastermob = child_mastermob or parent_mastermob or None
 
         if mastermob:
-            media = otio.schema.MissingReference()
+            mastermob_child = masterMobs.get(str(mastermob.mob_id))
+            unc_path = (mastermob_child.metadata.get("AAF", {})
+                                                .get("UserComments", {})
+                                                .get("UNC Path"))
+            if unc_path:
+                media = otio.schema.ExternalReference()
+                media.target_url = "file://" + unc_path.replace("\\", "/")
+            else:
+                media = otio.schema.MissingReference()
             media.available_range = otio.opentime.TimeRange(
                 otio.opentime.RationalTime(media_start, editRate),
                 otio.opentime.RationalTime(media_length, editRate)
             )
             # copy the metadata from the master into the media_reference
-            mastermob_child = masterMobs.get(str(mastermob.mob_id))
             media.metadata["AAF"] = mastermob_child.metadata.get("AAF", {})
             result.media_reference = media
 

--- a/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -832,6 +832,22 @@ class AAFReaderTests(unittest.TestCase):
         self.assertIsInstance(result, otio.schema.SerializableCollection)
         self.assertEqual(2, len(result))
 
+    def test_external_reference_from_unc_path(self):
+        timeline = otio.adapters.read_from_file(SIMPLE_EXAMPLE_PATH)
+        video_track = timeline.video_tracks()[0]
+        first_clip = video_track[0]
+        self.assertIsInstance(first_clip.media_reference,
+                              otio.schema.ExternalReference)
+
+        unc_path = first_clip.media_reference.metadata.get("AAF", {}) \
+                                                      .get("UserComments", {}) \
+                                                      .get("UNC Path")
+        unc_path = "file://" + unc_path
+        self.assertEqual(
+            first_clip.media_reference.target_url,
+            unc_path
+        )
+
 
 class AAFWriterTests(unittest.TestCase):
     def test_aaf_writer_gaps(self):


### PR DESCRIPTION
Moved from a closed PR (had trouble with the cxx-to-master rebase). Unittest added. Sorry for any confusion.