### PR TITLE
Fix tests for Visual Studio 2019

### DIFF
--- a/src/opentimelineio/serializableObject.cpp
+++ b/src/opentimelineio/serializableObject.cpp
@@ -133,6 +133,7 @@ void SerializableObject::_managed_release() {
     _mutex.lock();
 
     if (--_managed_ref_count == 0) {
+        _mutex.unlock();
         delete this;
         return;
     }

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -201,32 +201,29 @@ class TestPluginManifest(unittest.TestCase):
         # Generate a fake manifest in a temp file, and point at it with
         # the environment variable
         temp_dir = tempfile.mkdtemp(prefix='test_find_manifest_by_environment_variable')
-        try:
-            temp_file = os.path.join(temp_dir, 'bar' + suffix)
-            otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
+        temp_file = os.path.join(temp_dir, 'bar' + suffix)
+        otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
 
-            # clear out existing manifest
-            otio.plugins.manifest._MANIFEST = None
+        # clear out existing manifest
+        otio.plugins.manifest._MANIFEST = None
 
-            # set where to find the new manifest
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = temp_file + os.pathsep + 'foo'
-            result = otio.plugins.manifest.load_manifest()
+        # set where to find the new manifest
+        os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = temp_file + os.pathsep + 'foo'
+        result = otio.plugins.manifest.load_manifest()
 
-            # Rather than try and remove any other setuptools based plugins
-            # that might be installed, this check is made more permissive to
-            # see if the known unit test linker is being loaded by the manifest
-            self.assertTrue(len(result.media_linkers) > 0)
-            self.assertIn("example", (ml.name for ml in result.media_linkers))
-            
-            otio.plugins.manifest._MANIFEST = bak
-            if bak_env:
-                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
-            else:
-                del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
+        # Rather than try and remove any other setuptools based plugins
+        # that might be installed, this check is made more permissive to
+        # see if the known unit test linker is being loaded by the manifest
+        self.assertTrue(len(result.media_linkers) > 0)
+        self.assertIn("example", (ml.name for ml in result.media_linkers))
+        
+        otio.plugins.manifest._MANIFEST = bak
+        if bak_env:
+            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
+        else:
+            del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
 
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        shutil.rmtree(temp_dir)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -23,6 +23,7 @@
 #
 import unittest
 import os
+import shutil
 import tempfile
 
 import opentimelineio as otio
@@ -199,14 +200,16 @@ class TestPluginManifest(unittest.TestCase):
 
         # Generate a fake manifest in a temp file, and point at it with
         # the environment variable
-        with tempfile.NamedTemporaryFile(suffix=suffix) as fpath:
-            otio.adapters.write_to_file(self.man, fpath.name, 'otio_json')
+        temp_dir = tempfile.mkdtemp(prefix='test_find_manifest_by_environment_variable')
+        try:
+            temp_file = os.path.join(temp_dir, 'bar' + suffix)
+            otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
 
             # clear out existing manifest
             otio.plugins.manifest._MANIFEST = None
 
             # set where to find the new manifest
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = fpath.name + ':foo'
+            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = temp_file + os.pathsep + 'foo'
             result = otio.plugins.manifest.load_manifest()
 
             # Rather than try and remove any other setuptools based plugins
@@ -214,13 +217,16 @@ class TestPluginManifest(unittest.TestCase):
             # see if the known unit test linker is being loaded by the manifest
             self.assertTrue(len(result.media_linkers) > 0)
             self.assertIn("example", (ml.name for ml in result.media_linkers))
+            
+            otio.plugins.manifest._MANIFEST = bak
+            if bak_env:
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
+            else:
+                del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
 
-        otio.plugins.manifest._MANIFEST = bak
-        if bak_env:
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
-        else:
-            del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
-
+        except:
+            shutil.rmtree(temp_dir)
+            raise
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -216,7 +216,7 @@ class TestPluginManifest(unittest.TestCase):
         # see if the known unit test linker is being loaded by the manifest
         self.assertTrue(len(result.media_linkers) > 0)
         self.assertIn("example", (ml.name for ml in result.media_linkers))
-        
+
         otio.plugins.manifest._MANIFEST = bak
         if bak_env:
             os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
@@ -224,6 +224,7 @@ class TestPluginManifest(unittest.TestCase):
             del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
 
         shutil.rmtree(temp_dir)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -201,29 +201,31 @@ class TestPluginManifest(unittest.TestCase):
         # Generate a fake manifest in a temp file, and point at it with
         # the environment variable
         temp_dir = tempfile.mkdtemp(prefix='test_find_manifest_by_environment_variable')
-        temp_file = os.path.join(temp_dir, 'bar' + suffix)
-        otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
+        try:
+            temp_file = os.path.join(temp_dir, 'bar' + suffix)
+            otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
 
-        # clear out existing manifest
-        otio.plugins.manifest._MANIFEST = None
+            # clear out existing manifest
+            otio.plugins.manifest._MANIFEST = None
 
-        # set where to find the new manifest
-        os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = temp_file + os.pathsep + 'foo'
-        result = otio.plugins.manifest.load_manifest()
+            # set where to find the new manifest
+            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = temp_file + os.pathsep + 'foo'
+            result = otio.plugins.manifest.load_manifest()
 
-        # Rather than try and remove any other setuptools based plugins
-        # that might be installed, this check is made more permissive to
-        # see if the known unit test linker is being loaded by the manifest
-        self.assertTrue(len(result.media_linkers) > 0)
-        self.assertIn("example", (ml.name for ml in result.media_linkers))
+            # Rather than try and remove any other setuptools based plugins
+            # that might be installed, this check is made more permissive to
+            # see if the known unit test linker is being loaded by the manifest
+            self.assertTrue(len(result.media_linkers) > 0)
+            self.assertIn("example", (ml.name for ml in result.media_linkers))
 
-        otio.plugins.manifest._MANIFEST = bak
-        if bak_env:
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
-        else:
-            del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
+            otio.plugins.manifest._MANIFEST = bak
+            if bak_env:
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
+            else:
+                del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
 
-        shutil.rmtree(temp_dir)
+        finally:
+            shutil.rmtree(temp_dir)
 
 
 if __name__ == '__main__':

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -46,14 +46,11 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         edl_path = SCREENING_EXAMPLE_PATH
         timeline = otio.adapters.read_from_file(edl_path)
         temp_dir = tempfile.mkdtemp(prefix='test_disk_io')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
-            otio.adapters.write_to_file(timeline, temp_file)
-            decoded = otio.adapters.read_from_file(temp_file)
-            self.assertJsonEqual(timeline, decoded)
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        temp_file = os.path.join(temp_dir, "foo.otio")
+        otio.adapters.write_to_file(timeline, temp_file)
+        decoded = otio.adapters.read_from_file(temp_file)
+        self.assertJsonEqual(timeline, decoded)
+        shutil.rmtree(temp_dir)
 
     def test_otio_round_trip(self):
         tl = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
@@ -63,18 +60,15 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(tl.name, "Example_Screening.01")
 
         temp_dir = tempfile.mkdtemp(prefix='test_otio_round_trip')
-        try:
-            temp_file = os.path.join(temp_dir, 'test.otio')
-            otio.adapters.otio_json.write_to_file(tl, temp_file)
-            new = otio.adapters.otio_json.read_from_file(temp_file)
+        temp_file = os.path.join(temp_dir, 'test.otio')
+        otio.adapters.otio_json.write_to_file(tl, temp_file)
+        new = otio.adapters.otio_json.read_from_file(temp_file)
 
-            new_json = otio.adapters.otio_json.write_to_string(new)
+        new_json = otio.adapters.otio_json.write_to_string(new)
 
-            self.assertMultiLineEqual(baseline_json, new_json)
-            self.assertIsOTIOEquivalentTo(tl, new)
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        self.assertMultiLineEqual(baseline_json, new_json)
+        self.assertIsOTIOEquivalentTo(tl, new)
+        shutil.rmtree(temp_dir)
 
     def test_disk_vs_string(self):
         """ Writing to disk and writing to a string should
@@ -83,17 +77,14 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
 
         temp_dir = tempfile.mkdtemp(prefix='test_disk_vs_string')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
-            otio.adapters.write_to_file(timeline, temp_file)
-            in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
-            with open(temp_file, 'r') as f:
-                on_disk = f.read()
+        temp_file = os.path.join(temp_dir, "foo.otio")
+        otio.adapters.write_to_file(timeline, temp_file)
+        in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
+        with open(temp_file, 'r') as f:
+            on_disk = f.read()
 
-            self.assertEqual(in_memory, on_disk)
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        self.assertEqual(in_memory, on_disk)
+        shutil.rmtree(temp_dir)
 
     def test_adapters_fetch(self):
         """ Test the dynamic string based adapter fetching """

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -72,7 +72,7 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
             self.assertMultiLineEqual(baseline_json, new_json)
             self.assertIsOTIOEquivalentTo(tl, new)
-            
+
         finally:
             shutil.rmtree(temp_dir)
 

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -46,11 +46,14 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         edl_path = SCREENING_EXAMPLE_PATH
         timeline = otio.adapters.read_from_file(edl_path)
         temp_dir = tempfile.mkdtemp(prefix='test_disk_io')
-        temp_file = os.path.join(temp_dir, "foo.otio")
-        otio.adapters.write_to_file(timeline, temp_file)
-        decoded = otio.adapters.read_from_file(temp_file)
-        self.assertJsonEqual(timeline, decoded)
-        shutil.rmtree(temp_dir)
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+            otio.adapters.write_to_file(timeline, temp_file)
+            decoded = otio.adapters.read_from_file(temp_file)
+            self.assertJsonEqual(timeline, decoded)
+
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_otio_round_trip(self):
         tl = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
@@ -60,15 +63,18 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(tl.name, "Example_Screening.01")
 
         temp_dir = tempfile.mkdtemp(prefix='test_otio_round_trip')
-        temp_file = os.path.join(temp_dir, 'test.otio')
-        otio.adapters.otio_json.write_to_file(tl, temp_file)
-        new = otio.adapters.otio_json.read_from_file(temp_file)
+        try:
+            temp_file = os.path.join(temp_dir, 'test.otio')
+            otio.adapters.otio_json.write_to_file(tl, temp_file)
+            new = otio.adapters.otio_json.read_from_file(temp_file)
 
-        new_json = otio.adapters.otio_json.write_to_string(new)
+            new_json = otio.adapters.otio_json.write_to_string(new)
 
-        self.assertMultiLineEqual(baseline_json, new_json)
-        self.assertIsOTIOEquivalentTo(tl, new)
-        shutil.rmtree(temp_dir)
+            self.assertMultiLineEqual(baseline_json, new_json)
+            self.assertIsOTIOEquivalentTo(tl, new)
+            
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_disk_vs_string(self):
         """ Writing to disk and writing to a string should
@@ -77,14 +83,17 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
 
         temp_dir = tempfile.mkdtemp(prefix='test_disk_vs_string')
-        temp_file = os.path.join(temp_dir, "foo.otio")
-        otio.adapters.write_to_file(timeline, temp_file)
-        in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
-        with open(temp_file, 'r') as f:
-            on_disk = f.read()
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+            otio.adapters.write_to_file(timeline, temp_file)
+            in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
+            with open(temp_file, 'r') as f:
+                on_disk = f.read()
 
-        self.assertEqual(in_memory, on_disk)
-        shutil.rmtree(temp_dir)
+            self.assertEqual(in_memory, on_disk)
+
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_adapters_fetch(self):
         """ Test the dynamic string based adapter fetching """

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -25,6 +25,7 @@
 """Test builtin adapters."""
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -44,10 +45,15 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_disk_io(self):
         edl_path = SCREENING_EXAMPLE_PATH
         timeline = otio.adapters.read_from_file(edl_path)
-        otiotmp = tempfile.mkstemp(suffix=".otio", text=True)[1]
-        otio.adapters.write_to_file(timeline, otiotmp)
-        decoded = otio.adapters.read_from_file(otiotmp)
-        self.assertJsonEqual(timeline, decoded)
+        temp_dir = tempfile.mkdtemp(prefix='test_disk_io')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+            otio.adapters.write_to_file(timeline, temp_file)
+            decoded = otio.adapters.read_from_file(temp_file)
+            self.assertJsonEqual(timeline, decoded)
+        except:
+            shutil.rmtree(temp_dir)
+            raise
 
     def test_otio_round_trip(self):
         tl = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
@@ -56,17 +62,19 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(tl.name, "Example_Screening.01")
 
-        temp_dir = tempfile.mkdtemp(prefix='test_otio_adapter')
-        temp_file = os.path.join(temp_dir, 'test.otio')
-        otio.adapters.otio_json.write_to_file(tl, temp_file)
-        new = otio.adapters.otio_json.read_from_file(temp_file)
+        temp_dir = tempfile.mkdtemp(prefix='test_otio_round_trip')
+        try:
+            temp_file = os.path.join(temp_dir, 'test.otio')
+            otio.adapters.otio_json.write_to_file(tl, temp_file)
+            new = otio.adapters.otio_json.read_from_file(temp_file)
 
-        new_json = otio.adapters.otio_json.write_to_string(new)
+            new_json = otio.adapters.otio_json.write_to_string(new)
 
-        self.assertMultiLineEqual(baseline_json, new_json)
-        self.assertIsOTIOEquivalentTo(tl, new)
-        # Clean up the temporary file when you're finished.
-        os.remove(temp_file)
+            self.assertMultiLineEqual(baseline_json, new_json)
+            self.assertIsOTIOEquivalentTo(tl, new)
+        except:
+            shutil.rmtree(temp_dir)
+            raise
 
     def test_disk_vs_string(self):
         """ Writing to disk and writing to a string should
@@ -74,13 +82,18 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         """
         timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
 
-        tmp = tempfile.mkstemp(suffix=".otio", text=True)[1]
-        otio.adapters.write_to_file(timeline, tmp)
-        in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
-        with open(tmp, 'r') as f:
-            on_disk = f.read()
+        temp_dir = tempfile.mkdtemp(prefix='test_disk_vs_string')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+            otio.adapters.write_to_file(timeline, temp_file)
+            in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
+            with open(temp_file, 'r') as f:
+                on_disk = f.read()
 
-        self.assertEqual(in_memory, on_disk)
+            self.assertEqual(in_memory, on_disk)
+        except:
+            shutil.rmtree(temp_dir)
+            raise
 
     def test_adapters_fetch(self):
         """ Test the dynamic string based adapter fetching """

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -190,7 +190,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             # read results back in
             with open(temp_file, 'r') as fi:
                 self.assertIn('"name": "Example_Screening.01",', fi.read())
-        
+
         finally:
             shutil.rmtree(temp_dir)
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -27,6 +27,7 @@
 import unittest
 import sys
 import os
+import shutil
 import tempfile
 import subprocess
 
@@ -173,11 +174,13 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
     test_module = otio_console.otioconvert
 
     def test_basic(self):
-        with tempfile.NamedTemporaryFile() as tf:
+        temp_dir = tempfile.mkdtemp(prefix='test_basic')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 '--tracks', '0',
                 "-a", "rate=24",
@@ -185,16 +188,23 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             self.run_test()
 
             # read results back in
-            with open(tf.name, 'r') as fi:
+            with open(temp_file, 'r') as fi:
                 self.assertIn('"name": "Example_Screening.01",', fi.read())
 
+        except:
+            shutil.rmtree(temp_dir)
+            raise
+
     def test_begin_end(self):
-        with tempfile.NamedTemporaryFile() as tf:
+        temp_dir = tempfile.mkdtemp(prefix='test_begin_end')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+
             # begin needs to be a,b
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "--begin", "foobar"
             ]
