### PR TITLE
xges: schemas

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/contrib_adapters.plugin_manifest.json
+++ b/contrib/opentimelineio_contrib/adapters/contrib_adapters.plugin_manifest.json
@@ -57,5 +57,13 @@
             "filepath": "xges.py",
             "suffixes": ["xges"]
         }
+    ],
+    "schemadefs" : [
+        {
+            "OTIO_SCHEMA" : "SchemaDef.1",
+            "name" : "xges",
+            "execution_scope" : "in process",
+            "filepath" : "xges.py"
+        }
     ]
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
@@ -25,12 +25,26 @@
 import os
 import tempfile
 import unittest
+from fractions import Fraction
 
 import opentimelineio as otio
 import opentimelineio.test_utils as otio_test_utils
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 XGES_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "xges_example.xges")
+
+SCHEMA = otio.schema.schemadef.module_from_name("xges")
+# TODO: remove once python2 has ended:
+# (problem is that python2 needs a source code encoding
+# definition to include utf8 text!!!)
+if str is bytes:
+    UTF8_NAME = 'Ri"\',;=)(+9@{\xcf\x93\xe7\xb7\xb6\xe2\x98\xba'\
+        '\xef\xb8\x8f  l\xd1\xa6\xf1\xbd\x9a\xbb\xf1\xa6\x84\x83  \\'
+else:
+    UTF8_NAME = str(
+        b'Ri"\',;=)(+9@{\xcf\x93\xe7\xb7\xb6\xe2\x98\xba\xef\xb8'
+        b'\x8f  l\xd1\xa6\xf1\xbd\x9a\xbb\xf1\xa6\x84\x83  \\',
+        encoding="utf8")
 
 
 class AdaptersXGESTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
@@ -51,6 +65,93 @@ class AdaptersXGESTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(len(video_tracks), 3)
         self.assertEqual(len(audio_tracks), 3)
+
+    def test_XgesTrack(self):
+        vid = SCHEMA.XgesTrack.\
+            new_from_otio_track_kind(otio.schema.TrackKind.Video)
+        self.assertEqual(vid.track_type, 4)
+        aud = SCHEMA.XgesTrack.\
+            new_from_otio_track_kind(otio.schema.TrackKind.Audio)
+        self.assertEqual(aud.track_type, 2)
+
+    def test_serialize_string(self):
+        serialize = SCHEMA.GstStructure.serialize_string(UTF8_NAME)
+        deserialize = SCHEMA.GstStructure.deserialize_string(serialize)
+        self.assertEqual(deserialize, UTF8_NAME)
+
+    def test_GstStructure_parsing(self):
+        struct = SCHEMA.GstStructure(
+            " properties  , String-1 = ( string ) test , "
+            "String-2=(string)\"test\", String-3= (  string) {}  , "
+            "Int  =(int) -5  , Uint =(uint) 5 , Float-1=(float)0.5, "
+            "Float-2= (float  ) 2, Boolean-1 =(boolean  ) true, "
+            "Boolean-2=(boolean)No, Boolean-3=( boolean) 0  ,   "
+            "Fraction=(fraction) 2/5 ; hidden!!!".format(
+                SCHEMA.GstStructure.serialize_string(UTF8_NAME))
+        )
+        self.assertEqual(struct.name, "properties")
+        self.assertEqual(struct["String-1"], "test")
+        self.assertEqual(struct["String-2"], "test")
+        self.assertEqual(struct["String-3"], UTF8_NAME)
+        self.assertEqual(struct["Int"], -5)
+        self.assertEqual(struct["Uint"], 5)
+        self.assertEqual(struct["Float-1"], 0.5)
+        self.assertEqual(struct["Float-2"], 2.0)
+        self.assertEqual(struct["Boolean-1"], True)
+        self.assertEqual(struct["Boolean-2"], False)
+        self.assertEqual(struct["Boolean-3"], False)
+        self.assertEqual(struct["Fraction"], "2/5")
+
+    def test_GstStructure_dictionary_def(self):
+        struct = SCHEMA.GstStructure(
+            "properties", {
+                "String-1": ("string", "test"),
+                "String-2": ("string", "test space"),
+                "Int": ("int", -5),
+                "Uint": ("uint", 5),
+                "Float": ("float", 2.0),
+                "Boolean": ("boolean", True),
+                "Fraction": ("fraction", "2/5")
+            }
+        )
+        self.assertEqual(struct.name, "properties")
+        write = str(struct)
+        self.assertIn("String-1=(string)test", write)
+        self.assertIn("String-2=(string)\"test\\ space\"", write)
+        self.assertIn("Int=(int)-5", write)
+        self.assertIn("Uint=(uint)5", write)
+        self.assertIn("Float=(float)2.0", write)
+        self.assertIn("Boolean=(boolean)true", write)
+        self.assertIn("Fraction=(fraction)2/5", write)
+
+    def test_GstStructure_editing_string(self):
+        struct = SCHEMA.GstStructure('properties, name=(string)before;')
+        self.assertEqual(struct["name"], "before")
+        struct.set("name", "string", "after")
+        self.assertEqual(struct["name"], "after")
+        self.assertEqual(str(struct), 'properties, name=(string)after;')
+
+    def test_GstStructure_empty_string(self):
+        struct = SCHEMA.GstStructure('properties, name=(string)"";')
+        self.assertEqual(struct["name"], "")
+
+    def test_GstStructure_NULL_string(self):
+        struct = SCHEMA.GstStructure('properties, name=(string)NULL;')
+        self.assertEqual(struct["name"], None)
+        struct = SCHEMA.GstStructure("properties;")
+        struct.set("name", "string", None)
+        self.assertEqual(str(struct), 'properties, name=(string)NULL;')
+        struct = SCHEMA.GstStructure('properties, name=(string)\"NULL\";')
+        self.assertEqual(struct["name"], "NULL")
+        self.assertEqual(str(struct), 'properties, name=(string)\"NULL\";')
+
+    def test_GstStructure_fraction(self):
+        struct = SCHEMA.GstStructure('properties, framerate=(fraction)2/5;')
+        self.assertEqual(struct["framerate"], "2/5")
+        struct.set("framerate", "fraction", Fraction("3/5"))
+        self.assertEqual(struct["framerate"], "3/5")
+        struct.set("framerate", "fraction", "4/5")
+        self.assertEqual(struct["framerate"], "4/5")
 
     def SKIP_test_roundtrip_disk2mem2disk(self):
         self.maxDiff = None

