### PR TITLE
Ensure that dictionary comparison is symmetrical

### DIFF
--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -463,7 +463,7 @@ bool SerializableObject::Writer::_any_dict_equals(any const& lhs, any const& rhs
         }
         ++r_it;
     }
-    return true;
+    return r_it == rd.end();
 }
 
 bool SerializableObject::Writer::_any_array_equals(any const& lhs, any const& rhs) {
@@ -678,8 +678,9 @@ bool SerializableObject::is_equivalent_to(SerializableObject const& other) const
     w1.write(w1._no_key, any(Retainer<>(this)));
     w2.write(w2._no_key, any(Retainer<>(&other)));
 
-    return !e1.has_errored() && !e2.has_errored() &&
-            w1._any_equals(e1._root, e2._root);
+    return (!e1.has_errored() 
+            && !e2.has_errored()
+            && w1._any_equals(e1._root, e2._root));
 }
 
 SerializableObject* SerializableObject::clone(ErrorStatus* error_status) const {

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -147,6 +147,28 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertTrue(o1.is_equivalent_to(o2))
         self.assertIsOTIOEquivalentTo(o1, o2)
 
+    def test_equivalence_symmetry(self):
+        def test_equivalence(A, B, msg):
+            self.assertTrue(A.is_equivalent_to(B), "{}: A ~= B".format(msg))
+            self.assertTrue(B.is_equivalent_to(A), "{}: B ~= A".format(msg))
+
+        def test_difference(A, B, msg):
+            self.assertFalse(A.is_equivalent_to(B), "{}: A ~= B".format(msg))
+            self.assertFalse(B.is_equivalent_to(A), "{}: B ~= A".format(msg))
+
+        A = otio.core.Composable()
+        B = otio.core.Composable()
+        test_equivalence(A, B, "blank objects")
+
+        A.metadata["key"] = {"a": 0}
+        test_difference(A, B, "A has different metadata")
+
+        B.metadata["key"] = {"a": 0}
+        test_equivalence(A, B, "add metadata to B")
+
+        A.metadata["key"]["sub-key"] = 1
+        test_difference(A, B, "Add dict within A with specific metadata")
+
     def test_truthiness(self):
         o = otio.core.SerializableObject()
         self.assertTrue(o)


### PR DESCRIPTION
Fixes #578 

The any dictionary equality function was walking over the left
dictionary and incrementing an iterator.  To make sure that the
dictionaries are equivalent, checking to make sure that the end of BOTH
dictionaries has been reached at the end of the function instead of just
the left dictionary should correct the symmetry of is_equivalent_to.