@@ -205,7 +215,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "--end", "foobar"
             ]
@@ -216,7 +226,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "--begin", "0,24",
                 "--end", "0,24",
@@ -227,7 +237,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "--begin", "0",
                 "--end", "0,24",
@@ -238,7 +248,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "--begin", "0,24",
                 "--end", "0",
@@ -246,16 +256,23 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             with self.assertRaises(SystemExit):
                 self.run_test()
 
-            result = otio.adapters.read_from_file(tf.name, "otio_json")
+            result = otio.adapters.read_from_file(temp_file, "otio_json")
             self.assertEquals(len(result.tracks[0]), 0)
             self.assertEquals(result.name, "Example_Screening.01")
 
+        except:
+            shutil.rmtree(temp_dir)
+            raise
+
     def test_input_argument_error(self):
-        with tempfile.NamedTemporaryFile(suffix=".otio") as tf:
+        temp_dir = tempfile.mkdtemp(prefix='test_input_argument_error')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 "-a", "foobar",
             ]
 
@@ -265,12 +282,19 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             # read results back in
             self.assertIn('error: input adapter', sys.stderr.getvalue())
 
+        except:
+            shutil.rmtree(temp_dir)
+            raise
+
     def test_output_argument_error(self):
-        with tempfile.NamedTemporaryFile() as tf:
+        temp_dir = tempfile.mkdtemp(prefix='test_output_argument_error')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "-A", "foobar",
             ]