--- a/contrib/opentimelineio_contrib/adapters/xges.py
+++ b/contrib/opentimelineio_contrib/adapters/xges.py
@@ -484,8 +484,7 @@ class XGESOtio:
         return element.metadata.get(META_NAMESPACE, {}).get("properties", "properties;")
 
     def _get_element_metadatas(self, element):
-        return element.metadata.get(META_NAMESPACE,
-                                    {"GES": {}}).get("metadatas", "metadatas;")
+        return element.metadata.get(META_NAMESPACE, {}).get("metadatas", "metadatas;")
 
     def _serialize_ressource(self, ressources, ressource, asset_type):
         if isinstance(ressource, otio.schema.MissingReference):

--- a/contrib/opentimelineio_contrib/adapters/xges.py
+++ b/contrib/opentimelineio_contrib/adapters/xges.py
@@ -24,7 +24,6 @@
 
 """OpenTimelineIO GStreamer Editing Services XML Adapter. """
 import re
-import unittest
 
 from fractions import Fraction
 from xml.etree import cElementTree
@@ -53,131 +52,6 @@ TRANSITION_MAP.update(dict([(v, k) for k, v in TRANSITION_MAP.items()]))
 
 class GstParseError(otio.exceptions.OTIOError):
     pass
-
-
-class GstStructure(object):
-    """
-    GstStructure parser with a "dictionary" like API.
-    """
-    UNESCAPE = re.compile(r'(?<!\\)\\(.)')
-    INT_TYPES = "".join(
-        ("int", "uint", "int8", "uint8", "int16",
-         "uint16", "int32", "uint32", "int64", "uint64")
-    )
-
-    def __init__(self, text):
-        self.text = text
-        self.modified = False
-        self.name, self.types, self.values = GstStructure._parse(text + ";")
-
-    def __repr__(self):
-        if not self.modified:
-            return self.text
-
-        res = [self.name]
-        for key in sorted(self.values.keys()):
-            value = self.values[key]
-            value_type = self.types[key]
-            res.append(', %s=(%s)"%s"' % (key, value_type, self.escape(value)))
-        res.append(';')
-        return ''.join(res)
-
-    def __getitem__(self, key):
-        return self.values[key]
-
-    def set(self, key, value_type, value):
-        if self.types.get(key) == value_type and self.values.get(key) == value:
-            return
-
-        self.modified = True
-        self.types[key] = value_type
-        self.values[key] = value
-
-    def get(self, key, default=None):
-        return self.values.get(key, default)
-
-    @staticmethod
-    def _find_eos(s):
-        # find next '"' without preceeding '\'
-        line = 0
-        while 1:  # faster than regexp for '[^\\]\"'
-            p = s.index('"')
-            line += p + 1
-            if s[p - 1] != '\\':
-                return line
-            s = s[(p + 1):]
-        return -1
-
-    @staticmethod
-    def escape(s):
-        # XXX: The unicode type doesn't exist in Python 3 (all strings are unicode)
-        # so we have to use type(u"") which works in both Python 2 and 3.
-        if type(s) not in (str, type(u"")):
-            return s
-        return s.replace(" ", "\\ ")
-
-    @staticmethod
-    def _parse(s):
-        in_string = s
-        types = {}
-        values = {}
-        scan = True
-        # parse id
-        p = s.find(',')
-        if p == -1:
-            try:
-                p = s.index(';')
-            except ValueError:
-                p = len(s)
-            scan = False
-        name = s[:p]
-        # parse fields
-        while scan:
-            comma_space_it = p
-            # skip 'name, ' / 'value, '
-            while s[comma_space_it] in [' ', ',']:
-                comma_space_it += 1
-            s = s[comma_space_it:]
-            p = s.index('=')
-            k = s[:p]
-            if not s[p + 1] == '(':
-                raise ValueError("In %s position: %d" % (in_string, p))
-            s = s[(p + 2):]  # skip 'key=('
-            p = s.index(')')
-            t = s[:p]
-            s = s[(p + 1):]  # skip 'type)'
-
-            if s[0] == '"':
-                s = s[1:]  # skip '"'
-                p = GstStructure._find_eos(s)
-                if p == -1:
-                    raise ValueError
-                v = s[:(p - 1)]
-                if s[p] == ';':
-                    scan = False
-                # unescape \., but not \\. (using a backref)
-                # need a reverse for re.escape()
-                v = v.replace('\\\\', '\\')
-                v = GstStructure.UNESCAPE.sub(r'\1', v)
-            else:
-                p = s.find(',')
-                if p == -1:
-                    p = s.index(';')
-                    scan = False
-                v = s[:p]
-
-            if t == 'structure':
-                v = GstStructure(v)
-            elif t == 'string' and len(v) and v[0] == '"':
-                v = v[1:-1]
-            elif t == 'boolean':
-                v = (v == '1')
-            elif t in GstStructure.INT_TYPES:
-                v = int(v)
-            types[k] = t
-            values[k] = v
-
-        return (name, types, values)
 
 
 class GESTrackType:
@@ -216,11 +90,6 @@ def to_gstclocktime(rational_time):
     return int(rational_time.value_rescaled_to(1) * GST_SECOND)
 
 
-def get_from_structure(xmlelement, fieldname, default=None, attribute="properties"):
-    structure = GstStructure(xmlelement.get(attribute, attribute))
-    return structure.get(fieldname, default)
-
-
 class XGES:
     """
     This object is responsible for knowing how to convert an xGES
@@ -231,25 +100,80 @@ class XGES:
         self.xges_xml = cElementTree.fromstring(xml_string)
         self.rate = 25.0
 
-    def _set_rate_from_timeline(self, timeline):
-        metas = GstStructure(timeline.attrib.get("metadatas", "metadatas"))
-        framerate = metas.get("framerate")
-        if framerate:
-            rate = Fraction(framerate)
-        else:
-            video_track = timeline.find("./track[@track-type='4']")
-            rate = None
-            if video_track is not None:
-                properties = GstStructure(
-                    video_track.get("properties", "properties;"))
-                restriction_caps = GstStructure(properties.get(
-                    "restriction-caps", "restriction-caps"))
-                rate = restriction_caps.get("framerate")
+    @staticmethod
+    def _get_from_properties(xmlelement, fieldname, default=None):
+        structure = GstStructure(
+            xmlelement.get("properties", "properties;"))
+        return structure.get(fieldname, default)
 
+    @staticmethod
+    def _get_from_caps(caps, fieldname, structname=None, default=None):
+        """
+        Return the value for the first fieldname that matches.
+        If structname is given, then only search in structures who's
+        name matches
+        """
+        # restriction-caps is in general a *collection* of GstStructures
+        # along with corresponding features in the format:
+        #   "struct-name-nums(feature), "
+        #   "field1=(type1)val1, field2=(type2)val2; "
+        #   "struct-name-alphas(feature), "
+        #   "fieldA=(typeA)valA, fieldB=(typeB)valB"
+        # Note the lack of ';' for the last structure, and the
+        # '(feature)' is optional.
+        #
+        # Also note that gst_caps_from_string will also accept:
+        #   "struct-name(feature"
+        # without the final ')', but this must be the end of the string,
+        # which is why we have included (\)|$) at the end of
+        # CAPS_NAME_FEATURES_REGEX, i.e. match a closing ')' or the end.
+        if caps in ("ANY", "EMPTY", "NONE"):
+            return default
+        CAPS_NAME_FEATURES_REGEX = re.compile(
+            GstStructure.ASCII_SPACES + GstStructure.NAME_FORMAT
+            + r"(\([^)]*(\)|$))?" + GstStructure.END_FORMAT)
+        while caps:
+            match = CAPS_NAME_FEATURES_REGEX.match(caps)
+            if match is None:
+                raise GstParseError(
+                    "The structure name in the caps (%s) is not of "
+                    "the correct format" % (caps))
+            caps = caps[match.end("end"):]
+            try:
+                fields, caps = GstStructure._parse_fields(caps)
+            except ValueError as err:
+                raise GstParseError(
+                    "Failed to read the fields in the caps (%s):\n"
+                    + str(err))
+            if structname is not None:
+                if match.group("name") != structname:
+                    continue
+            # use below method rather than fields.get(fieldname) to
+            # allow us to want any value back, including None
+            for key in fields:
+                if key == fieldname:
+                    return fields[key][1]
+        return default
+
+    def _set_rate_from_timeline(self, timeline):
+        metas = GstStructure(timeline.attrib.get("metadatas", "metadatas;"))
+        rate = metas.get("framerate")
+        if rate is None:
+            video_track = timeline.find("./track[@track-type='4']")
+            if video_track is not None:
+                res_caps = self._get_from_properties(
+                    video_track, "restriction-caps")
+                rate = self._get_from_caps(res_caps, "framerate")
         if rate is None:
             return
-
-        self.rate = float(Fraction(rate))
+        try:
+            rate = Fraction(rate)
+        except ValueError:
+            print(
+                "WARNING: read a framerate that is not a fraction. "
+                "Ignoring")
+        else:
+            self.rate = float(rate)
 
     def to_rational_time(self, ns_timestamp):
         """
