### PR TITLE
[opentimelineio] fix unused parameter compilation warnings

### DIFF
--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -153,7 +153,7 @@ bool Composition::is_parent_of(Composable const* other) const {
 }
 
 std::pair<optional<RationalTime>, optional<RationalTime>>
-Composition::handles_of_child(Composable const* child, ErrorStatus* error_status) const {
+Composition::handles_of_child(Composable const* /* child */, ErrorStatus* /* error_status */) const {
     return std::make_pair(optional<RationalTime>(), optional<RationalTime>());
 }
 
@@ -187,12 +187,12 @@ std::vector<Composition*> Composition::_path_from_child(Composable const* child,
     return parents;
 }
 
-TimeRange Composition::range_of_child_at_index(int index, ErrorStatus* error_status) const {
+TimeRange Composition::range_of_child_at_index(int /* index */, ErrorStatus* error_status) const {
     *error_status = ErrorStatus::NOT_IMPLEMENTED;
     return TimeRange();
 }
 
-TimeRange Composition::trimmed_range_of_child_at_index(int index, ErrorStatus* error_status) const {
+TimeRange Composition::trimmed_range_of_child_at_index(int /* index */, ErrorStatus* error_status) const {
     *error_status = ErrorStatus::NOT_IMPLEMENTED;
     return TimeRange();
 }

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -43,11 +43,11 @@ public:
     bool Uint64(uint64_t u) { return store(any(int64_t(u))); }
     bool Double(double d) { return store(any(d)); }
 
-    bool String(const char* str, OTIO_rapidjson::SizeType length, bool copy) {
+    bool String(const char* str, OTIO_rapidjson::SizeType length, bool /* copy */) {
         return store(any(std::string(str, length)));
     }
 
-    bool Key(const char* str, OTIO_rapidjson::SizeType length, bool copy) {
+    bool Key(const char* str, OTIO_rapidjson::SizeType length, bool /* copy */) {
         if (has_errored()) {
             return false;
         }

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -152,7 +152,7 @@ public:
         _store(any(value));
     }
 
-    void start_array(size_t n) {
+    void start_array(size_t /* n */) {
         if (has_errored()) {
             return;
         }

--- a/src/opentimelineio/transition.cpp
+++ b/src/opentimelineio/transition.cpp
@@ -36,7 +36,7 @@ void Transition::write_to(Writer& writer) const {
 }
 
 
-RationalTime Transition::duration(ErrorStatus* error_status) const {
+RationalTime Transition::duration(ErrorStatus* /* error_status */) const {
     return _in_offset + _out_offset;
 }
 

--- a/src/opentimelineio/typeRegistry.cpp
+++ b/src/opentimelineio/typeRegistry.cpp
@@ -102,7 +102,7 @@ TypeRegistry::register_type(std::string const& schema_name, int schema_version,
 }
 
 bool
-TypeRegistry::register_type_from_existing_type(std::string const& schema_name, int schema_version,
+TypeRegistry::register_type_from_existing_type(std::string const& schema_name, int /* schema_version */,
                                                std::string const& existing_schema_name,
                                                ErrorStatus* error_status) {
     std::lock_guard<std::mutex> lock(_registry_mutex);

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -384,10 +384,10 @@ static void define_items_and_compositions(py::module m) {
         .def("trimmed_range_of_child_at_index", [](Composition* c, int index) {
             return c->trimmed_range_of_child_at_index(index, ErrorStatusHandler());
             }, "index"_a)
-        .def("range_of_child", [](Composition* c, Composable* child, Composable* ignored) {
+        .def("range_of_child", [](Composition* c, Composable* child, Composable* /* ignored */) {
             return c->range_of_child(child, ErrorStatusHandler());
             }, "child"_a, "reference_space"_a = nullptr)
-        .def("trimmed_range_of_child", [](Composition* c, Composable* child, Composable* ignored) {
+        .def("trimmed_range_of_child", [](Composition* c, Composable* child, Composable* /* ignored */) {
             return c->trimmed_range_of_child(child, ErrorStatusHandler());
             }, "child"_a, "reference_space"_a = nullptr)
         .def("trimmed_child_range", &Composition::trim_child_range,

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
@@ -50,7 +50,7 @@ py::object plain_int(int64_t i) {
 void _build_any_to_py_dispatch_table() {
     auto& t = _py_cast_dispatch_table;
 
-    t[&typeid(void)] = [](any const& a, bool) { return py::none(); };
+    t[&typeid(void)] = [](any const& /* a */, bool) { return py::none(); };
     t[&typeid(bool)] = [](any const& a, bool) { return py::cast(safely_cast_bool_any(a)); };
     t[&typeid(int)] = [](any const& a, bool) {  return plain_int(safely_cast_int_any(a)); };
     t[&typeid(int64_t)] = [](any const& a, bool) {  return plain_int(safely_cast_int64_any(a)); };


### PR DESCRIPTION
This cleans up a bunch of unused parameter warnings seen when using gcc 4.8.3
and compiling with -Wextra.