@@ -281,12 +305,19 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             # read results back in
             self.assertIn('error: output adapter', sys.stderr.getvalue())
 
+        except:
+            shutil.rmtree(temp_dir)
+            raise
+
     def test_media_linker_argument_error(self):
-        with tempfile.NamedTemporaryFile() as tf:
+        temp_dir = tempfile.mkdtemp(prefix='test_media_linker_argument_error')
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
-                '-o', tf.name,
+                '-o', temp_file,
                 '-O', 'otio_json',
                 "-m", "fake_linker",
                 "-M", "somestring=foobar",
@@ -299,6 +330,9 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             # read results back in
             self.assertIn('error: media linker', sys.stderr.getvalue())
 
+        except:
+            shutil.rmtree(temp_dir)
+            raise
 
 OTIOConvertTests_OnShell = CreateShelloutTest(OTIOConvertTests)
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -319,6 +319,7 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
 
         shutil.rmtree(temp_dir)
 
+
 OTIOConvertTests_OnShell = CreateShelloutTest(OTIOConvertTests)
 
 if __name__ == '__main__':

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -175,164 +175,149 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
 
     def test_basic(self):
         temp_dir = tempfile.mkdtemp(prefix='test_basic')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                '--tracks', '0',
-                "-a", "rate=24",
-            ]
-            self.run_test()
+        temp_file = os.path.join(temp_dir, "foo.otio")
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            '--tracks', '0',
+            "-a", "rate=24",
+        ]
+        self.run_test()
 