@@ -275,7 +199,7 @@ class XGES:
         """
 
         project = self.xges_xml.find("./project")
-        metas = GstStructure(project.attrib.get("metadatas", "metadatas"))
+        metas = GstStructure(project.attrib.get("metadatas", "metadatas;"))
         otio_project = otio.schema.SerializableCollection(
             name=metas.get('name', ""),
             metadata={
@@ -290,8 +214,8 @@ class XGES:
             name=metas.get('name') or "unnamed",
             metadata={
                 META_NAMESPACE: {
-                    "metadatas": timeline.attrib.get("metadatas", "metadatas"),
-                    "properties": timeline.attrib.get("properties", "properties")
+                    "metadatas": timeline.attrib.get("metadatas", "metadatas;"),
+                    "properties": timeline.attrib.get("properties", "properties;")
                 }
             }
         )
@@ -434,7 +358,11 @@ class XGES:
 
         duration = GST_CLOCK_TIME_NONE
         if asset_type == "GESUriClip":
-            duration = int(get_from_structure(asset, "duration", duration))
+            tmp_dur = self._get_from_properties(asset, "duration", duration)
+            if type(tmp_dur) is int:
+                duration = tmp_dur
+            else:
+                print("WARNING: read a duration that is not an int")
 
         available_range = otio.opentime.TimeRange(
             start_time=self.to_rational_time(0),
@@ -463,7 +391,7 @@ class XGES:
 
     def _timeline_element_by_name(self, timeline, name):
         for clip in timeline.findall("./layer/clip"):
-            if get_from_structure(clip, 'name') == name:
+            if self._get_from_properties(clip, "name") == name:
                 return clip
 
         return None
@@ -496,7 +424,7 @@ class XGESOtio:
 
         properties = GstStructure(self._get_element_properties(ressource))
         if properties.get('duration') is None:
-            properties.set('duration', 'guin64',
+            properties.set('duration', 'guint64',
                            to_gstclocktime(ressource.available_range.duration))
 
         self._insert_new_sub_element(
@@ -556,13 +484,10 @@ class XGESOtio:
         else:
             raise ValueError("Unhandled track type: %s" % otio_track.kind)
 
-        properties = otio_clip.metadata.get(
-            META_NAMESPACE,
-            {
-                "properties": 'properties, name=(string)"%s"' % (
-                    GstStructure.escape(otio_clip.name)
-                )
-            }).get("properties")
+        properties = otio_clip.metadata.get(META_NAMESPACE, {}).get("properties")
+        if properties is None:
+            properties = str(GstStructure(
+                "properties", {"name": ("string", str(otio_clip.name))}))
         return self._insert_new_sub_element(
             layer, 'clip',
             attrib={
@@ -604,8 +529,8 @@ class XGESOtio:
                         "caps": xges_track.caps,
                         "track-type": str(xges_track.track_type),
                         "track-id": str(track_id),
-                        "properties": xges_track.properties,
-                        "metadatas": xges_track.metadatas
+                        "properties": str(xges_track.properties),
+                        "metadatas": str(xges_track.metadatas)
                     }
                 )
                 track_id += 1
@@ -666,11 +591,10 @@ class XGESOtio:
 
     def _serialize_timeline(self, project, ressources, otio_timeline):
         metadatas = GstStructure(self._get_element_metadatas(otio_timeline))
-        metadatas.set(
-            "framerate", "fraction", self._framerate_to_frame_duration(
-                otio_timeline.duration().rate
-            )
-        )
+        rate = self._framerate_to_frame_duration(
+            otio_timeline.duration().rate)
+        if rate:
+            metadatas.set("framerate", "fraction", Fraction(rate))
         timeline = self._insert_new_sub_element(
             project, 'timeline',
             attrib={
@@ -805,9 +729,541 @@ def write_to_string(input_otio):
 # --------------------
 
 @otio.core.register_type
+class GstStructure(otio.core.SerializableObject):
+    """
+    An OpenTimelineIO Schema that acts as a named dictionary with
+    typed entries, essentially mimicking the GstStructure of the
+    GStreamer C library.
+
+    In particular, this schema mimics the gst_structure_to_string and
+    gst_structure_from_string C methods. As such, it can be used to
+    read and write the properties and metadatas attributes found in
+    xges elements.
+
+    Note that the types are to correspond to GStreamer/GES GTypes,
+    rather than python types.
+
+    Current supported GTypes:
+    GType         Associated    Accepted
+                  Python type   aliases
+    ======================================
+    gint          int           int, i
+    glong         int
+    gint64        int
+    guint         int           uint, u
+    gulong        int
+    guint64       int
+    gfloat        float         float, f
+    gdouble       float         double, d
+    gboolean      bool          boolean,
+                                bool, b
+    string        str or None   str, s
+    GstFraction   str or        fraction
+                  Fraction
+    """
+    _serializable_label = "GstStructure.1"
+
+    name = otio.core.serializable_field(
+        "name", str, "The name of the structure")
+    fields = otio.core.serializable_field(
+        "fields", dict, "The fields of the structure, of the form:\n"
+        "    {fielname: (type, value), ...}\n"
+        "where 'fieldname' is a str that names the field, 'type' is "
+        "a str that names the value type, and 'value' is the actual "
+        "value. Note that the name of the type corresponds to the "
+        "GType that would be used in the Gst/GES library, or some "
+        "accepted alias, rather than the python type.")
+
+    INT_TYPES = ("int", "i", "gint", "glong", "gint64")
+    UINT_TYPES = ("uint", "u", "guint", "gulong", "guint64")
+    FLOAT_TYPES = ("float", "f", "gfloat", "double", "d", "gdouble")
+    BOOLEAN_TYPES = ("boolean", "bool", "b", "gboolean")
+    FRACTION_TYPES = ("fraction", "GstFraction")
+    STRING_TYPES = ("string", "str", "s")
+
+    def __init__(self, text="Unnamed", fields=None):
+        """
+        Initialize the GstStructure.
+
+        If only a single string is given it will be parsed to extract
+        the full structure.
+
+        If two arguments are given, the first will be interpreted as
+        the name of the structure, and the second will be treated as
+        a dictionary containing the fields data, where each entry is
+        a two-entry tuple containing the type name and value.
+        """
+        otio.core.SerializableObject.__init__(self)
+        if type(text) is not str:
+            if isinstance(text, type(u"")):
+                # TODO: remove once python2 has ended
+                text = text.encode("utf8")
+            else:
+                raise TypeError("Expect a str type for the first argument")
+        if fields is not None:
+            if type(fields) is not dict:
+                try:
+                    fields = dict(fields)
+                except (TypeError, ValueError):
+                    raise TypeError(
+                        "Expect a dict-like type for the second argument")
+            self._check_name(text)
+            self.name = text
+            self.fields = {}
+            for key in fields:
+                entry = fields[key]
+                if type(entry) is not tuple:
+                    try:
+                        entry = tuple(entry)
+                    except (TypeError, ValueError):
+                        raise TypeError(
+                            "Expect dict to be filled with tuple-like "
+                            "entries")
+                if len(entry) != 2:
+                    raise TypeError(
+                        "Expect dict to be filled with 2-entry tuples")
+                self.set(key, *entry)
+        else:
+            self.name, self.fields = self._parse(text)
+            # NOTE: in python2 the str values in the returned fields are
+            # converted to unicode when we make this assignment!!!!
+            # this comes from being an otio serializable_field
+
+    def __repr__(self):
+        return "GstStructure({}, {})".format(
+            repr(self.name), repr(self.fields))
+
+    def _fields_to_str(self):
+        write = []
+        for key in self.fields:
+            entry = self.fields[key]
+            write.append(
+                ", %s=(%s)%s"
+                % (key, entry[0], self.serialize_value(*entry)))
+        return "".join(write)
+
+    def __str__(self):
+        """Emulates gst_structure_to_string"""
+        self._check_name(self.name)
+        return self.name + self._fields_to_str() + ";"
+
+    def __getitem__(self, key):
+        value = self.fields[key][1]
+        # TODO: remove below once python2 has ended
+        if not isinstance(value, str) and isinstance(value, type(u"")):
+            # Only possible in python2
+            return value.encode("utf8")
+        return value
+
+    @staticmethod
+    def _unknown_type(_type):
+        raise ValueError("The type (%s) is unknown" % (_type))
+
+    @staticmethod
+    def _shorten_str(in_string):
+        MAX_LEN = 20
+        if len(in_string) <= MAX_LEN:
+            return in_string
+        return in_string[:MAX_LEN] + "..."
+
+    @classmethod
+    def _string_val_err(cls, string_val, problem, prefix=""):
+        raise ValueError(
+            "Received string (%s%s) "
+            % (prefix, cls._shorten_str(string_val)) + problem)
+
+    @staticmethod
+    def _val_type_err(typ, val, expect):
+        raise TypeError(
+            "Received value (%s) is not a %s even though the %s "
+            "type was given" % (str(val), expect, typ))
+
+    @staticmethod
+    def _val_prop_err(typ, val, wrong_prop):
+        raise ValueError(
+            "Received value (%s) is %s even though the %s type "
+            "was given" % (val, wrong_prop, typ))
+
+    @staticmethod
+    def _val_read_err(typ, val, extra=None):
+        message = "Value (%s) is invalid for %s type" % (val, typ)
+        if extra:
+            message += ":\n" + str(extra)
+        raise ValueError(message)
+
+    def set(self, key, _type, value):
+        if self.fields.get(key) == (_type, value):
+            return
+        if type(key) is not str:
+            raise TypeError("Expected a str for the key argument")
+        if type(_type) not in (str, type(u"")):
+            # TODO: change to a simple check that the type is a str
+            # once python2 has ended.
+            # The current problem is that, in python2, otio will
+            # convert _type from str to the unicode type on assignment
+            # to the serializable_field 'fields'
+            raise TypeError("Expected a str for the type argument")
+        self._check_key(key)
+
+        if _type in self.INT_TYPES:
+            if type(value) is not int:
+                self._val_type_err(_type, value, "int")
+        elif _type in self.UINT_TYPES:
+            if type(value) is not int:
+                self._val_type_err(_type, value, "int")
+            if value < 0:
+                self._val_prop_err(_type, value, "negative")
+        elif _type in self.FLOAT_TYPES:
+            if type(value) is not float:
+                self._val_type_err(_type, value, "float")
+        elif _type in self.BOOLEAN_TYPES:
+            if type(value) is not bool:
+                self._val_type_err(_type, value, "bool")
+        elif _type in self.FRACTION_TYPES:
+            if type(value) is Fraction:
+                value = str(value)  # store internally as a str
+            elif type(value) in (str, type(u"")):
+                # TODO: change to just str type once python2 has ended
+                try:
+                    Fraction(value)
+                except ValueError:
+                    self._val_prop_err(_type, value, "not a fraction")
+            else:
+                self._val_type_err(_type, value, "Fraction or str")
+        elif _type in self.STRING_TYPES:
+            if value is not None and \
+                    type(value) not in (str, type(u"")):
+                # TODO: change to just str type once python2 has ended
+                self._val_type_err(_type, value, "str or None")
+        else:
+            self._unknown_type(_type)
+        self.fields[key] = (_type, value)
+        # NOTE: in python2, otio will convert a str value to a unicode
+
+    def get(self, key, default=None):
+        """Return the raw value associated with key"""
+        value = self.fields.get(key, (None, default))[1]
+        # TODO: remove below once python2 has ended
+        if not isinstance(value, str) and isinstance(value, type(u"")):
+            # Only possible in python2
+            return value.encode("utf8")
+        return value
+
+    ASCII_SPACES = r"(\\?[ \t\n\r\f\v])*"
+    END_FORMAT = r"(?P<end>" + ASCII_SPACES + r")"
+    NAME_FORMAT = r"(?P<name>[a-zA-Z][a-zA-Z0-9/_.:-]*)"
+    # ^Format requirement for the name of a GstStructure
+    SIMPLE_STRING = r"[a-zA-Z0-9_+/:.-]+"
+    # see GST_ASCII_CHARS (below)
+    KEY_FORMAT = r"(?P<key>" + SIMPLE_STRING + r")"
+    # NOTE: GstStructure technically allows more general keys, but
+    # these can break the parsing.
+    TYPE_FORMAT = r"(?P<type>" + SIMPLE_STRING + r")"
+    SIMPLE_VALUE_FORMAT = r"(?P<value>" + SIMPLE_STRING + r")"
+    QUOTED_VALUE_FORMAT = r'(?P<value>"(\\.|[^"])*")'
+    # consume simple string or a string between quotes. Second will
+    # consume anything that is escaped, including a '"'
+    # NOTE: \\. is used rather than \\" since:
+    #   + '"start\"end;"'  should be captured as '"start\"end"' since
+    #     the '"' is escaped.
+    #   + '"start\\"end;"' should be captured as '"start\\"' since the
+    #     '\' is escaped, not the '"'
+    # In the fist case \\. will consume '\"', and in the second it will
+    # consumer '\\', as desired. The second would not work with just \\"
+
+    @classmethod
+    def _check_name(cls, name):
+        if "fullmatch" in dir(re):
+            # Not available in python2
+            if not re.fullmatch(cls.NAME_FORMAT, name):
+                raise ValueError(
+                    "The name (%s) is not of the correct format" % (name))
+        else:
+            # TODO: remove once python2 has ended
+            if not re.match(cls.NAME_FORMAT + "$", name):
+                raise ValueError(
+                    "The name (%s) is not of the correct format" % (name))
+
+    @classmethod
+    def _check_key(cls, key):
+        if "fullmatch" in dir(re):
+            if not re.fullmatch(cls.KEY_FORMAT, key):
+                raise ValueError(
+                    "The key (%s) is not of the correct format" % (key))
+        else:
+            # TODO: remove once python2 has ended
+            if not re.match(cls.KEY_FORMAT + "$", key):
+                raise ValueError(
+                    "The key (%s) is not of the correct format" % (key))
+
+    NAME_REGEX = re.compile(ASCII_SPACES + NAME_FORMAT + END_FORMAT)
+
+    @classmethod
+    def _parse_name(cls, read):
+        match = cls.NAME_REGEX.match(read)
+        if match is None:
+            cls._string_val_err(
+                read, "does not start with a correct name")
+        name = match.group("name")
+        read = read[match.end("end"):]
+        return name, read
+
+    FIELD_START = ASCII_SPACES + KEY_FORMAT + ASCII_SPACES + r"=" \
+        + ASCII_SPACES + r"\(" + ASCII_SPACES + TYPE_FORMAT \
+        + ASCII_SPACES + r"\)" + ASCII_SPACES
+    SIMPLE_FIELD_REGEX = re.compile(
+        FIELD_START + SIMPLE_VALUE_FORMAT + END_FORMAT)
+    QUOTED_FIELD_REGEX = re.compile(
+        FIELD_START + QUOTED_VALUE_FORMAT + END_FORMAT)
+
+    @classmethod
+    def _parse_field(cls, read):
+        match = cls.SIMPLE_FIELD_REGEX.match(read)
+        if match is None:
+            match = cls.QUOTED_FIELD_REGEX.match(read)
+            if match is None:
+                cls._string_val_err(
+                    read,
+                    "does not have a valid 'key=(type)value' format", "...")
+        key = match.group("key")
+        _type = match.group("type")
+        value = match.group("value")
+        try:
+            value = cls.deserialize_value(_type, value)
+        except ValueError as err:
+            cls._string_val_err(
+                read,
+                "contains an invalid typed value:\n" + str(err), "...")
+        read = read[match.end("end"):]
+        return key, (_type, value), read
+
+    @classmethod
+    def _parse_fields(cls, read):
+        fields = {}
+        while read and read[0] != ';':
+            if read[0] != ',':
+                cls._string_val_err(
+                    read, "does not separate fields with commas", "...")
+            read = read[1:]
+            key, entry, read = cls._parse_field(read)
+            fields[key] = entry
+        if read:
+            # read[0] == ';'
+            read = read[1:]
+        return fields, read
+
+    @classmethod
+    def _parse(cls, read):
+        """Emulates gst_structure_from_string"""
+        name, read = cls._parse_name(read)
+        fields = cls._parse_fields(read)[0]
+        # ignore returned end of string -^
+        return (name, fields)
+
+    @classmethod
+    def deserialize_value(cls, _type, value):
+        """Return the value as the corresponding type"""
+        if _type in cls.INT_TYPES or _type in cls.UINT_TYPES:
+            if type(value) is float and int(value) != value:
+                cls._val_read_err(_type, value)
+            try:
+                value = int(value)
+            except ValueError:
+                cls._val_read_err(_type, value)
+            if _type in cls.UINT_TYPES and value < 0:
+                cls._val_read_err(_type, value)
+        elif _type in cls.FLOAT_TYPES:
+            try:
+                value = float(value)
+            except ValueError:
+                cls._val_read_err(_type, value)
+        elif _type in cls.BOOLEAN_TYPES:
+            try:
+                value = cls.deserialize_boolean(value)
+            except ValueError:
+                cls._val_read_err(_type, value)
+        elif _type in cls.FRACTION_TYPES:
+            try:
+                value = str(Fraction(value))  # store internally as a str
+            except ValueError:
+                cls._val_read_err(_type, value)
+        elif _type in cls.STRING_TYPES:
+            try:
+                value = cls.deserialize_string(value)
+            except ValueError as err:
+                cls._val_read_err(_type, value, err)
+        else:
+            cls._unknown_type(_type)
+        return value
+
+    @classmethod
+    def serialize_value(cls, _type, value):
+        """Serialize the typed value as a string"""
+        if _type in cls.INT_TYPES + cls.UINT_TYPES + cls.FLOAT_TYPES \
+                + cls.FRACTION_TYPES:
+            return str(value)
+        if _type in cls.BOOLEAN_TYPES:
+            if value:
+                return "true"
+            return "false"
+        if _type in cls.STRING_TYPES:
+            if value is not None and type(value) is not str:
+                # TODO: remove once python2 has ended
+                # will only happen in python2 when we have unicode
+                value = value.encode("utf8")
+            return cls.serialize_string(value)
+        cls._unkown_type(_type)
+
+    # see GST_ASCII_IS_STRING in gst_private.h
+    GST_ASCII_CHARS = [
+        ord(l) for l in "abcdefghijklmnopqrstuvwxyz"
+                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                        "0123456789"
+                        "_-+/:."
+    ]
+    LEADING_OCTAL_CHARS = [ord(l) for l in "0123"]
+    OCTAL_CHARS = [ord(l) for l in "01234567"]
+
+    @classmethod
+    def serialize_string(cls, read):
+        """
+        Emulates gst_value_serialize_string.
+        Accepts a bytes, str or None type.
+        Returns a str type.
+        """
+        if read is None:
+            return "NULL"
+        if read == "NULL":
+            return "\"NULL\""
+        if type(read) is bytes:
+            # NOTE: in python2 this will be True if read is a str type
+            # in python3 it will not
+            pass
+        elif type(read) is str:
+            read = read.encode()
+        else:
+            raise TypeError("Expect a None, str, or a bytes type")
+        if not read:
+            return '""'
+        added_wrap = False
+        ser_string_list = []
+        for byte in bytearray(read):
+            # For python3 we could have just called `byte in read`
+            # For python2 we need the `bytearray(read)` cast to convert
+            # the str type to int
+            # TODO: simplify once python2 has ended
+            if byte in cls.GST_ASCII_CHARS:
+                ser_string_list.append(chr(byte))
+            elif byte < 0x20 or byte >= 0x7f:
+                ser_string_list.append("\\%03o" % (byte))
+                added_wrap = True
+            else:
+                ser_string_list.append("\\" + chr(byte))
+                added_wrap = True
+        if added_wrap:
+            ser_string_list.insert(0, '"')
+            ser_string_list.append('"')
+        return "".join(ser_string_list)
+
+    @classmethod
+    def deserialize_string(cls, read):
+        """
+        Emulates gst_value_deserialize_string.
+        Accepts a str type.
+        Returns a str or None type.
+        """
+        if not type(read) is str:
+            raise TypeError("Expected a str type")
+        if read == "NULL":
+            return None
+        if not read:
+            return ""
+        if read[0] != '"' and read[-1] != '"':
+            return read
+
+        if type(read) is bytes:
+            # TODO: remove once python2 has ended
+            read_array = bytearray(read)
+        else:
+            read_array = bytearray(read.encode())
+        byte_list = []
+        bytes_iter = iter(read_array)
+
+        def next_byte():
+            try:
+                return next(bytes_iter)
+            except StopIteration:
+                cls._string_val_err(read, "end unexpectedly")
+
+        byte = next_byte()
+        if byte != ord('"'):
+            cls._string_val_err(
+                read, "does not start with '\"', but ends with '\"'")
+        while True:
+            byte = next_byte()
+            if byte in cls.GST_ASCII_CHARS:
+                byte_list.append(byte)
+            elif byte == ord('"'):
+                try:
+                    next(bytes_iter)
+                except StopIteration:
+                    # expect there to be no more bytes
+                    break
+                cls._string_val_err(
+                    read, "contains an un-escaped '\"' before the end")
+            elif byte == ord('\\'):
+                byte = next_byte()
+                if byte in cls.LEADING_OCTAL_CHARS:
+                    # could be the start of an octal
+                    byte2 = next_byte()
+                    byte3 = next_byte()
+                    if byte2 in cls.OCTAL_CHARS and byte3 in cls.OCTAL_CHARS:
+                        nums = [b - ord('0') for b in (byte, byte2, byte3)]
+                        byte = (nums[0] << 6) + (nums[1] << 3) + nums[2]
+                        byte_list.append(byte)
+                    else:
+                        cls._string_val_err(
+                            read, "contains the start of an octal "
+                            "sequence but not the end")
+                else:
+                    if byte == 0:
+                        cls._string_val_err(
+                            read, "contains a null byte after an escape")
+                    byte_list.append(byte)
+            else:
+                cls._string_val_err(
+                    read, "contains an unexpected un-escaped character")
+        out_str = bytes(bytearray(byte_list))
+        if type(out_str) is str:
+            # TODO: remove once python2 has ended
+            # and simplify above to only call bytes(byte_list)
+            return out_str
+        try:
+            return out_str.decode()
+        except (UnicodeError, ValueError):
+            cls._string_val_err(
+                read, "contains invalid utf-8 byte sequences")
+
+    @staticmethod
+    def deserialize_boolean(read):
+        """Return a boolean"""
+        if type(read) is bool:
+            return read
+        if type(read) is int and read in (0, 1):
+            return bool(read)
+        if read.lower() in ("true", "t", "yes", "1"):
+            return True
+        if read.lower() in ("false", "f", "no", "0"):
+            return False
+        raise ValueError("Unknown boolean value %s" % str(read))
+
+
+@otio.core.register_type
 class XgesTrack(otio.core.SerializableObject):
-    """An OpenTimelineIO Schema for storing a GESTrack
-    (Not to be confused with OpenTimelineIO's schema.Track)
+    """
+    An OpenTimelineIO Schema for storing a GESTrack.
+
+    Not to be confused with OpenTimelineIO's schema.Track.
     """
     _serializable_label = "XgesTrack.1"
 
@@ -816,20 +1272,32 @@ class XgesTrack(otio.core.SerializableObject):
     track_type = otio.core.serializable_field(
         "track-type", int, "The GESTrackType of the track")
     properties = otio.core.serializable_field(
-        "properties", str, "The GObject properties of the track")
+        "properties", GstStructure, "The GObject properties of the track")
     metadatas = otio.core.serializable_field(
-        "metadatas", str, "Metadata for the track")
+        "metadatas", GstStructure, "Metadata for the track")
 
     def __init__(
-            self,
-            caps="ANY",
-            track_type=GESTrackType.UNKNOWN,
-            properties="properties;",
-            metadatas="metadatas;"
-    ):
+            self, caps="ANY", track_type=GESTrackType.UNKNOWN,
+            properties=None, metadatas=None):
+        """
+        Initialize the XgesTrack.
+
+        properties and metadatas can either be GstStructures, strings,
+        None, or dict-like objects.
+        If it is a GstStructure, then the fields are passed to
+        GstStructure() (the structure name is ignored).
+        If it is a string, then the string is to be parsed by
+        GstStructure().
+        If it is None, then an empty GstStructure will be made.
+        Otherwise, it will be passed as the fields for GstStructure.
+        """
         otio.core.SerializableObject.__init__(self)
         if type(caps) is not str:
-            raise TypeError("Expect a str type for the caps")
+            if isinstance(caps, type(u"")):
+                # TODO: remove once python2 has ended
+                caps = caps.encode("utf8")
+            else:
+                raise TypeError("Expect a str type for the caps")
         self.caps = caps
         if type(track_type) is not int:
             raise TypeError("Expect an int type for the track_type")
@@ -838,14 +1306,24 @@ class XgesTrack(otio.core.SerializableObject):
                 "Expect the track_type to be a non-negative int "
                 "< %i" % (GESTrackType.MAX))
         self.track_type = track_type
-        if type(properties) is str:
-            self.properties = properties
-        else:
-            raise TypeError("Expect a str type for properties")
-        if type(metadatas) is str:
-            self.metadatas = metadatas
-        else:
-            raise TypeError("Expect a str type for metadatas")
+        self.properties = self._get_structure(properties, "properties")
+        self.metadatas = self._get_structure(metadatas, "metadatas")
+
+    @staticmethod
+    def _get_structure(struct, struct_name):
+        if isinstance(struct, GstStructure):
+            return GstStructure(struct_name, struct.fields)
+        if type(struct) in (str, type(u"")):
+            # TODO: only check if str once python2 has ended
+            struct = GstStructure(struct)
+            if struct.name != struct_name:
+                raise ValueError(
+                    "The given string contains the structure name '%s'"
+                    ", but '%s' was expected"
+                    % (struct.name, struct_name))
+            return struct
+        # assume a dict-like type that contains the fields
+        return GstStructure(struct_name, struct)
 
     def __repr__(self):
         return \
