### PR TITLE
Fix warnings for Visual Studio 2019

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 set(CMAKE_CXX_STANDARD 11)
 if(MSVC)
-	set(PYBIND11_CPP_STANDARD /std:c++11)
+	set(PYBIND11_CPP_STANDARD /std:c++14)
 	set(CMAKE_CXX_FLAGS "/W4 /EHsc")
 else()
 	set(PYBIND11_CPP_STANDARD -std=c++11)

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -293,10 +293,10 @@ RationalTime::to_time_string() const {
 
     double hour_units = std::fmod((double)total_seconds, time_units_per_day);
 
-    int hours = std::floor(hour_units / time_units_per_hour);
+    int hours = static_cast<int>(std::floor(hour_units / time_units_per_hour));
     double minute_units = std::fmod(hour_units, time_units_per_hour);
 
-    int minutes = std::floor(minute_units / time_units_per_minute);
+    int minutes = static_cast<int>(std::floor(minute_units / time_units_per_minute));
     double seconds = std::fmod(minute_units, time_units_per_minute);
 
     // split the seconds string apart

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -14,7 +14,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 class JSONDecoder : public OTIO_rapidjson::BaseReaderHandler<OTIO_rapidjson::UTF8<>, JSONDecoder> {
 public:
-    JSONDecoder(std::function<int ()> line_number_function)
+    JSONDecoder(std::function<size_t ()> line_number_function)
         : _line_number_function {line_number_function} {
         using namespace std::placeholders;
         _error_function = std::bind(&JSONDecoder::_error, this, _1);
@@ -121,7 +121,7 @@ public:
             else {
                 // when we end a dictionary, we immediately convert it
                 // to the type it really represents, if it is a schema object.
-                SerializableObject::Reader reader(top.dict, _error_function, nullptr, _line_number_function());
+                SerializableObject::Reader reader(top.dict, _error_function, nullptr, static_cast<int>(_line_number_function()));
                 _stack.pop_back();                
                 store(reader._decode(_resolver));
             }
@@ -185,7 +185,7 @@ public:
 
     std::vector<_DictOrArray> _stack;
     std::function<void (ErrorStatus const&)> _error_function;
-    std::function<int ()> _line_number_function;
+    std::function<size_t ()> _line_number_function;
 
     SerializableObject::Reader::_Resolver _resolver;
 };
@@ -309,12 +309,12 @@ bool SerializableObject::Reader::_fetch(std::string const& key, double* dest) {
         return true;
     }
     else if (e->second.type() == typeid(int)) {
-        *dest = any_cast<int>(e->second);
+        *dest = static_cast<double>(any_cast<int>(e->second));
         _dict.erase(e);
         return true;
     }
     else if (e->second.type() == typeid(int64_t)) {
-        *dest = any_cast<int64_t>(e->second);
+        *dest = static_cast<double>(any_cast<int64_t>(e->second));
         _dict.erase(e);
         return true;
     }
@@ -592,7 +592,15 @@ bool deserialize_json_from_string(std::string const& input, any* destination, Er
 }
 
 bool deserialize_json_from_file(std::string const& file_name, any* destination, ErrorStatus* error_status) {
-    FILE* fp = fopen(file_name.c_str(), "r");
+    FILE* fp = nullptr;
+#if defined(_WIN32)
+    if (fopen_s(&fp, file_name.c_str(), "r") != 0)
+    {
+        fp = nullptr;
+    }
+#else
+    fp = fopen(file_name.c_str(), "r");
+#endif
     if (!fp) {
         *error_status = ErrorStatus(ErrorStatus::FILE_OPEN_FAILED, file_name);
         return false;

--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -59,8 +59,8 @@ struct ErrorStatus {
           object_details(object) {
     }
     
-    ErrorStatus& operator=(Outcome outcome) {
-        *this = ErrorStatus(outcome);
+    ErrorStatus& operator=(Outcome in_outcome) {
+        *this = ErrorStatus(in_outcome);
         return *this;
     }
 

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -647,21 +647,21 @@ void SerializableObject::Writer::write(std::string const& key, any const& value)
         e->second(value);
     }
     else {
-        std::string e;
+        std::string s;
         std::string bad_type_name = (type == typeid(UnknownType)) ?
                                      demangled_type_name(any_cast<UnknownType>(value).type_name) :
                                      demangled_type_name(type);
             
         if (&key != &_no_key) {
-            e = string_printf("Encountered object of unknown type '%s' under key '%s'",
+            s = string_printf("Encountered object of unknown type '%s' under key '%s'",
                               bad_type_name.c_str(), key.c_str());
         }
         else {
-            e = string_printf("Encountered object of unknown type '%s'",
+            s = string_printf("Encountered object of unknown type '%s'",
                               bad_type_name.c_str());
         }
 
-        _encoder._error(ErrorStatus(ErrorStatus::TYPE_MISMATCH, e));
+        _encoder._error(ErrorStatus(ErrorStatus::TYPE_MISMATCH, s));
         _encoder.write_null_value();
     }
 }

--- a/src/opentimelineio/stackAlgorithm.cpp
+++ b/src/opentimelineio/stackAlgorithm.cpp
@@ -50,7 +50,8 @@ static void _flatten_next_item(RangeTrackMap& range_track_map, Track* flat_track
         }
         
         if (!item || item->visible() || track_index == 0) {
-            flat_track->insert_child(flat_track->children().size(), static_cast<Composable*>(child.value->clone(error_status)),
+            flat_track->insert_child(static_cast<int>(flat_track->children().size()),
+                                     static_cast<Composable*>(child.value->clone(error_status)),
                                      error_status);
             if (*error_status) {
                 return;

--- a/src/opentimelineio/stringUtils.cpp
+++ b/src/opentimelineio/stringUtils.cpp
@@ -1,5 +1,5 @@
 #include "opentimelineio/serializableObject.h"
-#if defined(__GNUC__) or defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__)
 #include <cstdlib>
 #include <memory>
 #include <cxxabi.h>
@@ -9,7 +9,7 @@
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
-#if defined(__GNUC__) or defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__)
 std::string cxxabi_demangled_type_name(const char* name) {
     int status = -4; // some arbitrary value to eliminate the compiler warning
 
@@ -30,7 +30,7 @@ std::string demangled_type_name(std::type_info const& t) {
         return "None";
     }
 
-#if defined(__GNUC__) or defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__)
     return cxxabi_demangled_type_name(t.name());
 #else
     // On Windows std::type_info.name() returns a human readable string.

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -61,8 +61,8 @@ TimeRange Track::range_of_child_at_index(int index, ErrorStatus* error_status) c
     RationalTime start_time(0, child_duration.rate());
     
     for (int i = 0; i < index; i++) {
-        Composable* child = children()[i].value;
-        if (!child->overlapping()) {
+        Composable* child2 = children()[i].value;
+        if (!child2->overlapping()) {
             start_time += _safe_duration(children()[i].value, error_status);
         }
         if (*error_status) {

--- a/src/opentimelineio/trackAlgorithm.cpp
+++ b/src/opentimelineio/trackAlgorithm.cpp
@@ -28,7 +28,7 @@ Track* track_trimmed_to_range(Track* in_track, TimeRange trim_range, ErrorStatus
         
         auto child_range = child_range_it->second;
         if (!trim_range.overlaps(child_range)) {
-            new_track->remove_child(i, error_status);
+            new_track->remove_child(static_cast<int>(i), error_status);
             if (*error_status) {
                 return nullptr;
             }

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.cpp
@@ -30,20 +30,12 @@ py::object plain_string(std::string const& s) {
 }
 
 py::object plain_int(int i) {
-    #if PY_MAJOR_VERSION >= 3
-        PyObject *p = PyLong_FromLong(i);
-    #else
-        PyObject *p = PyInt_FromLong(i);
-    #endif
+    PyObject *p = PyLong_FromLong(i);
     return py::reinterpret_steal<py::object>(p);
 }
 
 py::object plain_int(int64_t i) {
-    #if PY_MAJOR_VERSION >= 3
-        PyObject *p = PyLong_FromLong(i);
-    #else
-        PyObject *p = PyInt_FromLong(i);
-    #endif
+    PyObject *p = PyLong_FromLongLong(i);
     return py::reinterpret_steal<py::object>(p);
 }
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
@@ -110,7 +110,7 @@ struct MutableSequencePyAPI : public V {
     }
 
     int len() {
-        return this->size();
+        return static_cast<int>(this->size());
     }
 
     Iterator* iter() {


### PR DESCRIPTION
These changes fix all warnings when compiling with Visual Studio 2019. Note that I bumped PyBind11 to C++14 on Windows, since it looks like C++11 isn't supported by PyBind11 on Windows (I was getting "/std:c++11" argument not recognized warnings when compiling the Python bindings):

https://pybind11.readthedocs.io/en/stable/compiling.html#configuration-variables