-            # read results back in
-            with open(temp_file, 'r') as fi:
-                self.assertIn('"name": "Example_Screening.01",', fi.read())
+        # read results back in
+        with open(temp_file, 'r') as fi:
+            self.assertIn('"name": "Example_Screening.01",', fi.read())
 
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        shutil.rmtree(temp_dir)
 
     def test_begin_end(self):
         temp_dir = tempfile.mkdtemp(prefix='test_begin_end')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        temp_file = os.path.join(temp_dir, "foo.otio")
 
-            # begin needs to be a,b
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "--begin", "foobar"
-            ]
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        # begin needs to be a,b
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "--begin", "foobar"
+        ]
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            # end requires begin
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "--end", "foobar"
-            ]
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        # end requires begin
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "--end", "foobar"
+        ]
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            # prune everything
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "--begin", "0,24",
-                "--end", "0,24",
-            ]
-            otio_console.otioconvert.main()
+        # prune everything
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "--begin", "0,24",
+            "--end", "0,24",
+        ]
+        otio_console.otioconvert.main()
 
-            # check that begin/end "," parsing is checked
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "--begin", "0",
-                "--end", "0,24",
-            ]
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        # check that begin/end "," parsing is checked
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "--begin", "0",
+            "--end", "0,24",
+        ]
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "--begin", "0,24",
-                "--end", "0",
-            ]
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "--begin", "0,24",
+            "--end", "0",
+        ]
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            result = otio.adapters.read_from_file(temp_file, "otio_json")
-            self.assertEquals(len(result.tracks[0]), 0)
-            self.assertEquals(result.name, "Example_Screening.01")
+        result = otio.adapters.read_from_file(temp_file, "otio_json")
+        self.assertEquals(len(result.tracks[0]), 0)
+        self.assertEquals(result.name, "Example_Screening.01")
 
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        shutil.rmtree(temp_dir)
 
     def test_input_argument_error(self):
         temp_dir = tempfile.mkdtemp(prefix='test_input_argument_error')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        temp_file = os.path.join(temp_dir, "foo.otio")
 
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                "-a", "foobar",
-            ]
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            "-a", "foobar",
+        ]
 
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            # read results back in
-            self.assertIn('error: input adapter', sys.stderr.getvalue())
+        # read results back in
+        self.assertIn('error: input adapter', sys.stderr.getvalue())
 
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        shutil.rmtree(temp_dir)
 
     def test_output_argument_error(self):
         temp_dir = tempfile.mkdtemp(prefix='test_output_argument_error')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        temp_file = os.path.join(temp_dir, "foo.otio")
 
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "-A", "foobar",
-            ]
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "-A", "foobar",
+        ]
 
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            # read results back in
-            self.assertIn('error: output adapter', sys.stderr.getvalue())
+        # read results back in
+        self.assertIn('error: output adapter', sys.stderr.getvalue())
 
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        shutil.rmtree(temp_dir)
 
     def test_media_linker_argument_error(self):
         temp_dir = tempfile.mkdtemp(prefix='test_media_linker_argument_error')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        temp_file = os.path.join(temp_dir, "foo.otio")
 