@@ -857,7 +1335,7 @@ class XgesTrack(otio.core.SerializableObject):
     @classmethod
     def new_from_otio_track_kind(cls, kind):
         """Return a new default XgesTrack for the given track kind"""
-        default_props = "properties"
+        props = {}
         if kind == otio.schema.TrackKind.Video:
             caps = "video/x-raw(ANY)"
             track_type = GESTrackType.VIDEO
@@ -865,47 +1343,12 @@ class XgesTrack(otio.core.SerializableObject):
             # library supports default, non-NULL restriction-caps for
             # GESVideoTrack (like GESAudioTrack).
             # For time being, framerate is needed for stability.
-            default_props += ', restriction-caps=(string)"' \
-                'video/x-raw\\,\\ framerate\\=\\(fraction\\)30/1"'
-            # NOTE: when written to xml, the '"'s will turn to
-            # '&quot;'s when writing to an attribute
-            # but the ', =)(' must be escaped for GES to parse in the
-            # restriction-caps
+            props["restriction-caps"] = \
+                ("string", "video/x-raw, framerate=(fraction)30/1")
         elif kind == otio.schema.TrackKind.Audio:
             caps = "audio/x-raw(ANY)"
             track_type = GESTrackType.AUDIO
         else:
             raise ValueError("Received unknown otio.schema.TrackKind")
