### PR TITLE
Use os.pathsep instead of ':' for splitting the OTIO_MANIFEST_...

### DIFF
--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -256,7 +256,7 @@ def load_manifest():
     # read local adapter manifests, if they exist
     _local_manifest_path = os.environ.get("OTIO_PLUGIN_MANIFEST_PATH", None)
     if _local_manifest_path is not None:
-        for json_path in _local_manifest_path.split(":"):
+        for json_path in _local_manifest_path.split(os.pathsep):
             if not os.path.exists(json_path):
                 # XXX: In case error reporting is requested
                 # print(


### PR DESCRIPTION
Fix #581 