-            sys.argv = [
-                'otioconvert',
-                '-i', SCREENING_EXAMPLE_PATH,
-                '-o', temp_file,
-                '-O', 'otio_json',
-                "-m", "fake_linker",
-                "-M", "somestring=foobar",
-                "-M", "foobar",
-            ]
+        sys.argv = [
+            'otioconvert',
+            '-i', SCREENING_EXAMPLE_PATH,
+            '-o', temp_file,
+            '-O', 'otio_json',
+            "-m", "fake_linker",
+            "-M", "somestring=foobar",
+            "-M", "foobar",
+        ]
 
-            with self.assertRaises(SystemExit):
-                self.run_test()
+        with self.assertRaises(SystemExit):
+            self.run_test()
 
-            # read results back in
-            self.assertIn('error: media linker', sys.stderr.getvalue())
+        # read results back in
+        self.assertIn('error: media linker', sys.stderr.getvalue())
 
-        except:
-            shutil.rmtree(temp_dir)
-            raise
+        shutil.rmtree(temp_dir)
 
 OTIOConvertTests_OnShell = CreateShelloutTest(OTIOConvertTests)
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -175,149 +175,159 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
 
     def test_basic(self):
         temp_dir = tempfile.mkdtemp(prefix='test_basic')
-        temp_file = os.path.join(temp_dir, "foo.otio")
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            '--tracks', '0',
-            "-a", "rate=24",
-        ]
-        self.run_test()
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                '--tracks', '0',
+                "-a", "rate=24",
+            ]
+            self.run_test()
 