-        default_props += ", mixing=(boolean)true;"
-        return cls(caps, track_type, default_props)
-
-
-# --------------------
-# Some unit check for internal types
-# --------------------
-
-class XGESTests(unittest.TestCase):
-
-    def test_gst_structure_parsing(self):
-        struct = GstStructure('properties, name=(string)"%s";' % (
-            GstStructure.escape("sc01 sh010_anim.mov"))
-        )
-        self.assertEqual(struct["name"], "sc01 sh010_anim.mov")
-
-    def test_gst_structure_editing(self):
-        struct = GstStructure('properties, name=(string)"%s";' % (
-            GstStructure.escape("sc01 sh010_anim.mov"))
-        )
-        self.assertEqual(struct["name"], "sc01 sh010_anim.mov")
-
-        struct.set("name", "string", "test")
-        self.assertEqual(struct["name"], "test")
-        self.assertEqual(str(struct), 'properties, name=(string)"test";')
-
-    def test_empty_string(self):
-        struct = GstStructure('properties, name=(string)"";')
-        self.assertEqual(struct["name"], "")
-
-
-if __name__ == '__main__':
-    unittest.main()
+        props["mixing"] = ("boolean", True)
+        return cls(caps, track_type, props)


### PR DESCRIPTION
Added custom schemas to be used both internally by xges and externally by users.

