### PR TITLE
[opentimelineio] add include of assert.h where assert() is used

### DIFF
--- a/src/opentimelineio/anyDictionary.h
+++ b/src/opentimelineio/anyDictionary.h
@@ -2,6 +2,8 @@
 
 #include "opentimelineio/version.h"
 #include "opentimelineio/any.h"
+
+#include <assert.h>
 #include <map>
 #include <string>
 

--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -1,5 +1,7 @@
 #include "opentimelineio/composition.h"
 #include "opentimelineio/vectorIndexing.h"
+
+#include <assert.h>
 #include <set>
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {

--- a/src/opentimelineio/item.cpp
+++ b/src/opentimelineio/item.cpp
@@ -3,6 +3,8 @@
 #include "opentimelineio/effect.h"
 #include "opentimelineio/marker.h"
 
+#include <assert.h>
+
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 Item::Item(std::string const& name,

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -10,9 +10,9 @@
 #include "opentime/rationalTime.h"
 #include "opentime/timeRange.h"
 #include "opentime/timeTransform.h"
-#include <type_traits>
-#include <assert.h>
+
 #include <list>
+#include <type_traits>
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     

--- a/src/opentimelineio/typeRegistry.cpp
+++ b/src/opentimelineio/typeRegistry.cpp
@@ -25,6 +25,7 @@
 #include "opentimelineio/stack.h"
 #include "opentimelineio/unknownSchema.h"
 
+#include <assert.h>
 #include <vector>
 //#include <sstream>
 //#include <iostream>


### PR DESCRIPTION
This addresses a compilation issue in OTIO client code where assert() can go
undeclared if assert.h does not get included indirectly from another header.
It also removes one case in serializableObject.h where assert.h was included
but not actually needed.