### PR TITLE
Rebuild float serializer for ffmpeg time string

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -284,7 +284,6 @@ RationalTime::to_time_string() const {
 
     // @TODO: fun fact, this will print the wrong values for numbers at a
     // certain number of decimal places, if you just std::cerr << total_seconds
-    /* OTIO_DEBUG_PRINT(total_seconds); */
 
     // reformat in time string
     constexpr double time_units_per_minute = 60.0;
@@ -299,29 +298,37 @@ RationalTime::to_time_string() const {
     int minutes = std::floor(minute_units / time_units_per_minute);
     double seconds = std::fmod(minute_units, time_units_per_minute);
 
+    // split the seconds string apart
     double fractpart, intpart;
-    fractpart = std::modf(seconds, &intpart);
 
-    std::string microseconds = std::to_string(std::floor(fractpart * 1e6));
+    fractpart = modf(seconds, &intpart);
 
-    // XXX: manually handle the rounding (couldn't find the right printf
-    // incantation...
-    for (int i = 5; i >= 0; i--) {
-        if (microseconds[i] != '0') {
-            microseconds = microseconds.substr(0, i+1);
-            break;
-        }
+    // clamp to 2 digits and zero-pad
+    std::string seconds_str = string_printf("%02d", (int)intpart);
+
+    // get the fractional component (with enough digits of resolution)
+    std::string microseconds_str = string_printf("%.7g", fractpart);
+
+    // trim leading 0
+    microseconds_str = microseconds_str.substr(1);
+
+    // enforce the minimum string of '.0'
+    if (microseconds_str.length() == 0) {
+        microseconds_str = std::string(".0");
+    }
+    else {
+        // ...and the string size
+        microseconds_str.resize(7, '\0');
     }
 
-    int imicroseconds;
-    try {
-        imicroseconds = std::stoi(microseconds);
-    }
-    catch (...) {
-        imicroseconds = 0;
-    }
-    
-    return string_printf("%02d:%02d:%02d.%d", hours, minutes, int(intpart), imicroseconds);
+    return string_printf(
+            // decimal should already be in the microseconds_str
+            "%02d:%02d:%s%s",
+            hours,
+            minutes,
+            seconds_str.c_str(),
+            microseconds_str.c_str()
+    );
 }
 
 } }

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -426,6 +426,15 @@ class TestTime(unittest.TestCase):
         self.assertEqual(time_string, otio.opentime.to_time_string(t))
         self.assertTrue(t.almost_equal(time_obj, delta=0.001))
 
+    def test_to_time_string_microseconds_starts_with_zero(self):
+        # this number has a leading 0 in the fractional part when converted to
+        # time string (ie 27.08333)
+        rt = otio.opentime.RationalTime(2090, 24)
+        self.assertEqual(
+            str(rt),
+            str(otio.opentime.from_time_string(otio.opentime.to_time_string(rt), 24))
+        )
+
     def test_long_running_time_string_24(self):
         final_frame_number = 24 * 60 * 60 * 24 - 1
         final_time = otio.opentime.from_frames(final_frame_number, 24)


### PR DESCRIPTION
- addresses a subtle bug in the `to_time_string` method on rationalTime
- old implementation would strip leading `0`s from the fractional compenent of the seconds field of the ffmpeg time string, for example `27.08333` would become `27.8333`.
- More closely matches the product of the python implementation