The two added schemas are:
+ `XgesTrack`, which stores attribute data corresponding to xges track elements (which are quite distinct from otio.schema.Tracks); and
+ `GstStructure`, which emulates the GstStructure used in the GStreamer/GES C library, which primarily means it can read the `properties` and `metadatas` attributes of the xges elements, as well as successfully create them.

The reason for creating these as schemas is that they will eventually be used in the metadata of otio core elements for conversion purposes. For example, currently the xges `properties` and `metadatas` attributes are stored in the otio metadata as serialized strings. If this was replaced with the `GstStructure` schema, the data within would be more transparent and easier for others to edit (both within the json_otio file and within python). The `XgesTrack` is also planned to be stored in the metadata of otio Stacks (once we have supported nested stacks) to make the xges->otio->xges conversion less lossy.

The class `GstStructure` existed before in xges.py (but not as a schema), and in translating it to an otio schema its methods have also been vastly improved to closer emulate the GStreamer behaviour. In particular, it can now successfully (de)serialize non-basic-ascii strings. Before, this was not supported, so any otio clip with a non-ascii utf8 name would convert to an xges that would cause warnings or errors when opened in the GES library. This is now fixed.

The commits also contain some other small fixes to xges.py, including using floats for otio RationalTimes, which means the timestamps are less lossy.