### PR TITLE
Update the C++ instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ OTIO also supports several other kinds of plugins, for more information see:
 Installing / Quick-Start
 ----------
 
-You can install OpenTimelineIO via
+The python-wrapped version of OpenTimelineIO is publicly available via pypy.  You can install OpenTimelineIO via:
 
 `pip install opentimelineio`
 
@@ -78,32 +78,31 @@ C++ Installation Instructions
 -----------------------------
 
 0.  Get the source and deal with submodules:
-    + git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git
-    + cd otio
-    + git checkout cxx
-    + git submodule init
-    + git submodule update
+    + `git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git`
+    + `cd OpenTimelineIO`
+    + `git submodule init`
+    + `git submodule update`
 
 1. If you want to only build for C++ development (i.e. produce the OTIO C++ libraries and header files), then use cmake:
-    + mkdir build
-    + cd build
-    + ccmake ..
+    + `mkdir build`
+    + `cd build`
+    + `ccmake ..`
     (configure PYTHON_EXECUTABLE, PYTHON_LIBRARY, and CMAKE_INSTALL_PREFIX)
-    + make install
+    + `make install`
     
 2. If you wish to build only for use with Python, run one of the following two commands:
-   + pip install .
-   + python setup.py install
+   + `pip install .`
+   + `python setup.py install`
    
 3. However, if you want to build for Python but you also want to install the OTIO C++ headers and libraries, then run one of the following two commands
-   + pip install . --install-option=“--cxx-install-root=/home/someone/cxx-otio-root"
-   + python setup.py install --cxx-install-root=/home/someone/cxx-otio-root
+   + `pip install . --install-option=“--cxx-install-root=/home/someone/cxx-otio-root"`
+   + `python setup.py install --cxx-install-root=/home/someone/cxx-otio-root`
    
    To compile a C++ file, add the following -I flags:
-   + c++ -c source.cpp -I/home/someone/cxx-otio-root/include -I/home/someone/cxx-otio-root/include/opentimelineio/deps
+   + `c++ -c source.cpp -I/home/someone/cxx-otio-root/include -I/home/someone/cxx-otio-root/include/opentimelineio/deps`
    
    To link, add the following -L/-l flags:
-   + c++ ... -L/home/someone/cxx-otio-root/lib -lopentimelineio
+   + `c++ ... -L/home/someone/cxx-otio-root/lib -lopentimelineio`
    
    (If you are using only opentime, not opentimelineio, use -lopentime.  Also, you could leave out the second -I flag.)
 
@@ -123,7 +122,7 @@ There are more code examples here: https://github.com/PixarAnimationStudios/Open
 Also, looking through the unit tests is a great way to see what OTIO can do:
 https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/master/tests
 
-OTIO includes a viewer program as well:
+OTIO includes a viewer program as well (see the quickstart section for instructions on installing it):
 
 ![OTIO View Screenshot](docs/_static/otioview.png)
 
@@ -136,9 +135,9 @@ You can get the latest development version via:
 
 `git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git OpenTimelineIO`
 
-You can install development dependencies with `pip install -e .[dev]`
+You can install development dependencies with `pip install .[dev]`
 
-You can also install the PySide2 dependency with `pip install -e .[view]`
+You can also install the PySide2 dependency with `pip install .[view]`
 
 Currently the code base is written against python 2.7, python 3.6 and 3.7, in keeping 
 with the pep8 style.  We ask that before you submit a pull request, you:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ C++ Installation Instructions
 1. If you want to only build for C++ development (i.e. produce the OTIO C++ libraries and header files), then use cmake:
     + `mkdir build`
     + `cd build`
-    + `ccmake ..`
+    + `cmake ..`
     (configure PYTHON_EXECUTABLE, PYTHON_LIBRARY, and CMAKE_INSTALL_PREFIX)
     + `make install`
     


### PR DESCRIPTION
- There were some outdated lines in the readme:
  - no more Cxx branch
  - `-e` branch is currently broken, removed that from the development instructions in the python section
- added `code` formatting to instructions
- added note about the viewer program installation instructions being in the quickstart section