-        # read results back in
-        with open(temp_file, 'r') as fi:
-            self.assertIn('"name": "Example_Screening.01",', fi.read())
-
-        shutil.rmtree(temp_dir)
+            # read results back in
+            with open(temp_file, 'r') as fi:
+                self.assertIn('"name": "Example_Screening.01",', fi.read())
+        
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_begin_end(self):
         temp_dir = tempfile.mkdtemp(prefix='test_begin_end')
-        temp_file = os.path.join(temp_dir, "foo.otio")
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
 
-        # begin needs to be a,b
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "--begin", "foobar"
-        ]
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            # begin needs to be a,b
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "--begin", "foobar"
+            ]
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        # end requires begin
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "--end", "foobar"
-        ]
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            # end requires begin
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "--end", "foobar"
+            ]
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        # prune everything
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "--begin", "0,24",
-            "--end", "0,24",
-        ]
-        otio_console.otioconvert.main()
+            # prune everything
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "--begin", "0,24",
+                "--end", "0,24",
+            ]
+            otio_console.otioconvert.main()
 
-        # check that begin/end "," parsing is checked
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "--begin", "0",
-            "--end", "0,24",
-        ]
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            # check that begin/end "," parsing is checked
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "--begin", "0",
+                "--end", "0,24",
+            ]
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "--begin", "0,24",
-            "--end", "0",
-        ]
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "--begin", "0,24",
+                "--end", "0",
+            ]
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        result = otio.adapters.read_from_file(temp_file, "otio_json")
-        self.assertEquals(len(result.tracks[0]), 0)
-        self.assertEquals(result.name, "Example_Screening.01")
+            result = otio.adapters.read_from_file(temp_file, "otio_json")
+            self.assertEquals(len(result.tracks[0]), 0)
+            self.assertEquals(result.name, "Example_Screening.01")
 
