### PR TITLE
Fixes for building with Visual Studio 2019

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,13 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(PYBIND11_CPP_STANDARD -std=c++11)
 set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wno-deprecated-register")
+if(MSVC)
+	set(PYBIND11_CPP_STANDARD /std:c++11)
+	set(CMAKE_CXX_FLAGS "/W4 /EHsc")
+else()
+	set(PYBIND11_CPP_STANDARD -std=c++11)
+	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wno-deprecated-register")
+endif()
 
 # make sure that git submodules are up to date when building
 find_package(Git QUIET)

--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(opentime SHARED
 
 target_include_directories(opentime PUBLIC "${PROJECT_SOURCE_DIR}/src")
 set_target_properties(opentime PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
-			MACOSX_RPATH true)
+			MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 install(TARGETS opentime LIBRARY DESTINATION lib)
 if (NOT OTIO_CXX_NOINSTALL)
     install(FILES ${OPENTIME_HEADER_FILES} DESTINATION include/opentime)

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -2,6 +2,7 @@
 #include "opentime/stringPrintf.h"
 #include <array>
 #include <algorithm>
+#include <ciso646>
 #include <cmath>
 #include <vector>
 

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -2,6 +2,7 @@
 
 #include "opentime/version.h"
 #include "opentime/rationalTime.h"
+#include <algorithm>
 #include <string>
 
 namespace opentime { namespace OPENTIME_VERSION {

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -76,7 +76,7 @@ target_include_directories(opentimelineio PUBLIC
 
 target_link_libraries(opentimelineio PUBLIC opentime)
 set_target_properties(opentimelineio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
-			MACOSX_RPATH true)
+			MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
 install(TARGETS opentimelineio LIBRARY DESTINATION lib)
 
 if (NOT OTIO_CXX_NOINSTALL)

--- a/src/opentimelineio/stringUtils.cpp
+++ b/src/opentimelineio/stringUtils.cpp
@@ -1,12 +1,16 @@
+#include "opentimelineio/serializableObject.h"
+#if defined(__GNUC__) or defined(__clang__)
 #include <cstdlib>
 #include <memory>
 #include <cxxabi.h>
-#include <string>
-#include "opentimelineio/serializableObject.h"
+#else
+#include <typeinfo>
+#endif
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
-std::string demangled_type_name(const char* name) {
+#if defined(__GNUC__) or defined(__clang__)
+std::string cxxabi_demangled_type_name(const char* name) {
     int status = -4; // some arbitrary value to eliminate the compiler warning
 
     std::unique_ptr<char, void(*)(void*)> res {
@@ -16,6 +20,7 @@ std::string demangled_type_name(const char* name) {
 
     return (status==0) ? res.get() : name;
 }
+#endif
 
 std::string demangled_type_name(std::type_info const& t) {
     if (t == typeid(std::string)) {
@@ -24,8 +29,13 @@ std::string demangled_type_name(std::type_info const& t) {
     if (t == typeid(void)) {
         return "None";
     }
-    
-    return demangled_type_name(t.name());
+
+#if defined(__GNUC__) or defined(__clang__)
+    return cxxabi_demangled_type_name(t.name());
+#else
+    // On Windows std::type_info.name() returns a human readable string.
+    return t.name();
+#endif
 }
 
 std::string demangled_type_name(any const& a) {

--- a/src/opentimelineio/stringUtils.h
+++ b/src/opentimelineio/stringUtils.h
@@ -11,7 +11,6 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 void fatal_error(std::string const& errMsg);
 
-std::string demangled_type_name(const char* name);
 std::string demangled_type_name(std::type_info const&);
 std::string demangled_type_name(any const& a);
 std::string demangled_type_name(class SerializableObject*);


### PR DESCRIPTION
Various fixes to successfully compile OpenTimelineIO with Visual Studio 2019. A separate pull request will be made to address the compiler warnings.