-        shutil.rmtree(temp_dir)
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_input_argument_error(self):
         temp_dir = tempfile.mkdtemp(prefix='test_input_argument_error')
-        temp_file = os.path.join(temp_dir, "foo.otio")
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
 
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            "-a", "foobar",
-        ]
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                "-a", "foobar",
+            ]
 
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        # read results back in
-        self.assertIn('error: input adapter', sys.stderr.getvalue())
+            # read results back in
+            self.assertIn('error: input adapter', sys.stderr.getvalue())
 
-        shutil.rmtree(temp_dir)
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_output_argument_error(self):
         temp_dir = tempfile.mkdtemp(prefix='test_output_argument_error')
-        temp_file = os.path.join(temp_dir, "foo.otio")
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
 
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "-A", "foobar",
-        ]
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "-A", "foobar",
+            ]
 
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        # read results back in
-        self.assertIn('error: output adapter', sys.stderr.getvalue())
+            # read results back in
+            self.assertIn('error: output adapter', sys.stderr.getvalue())
 
-        shutil.rmtree(temp_dir)
+        finally:
+            shutil.rmtree(temp_dir)
 
     def test_media_linker_argument_error(self):
         temp_dir = tempfile.mkdtemp(prefix='test_media_linker_argument_error')
-        temp_file = os.path.join(temp_dir, "foo.otio")
+        try:
+            temp_file = os.path.join(temp_dir, "foo.otio")
 
-        sys.argv = [
-            'otioconvert',
-            '-i', SCREENING_EXAMPLE_PATH,
-            '-o', temp_file,
-            '-O', 'otio_json',
-            "-m", "fake_linker",
-            "-M", "somestring=foobar",
-            "-M", "foobar",
-        ]
+            sys.argv = [
+                'otioconvert',
+                '-i', SCREENING_EXAMPLE_PATH,
+                '-o', temp_file,
+                '-O', 'otio_json',
+                "-m", "fake_linker",
+                "-M", "somestring=foobar",
+                "-M", "foobar",
+            ]
 
-        with self.assertRaises(SystemExit):
-            self.run_test()
+            with self.assertRaises(SystemExit):
+                self.run_test()
 
-        # read results back in
-        self.assertIn('error: media linker', sys.stderr.getvalue())
+            # read results back in
+            self.assertIn('error: media linker', sys.stderr.getvalue())
 
-        shutil.rmtree(temp_dir)
+        finally:
+            shutil.rmtree(temp_dir)
 
 
 OTIOConvertTests_OnShell = CreateShelloutTest(OTIOConvertTests)


### PR DESCRIPTION
A number of the core tests (OTIO_DISABLE_SHELLOUT_TESTS=true) were failing on Windows, this pull request has two changes to fix that.

Tests were crashing on exit with the error message, "d:\agent\_work\2\s\src\vctools\crt\crtw32\stdcpp\thr\mutex.c(64): mutex destroyed while busy". To fix this I unlocked the mutex in serializableObject.cpp before it is deleted.

Tests with temporary files were failing since the C++ code could not reopen the files opened by Python (this is mentioned as a caveat in the docs for tempfile.NamedTemporaryFile()). Since the Python tests don't actually need the file object, just the file name, I replaced using NamedTemporaryFile() with temporary directories that Python then passes to C++ along with a file name.
