### PR TITLE
Initial implementation of ImageSequenceReference

### DIFF
--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -183,16 +183,16 @@ parameters:
 
 parameters:
 - *available_range*
-- *image_number_zero_padding*
+- *frame_step*
+- *frame_zero_padding*
 - *metadata*
 - *missing_frame_policy*
 - *name*
 - *name_prefix*
 - *name_suffix*
 - *rate*
-- *start_value*
+- *start_frame*
 - *target_url_base*
-- *value_step*
 
 ### LinearTimeWarp.1
 

--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -179,6 +179,21 @@ parameters:
 - *name*
 - *parameters*
 
+### ImageSequenceReference.1
+
+parameters:
+- *available_range*
+- *image_number_zero_padding*
+- *metadata*
+- *missing_frame_policy*
+- *name*
+- *name_prefix*
+- *name_suffix*
+- *rate*
+- *start_value*
+- *target_url_base*
+- *value_step*
+
 ### LinearTimeWarp.1
 
 parameters:

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -354,6 +354,29 @@ parameters:
 - *name*: 
 - *parameters*: 
 
+### ImageSequenceReference.1
+
+*full module path*: `opentimelineio.schema.ImageSequenceReference`
+
+*documentation*:
+
+```
+None
+```
+
+parameters:
+- *available_range*: 
+- *image_number_zero_padding*: 
+- *metadata*: 
+- *missing_frame_policy*: 
+- *name*: 
+- *name_prefix*: 
+- *name_suffix*: 
+- *rate*: 
+- *start_value*: 
+- *target_url_base*: 
+- *value_step*: 
+
 ### LinearTimeWarp.1
 
 *full module path*: `opentimelineio.schema.LinearTimeWarp`

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -366,16 +366,16 @@ None
 
 parameters:
 - *available_range*: 
-- *image_number_zero_padding*: 
+- *frame_step*: 
+- *frame_zero_padding*: 
 - *metadata*: 
 - *missing_frame_policy*: 
 - *name*: 
 - *name_prefix*: 
 - *name_suffix*: 
 - *rate*: 
-- *start_value*: 
+- *start_frame*: 
 - *target_url_base*: 
-- *value_step*: 
 
 ### LinearTimeWarp.1
 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -12,6 +12,7 @@ set(OPENTIMELINEIO_HEADER_FILES
     freezeFrame.h
     gap.h
     generatorReference.h
+    imageSequenceReference.h
     item.h
     linearTimeWarp.h
     marker.h
@@ -47,6 +48,7 @@ add_library(opentimelineio SHARED
             freezeFrame.cpp
             gap.cpp
             generatorReference.cpp
+            imageSequenceReference.cpp
             item.cpp
             linearTimeWarp.cpp
             marker.cpp

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -5,10 +5,10 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 ImageSequenceReference::ImageSequenceReference(std::string const& target_url_base,
                       std::string const& name_prefix,
                       std::string const& name_suffix,
-                      int start_value,
-                      int value_step,
+                      int start_frame,
+                      int frame_step,
                       double const rate,
-                      int image_number_zero_padding,
+                      int frame_zero_padding,
                       MissingFramePolicy const missing_frame_policy,
                       optional<TimeRange> const& available_range,
                       AnyDictionary const& metadata)
@@ -16,10 +16,10 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
     _target_url_base(target_url_base),
     _name_prefix(name_prefix),
     _name_suffix(name_suffix),
-    _start_value {start_value},
-    _value_step {value_step},
+    _start_frame {start_frame},
+    _frame_step {frame_step},
     _rate {rate},
-    _image_number_zero_padding {image_number_zero_padding},
+    _frame_zero_padding {frame_zero_padding},
     _missing_frame_policy {missing_frame_policy} {
     }
 
@@ -28,18 +28,18 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
 
     RationalTime
     ImageSequenceReference::frame_duration() const {
-        return RationalTime((double)_value_step, _rate);
+        return RationalTime((double)_frame_step, _rate);
     }
 
     int ImageSequenceReference::number_of_images_in_sequence() const {
         if (!this->available_range().has_value()) {
             return 0;
         }
-        
-        double playback_rate = (_rate / (double)_value_step);
+
+        double playback_rate = (_rate / (double)_frame_step);
         int num_frames = this->available_range().value().duration().to_frames(playback_rate);
         return num_frames;
-    } 
+    }
 
     std::string
     ImageSequenceReference::target_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
@@ -47,12 +47,12 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
             *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX);
             return std::string();
         }
-        const int file_image_num = _start_value + (image_number * _value_step);
+        const int file_image_num = _start_frame + (image_number * _frame_step);
         const bool is_negative = (file_image_num < 0);
         std::string image_num_string = std::to_string(abs(file_image_num));
         std::string zero_pad = std::string();
-        if (image_num_string.length() <  _image_number_zero_padding) {
-            zero_pad = std::string(_image_number_zero_padding - image_num_string.length(), '0');
+        if (image_num_string.length() <  _frame_zero_padding) {
+            zero_pad = std::string(_frame_zero_padding - image_num_string.length(), '0');
         }
 
         std::string sign = std::string();
@@ -81,16 +81,16 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         auto result = reader.read("target_url_base", &_target_url_base) &&
                 reader.read("name_prefix", &_name_prefix) &&
                 reader.read("name_suffix", &_name_suffix) &&
-                reader.read("start_value", &_start_value) &&
-                reader.read("value_step", &_value_step) &&
+                reader.read("start_frame", &_start_frame) &&
+                reader.read("frame_step", &_frame_step) &&
                 reader.read("rate", &_rate) &&
-                reader.read("image_number_zero_padding", &_image_number_zero_padding);
+                reader.read("frame_zero_padding", &_frame_zero_padding);
 
                 std::string missing_frame_policy_value;
                 result && reader.read("missing_frame_policy", &missing_frame_policy_value);
                 if (!result) {
                     return result;
-                } 
+                }
 
                 if (missing_frame_policy_value == "error") {
                     _missing_frame_policy = MissingFramePolicy::error;
@@ -113,10 +113,10 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         writer.write("target_url_base", _target_url_base);
         writer.write("name_prefix", _name_prefix);
         writer.write("name_suffix", _name_suffix);
-        writer.write("start_value", _start_value);
-        writer.write("value_step", _value_step);
+        writer.write("start_frame", _start_frame);
+        writer.write("frame_step", _frame_step);
         writer.write("rate", _rate);
-        writer.write("image_number_zero_padding", _image_number_zero_padding);
+        writer.write("frame_zero_padding", _frame_zero_padding);
 
         std::string missing_frame_policy_value;
         switch (_missing_frame_policy)

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -48,13 +48,19 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
             return std::string();
         }
         const int file_image_num = _start_value + (image_number * _value_step);
-        std::string image_num_string = std::to_string(file_image_num);
+        const bool is_negative = (file_image_num < 0);
+        std::string image_num_string = std::to_string(abs(file_image_num));
         std::string zero_pad = std::string();
         if (image_num_string.length() <  _image_number_zero_padding) {
             zero_pad = std::string(_image_number_zero_padding - image_num_string.length(), '0');
         }
 
-        std::string out_string = _target_url_base + _name_prefix + zero_pad + image_num_string + _name_suffix;
+        std::string sign = std::string();
+        if (is_negative) {
+            sign = "-";
+        }
+
+        std::string out_string = _target_url_base + _name_prefix + sign + zero_pad + image_num_string + _name_suffix;
         *error_status = ErrorStatus(ErrorStatus::OK);
         return out_string;
     }

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -129,7 +129,9 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
                 }
                 else {
                     // Unrecognized value
-                    reader.error(ErrorStatus::NOT_IMPLEMENTED);
+                    ErrorStatus error_status = ErrorStatus(ErrorStatus::JSON_PARSE_ERROR,
+                               "Unknown missing_frame_policy: " + missing_frame_policy_value);
+                    reader.error(error_status);
                     return false;
                 }
 

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -75,7 +75,9 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         }
         const int file_image_num = _start_frame + (image_number * _frame_step);
         const bool is_negative = (file_image_num < 0);
+
         std::string image_num_string = std::to_string(abs(file_image_num));
+
         std::string zero_pad = std::string();
         if (image_num_string.length() <  _frame_zero_padding) {
             zero_pad = std::string(_frame_zero_padding - image_num_string.length(), '0');
@@ -86,7 +88,13 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
             sign = "-";
         }
 
-        std::string out_string = _target_url_base + _name_prefix + sign + zero_pad + image_num_string + _name_suffix;
+        // If the base does not include a trailing slash, add it
+        std::string path_sep = std::string();
+        if (_target_url_base.compare(_target_url_base.length() - 1, 1, "/") != 0) {
+            path_sep = "/";
+        }
+
+        std::string out_string = _target_url_base + path_sep + _name_prefix + sign + zero_pad + image_num_string + _name_suffix;
         *error_status = ErrorStatus(ErrorStatus::OK);
         return out_string;
     }

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -31,7 +31,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         return RationalTime((double)_frame_step, _rate);
     }
 
-    long ImageSequenceReference::end_frame() const {
+    int ImageSequenceReference::end_frame() const {
         if (!this->available_range().has_value()) {
             return _start_frame;
         }

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -35,7 +35,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
     } 
 
     std::string
-    ImageSequenceReference::image_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
+    ImageSequenceReference::target_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
         if (image_number >= this->number_of_images_in_sequence()) {
             *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX);
             return std::string();

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -52,6 +52,18 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         return out_string;
     }
 
+    RationalTime
+    ImageSequenceReference::presentation_time_for_image_number(int const image_number, ErrorStatus* error_status) const {
+        if (image_number >= this->number_of_images_in_sequence()) {
+            *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX);
+            return RationalTime();
+        }
+
+        auto first_frame_time = this->available_range().value().start_time();
+        auto time_multiplier = TimeTransform(first_frame_time, image_number, -1);
+        return time_multiplier.applied_to(_frame_duration);
+    }
+
     bool ImageSequenceReference::read_from(Reader& reader) {
         return reader.read("target_url_base", &_target_url_base) &&
                 reader.read("name_prefix", &_name_prefix) &&

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -1,0 +1,76 @@
+#include "opentimelineio/imageSequenceReference.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
+
+ImageSequenceReference::ImageSequenceReference(std::string const& target_url_base,
+                      std::string const& name_prefix,
+                      std::string const& name_suffix,
+                      int start_value,
+                      int value_step,
+                      RationalTime const& frame_duration,
+                      int image_number_zero_padding,
+                      optional<TimeRange> const& available_range,
+                      AnyDictionary const& metadata)
+    : Parent(std::string(), available_range, metadata),
+    _target_url_base(target_url_base),
+    _name_prefix(name_prefix),
+    _name_suffix(name_suffix),
+    _start_value {start_value},
+    _value_step {value_step},
+    _frame_duration {frame_duration},
+    _image_number_zero_padding {image_number_zero_padding} {
+    }
+
+    ImageSequenceReference::~ImageSequenceReference() {
+    }
+
+    int ImageSequenceReference::number_of_images_in_sequence() const {
+        if (!this->available_range().has_value()) {
+            return 0;
+        }
+        
+        RationalTime frame_rate = RationalTime(_frame_duration.rate(), _frame_duration.value());
+        int num_frames = this->available_range().value().duration().to_frames(frame_rate.to_seconds());
+        return num_frames;
+    } 
+
+    std::string
+    ImageSequenceReference::image_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
+        if (image_number >= this->number_of_images_in_sequence()) {
+            *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX);
+            return std::string();
+        }
+        const int file_image_num = _start_value + (image_number * _value_step);
+        std::string image_num_string = std::to_string(file_image_num);
+        std::string zero_pad = std::string();
+        if (image_num_string.length() <  _image_number_zero_padding) {
+            zero_pad = std::string(_image_number_zero_padding - image_num_string.length(), '0');
+        }
+
+        std::string out_string = _target_url_base + _name_prefix + zero_pad + image_num_string + _name_suffix;
+        *error_status = ErrorStatus(ErrorStatus::OK);
+        return out_string;
+    }
+
+    bool ImageSequenceReference::read_from(Reader& reader) {
+        return reader.read("target_url_base", &_target_url_base) &&
+                reader.read("name_prefix", &_name_prefix) &&
+                reader.read("name_suffix", &_name_suffix) &&
+                reader.read("start_value", &_start_value) &&
+                reader.read("value_step", &_value_step) &&
+                reader.read("frame_duration", &_frame_duration) &&
+                reader.read("image_number_zero_padding", &_image_number_zero_padding) &&
+                Parent::read_from(reader);
+    }
+
+    void ImageSequenceReference::write_to(Writer& writer) const {
+        Parent::write_to(writer);
+        writer.write("target_url_base", _target_url_base);
+        writer.write("name_prefix", _name_prefix);
+        writer.write("name_suffix", _name_suffix);
+        writer.write("start_value", _start_value);
+        writer.write("value_step", _value_step);
+        writer.write("frame_duration", _frame_duration);
+        writer.write("image_number_zero_padding", _image_number_zero_padding);
+}
+} }

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -128,7 +128,9 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
                     _missing_frame_policy = MissingFramePolicy::hold;
                 }
                 else {
-                    // TODO: This fails silently, what should we do?
+                    // Unrecognized value
+                    reader.error(ErrorStatus::NOT_IMPLEMENTED);
+                    return false;
                 }
 
                 return result && Parent::read_from(reader);

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -31,6 +31,17 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         return RationalTime((double)_frame_step, _rate);
     }
 
+    long ImageSequenceReference::end_frame() const {
+        if (!this->available_range().has_value()) {
+            return _start_frame;
+        }
+
+        int num_frames = this->available_range().value().duration().to_frames(_rate);
+
+        // Subtract 1 for inclusive frame ranges
+        return (_start_frame + num_frames - 1);
+    }
+
     int ImageSequenceReference::number_of_images_in_sequence() const {
         if (!this->available_range().has_value()) {
             return 0;

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -52,6 +52,21 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         return num_frames;
     }
 
+    int ImageSequenceReference::frame_for_time(RationalTime const time, ErrorStatus* error_status) const {
+        if (!this->available_range().has_value() || !this->available_range().value().contains(time)) {
+            *error_status = ErrorStatus(ErrorStatus::INVALID_TIME_RANGE);
+            return 0;
+        }
+
+        RationalTime start = this->available_range().value().start_time();
+        RationalTime duration_from_start = (time - start);
+        int frame_offset = duration_from_start.to_frames(_rate);
+
+        *error_status = ErrorStatus(ErrorStatus::OK);
+
+        return (_start_frame + frame_offset);
+    }
+
     std::string
     ImageSequenceReference::target_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
         if (image_number >= this->number_of_images_in_sequence()) {

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -85,6 +85,9 @@ public:
     std::string
     target_url_for_image_number(int const image_number, ErrorStatus* error_status) const;
 
+    RationalTime
+    presentation_time_for_image_number(int const image_number, ErrorStatus* error_status) const;
+
 protected:
     virtual ~ImageSequenceReference();
  

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -83,7 +83,7 @@ public:
     int number_of_images_in_sequence() const;
 
     std::string
-    image_url_for_image_number(int const image_number, ErrorStatus* error_status) const;
+    target_url_for_image_number(int const image_number, ErrorStatus* error_status) const;
 
 protected:
     virtual ~ImageSequenceReference();

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -97,6 +97,7 @@ public:
 
     long end_frame() const;
     int number_of_images_in_sequence() const;
+    int frame_for_time(RationalTime const time, ErrorStatus* error_status) const;
 
     std::string
     target_url_for_image_number(int const image_number, ErrorStatus* error_status) const;

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "opentimelineio/version.h"
+#include "opentimelineio/mediaReference.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
+    
+class ImageSequenceReference final : public MediaReference {
+public:
+    struct Schema {
+        static auto constexpr name = "ImageSequenceReference";
+        static int constexpr version = 1;
+    };
+
+    using Parent = MediaReference;
+
+    ImageSequenceReference(std::string const& target_url_base = std::string(),
+                      std::string const& name_prefix = std::string(),
+                      std::string const& name_suffix = std::string(),
+                      int start_value = 1,
+                      int value_step = 1,
+                      RationalTime const &frame_duration = RationalTime(1, 24),
+                      int image_number_zero_padding = 0,
+                      optional<TimeRange> const& available_range = nullopt,
+                      AnyDictionary const& metadata = AnyDictionary());
+        
+    std::string const& target_url_base() const {
+        return _target_url_base;
+    }
+    
+    void set_target_url_base(std::string const& target_url_base) {
+        _target_url_base = target_url_base;
+    }
+        
+    std::string const& name_prefix() const {
+        return _name_prefix;
+    }
+    
+    void set_name_prefix(std::string const& target_url_base) {
+        _name_prefix = target_url_base;
+    }
+
+    std::string const& name_suffix() const {
+        return _name_suffix;
+    }
+    
+    void set_name_suffix(std::string const& target_url_base) {
+        _name_suffix = target_url_base;
+    }
+
+    long start_value() const {
+        return _start_value;
+    }
+
+    void set_start_value(long const start_value) {
+        _start_value = start_value;
+    }
+
+    long value_step() const {
+        return _value_step;
+    }
+
+    void set_value_step(long const value_step) {
+        _value_step = value_step;
+    }
+
+    RationalTime const& frame_duration() const {
+        return _frame_duration;
+    }
+
+    void set_frame_duration(RationalTime const& frame_duration) {
+        _frame_duration = frame_duration;
+    }
+
+    int image_number_zero_padding() const {
+        return _image_number_zero_padding;
+    }
+
+    void set_image_number_zero_padding(int const image_number_zero_padding) {
+        _image_number_zero_padding = image_number_zero_padding;
+    }
+
+    int number_of_images_in_sequence() const;
+
+    std::string
+    image_url_for_image_number(int const image_number, ErrorStatus* error_status) const;
+
+protected:
+    virtual ~ImageSequenceReference();
+ 
+    virtual bool read_from(Reader&);
+    virtual void write_to(Writer&) const;
+
+private:
+    std::string _target_url_base;
+    std::string _name_prefix;
+    std::string _name_suffix;
+    int _start_value;
+    int _value_step;
+    RationalTime _frame_duration;
+    int _image_number_zero_padding;
+};
+
+} }

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -55,19 +55,19 @@ public:
         _name_suffix = target_url_base;
     }
 
-    long start_frame() const {
+    int start_frame() const {
         return _start_frame;
     }
 
-    void set_start_frame(long const start_frame) {
+    void set_start_frame(int const start_frame) {
         _start_frame = start_frame;
     }
 
-    long frame_step() const {
+    int frame_step() const {
         return _frame_step;
     }
 
-    void set_frame_step(long const frame_step) {
+    void set_frame_step(int const frame_step) {
         _frame_step = frame_step;
     }
 
@@ -95,7 +95,7 @@ public:
         return _missing_frame_policy;
     }
 
-    long end_frame() const;
+    int end_frame() const;
     int number_of_images_in_sequence() const;
     int frame_for_time(RationalTime const time, ErrorStatus* error_status) const;
 

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -23,10 +23,10 @@ public:
     ImageSequenceReference(std::string const& target_url_base = std::string(),
                       std::string const& name_prefix = std::string(),
                       std::string const& name_suffix = std::string(),
-                      int start_value = 1,
-                      int value_step = 1,
+                      int start_frame = 1,
+                      int frame_step = 1,
                       double const rate = 1,
-                      int image_number_zero_padding = 0,
+                      int frame_zero_padding = 0,
                       MissingFramePolicy const missing_frame_policy = MissingFramePolicy::error,
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
@@ -55,20 +55,20 @@ public:
         _name_suffix = target_url_base;
     }
 
-    long start_value() const {
-        return _start_value;
+    long start_frame() const {
+        return _start_frame;
     }
 
-    void set_start_value(long const start_value) {
-        _start_value = start_value;
+    void set_start_frame(long const start_frame) {
+        _start_frame = start_frame;
     }
 
-    long value_step() const {
-        return _value_step;
+    long frame_step() const {
+        return _frame_step;
     }
 
-    void set_value_step(long const value_step) {
-        _value_step = value_step;
+    void set_frame_step(long const frame_step) {
+        _frame_step = frame_step;
     }
 
     double const& rate() const {
@@ -79,12 +79,12 @@ public:
         _rate = rate;
     }
 
-    int image_number_zero_padding() const {
-        return _image_number_zero_padding;
+    int frame_zero_padding() const {
+        return _frame_zero_padding;
     }
 
-    void set_image_number_zero_padding(int const image_number_zero_padding) {
-        _image_number_zero_padding = image_number_zero_padding;
+    void set_frame_zero_padding(int const frame_zero_padding) {
+        _frame_zero_padding = frame_zero_padding;
     }
 
     void set_missing_frame_policy(MissingFramePolicy const missing_frame_policy) {
@@ -113,10 +113,10 @@ private:
     std::string _target_url_base;
     std::string _name_prefix;
     std::string _name_suffix;
-    int _start_value;
-    int _value_step;
+    int _start_frame;
+    int _frame_step;
     double _rate;
-    int _image_number_zero_padding;
+    int _frame_zero_padding;
     MissingFramePolicy _missing_frame_policy;
     
     RationalTime frame_duration() const;

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -19,7 +19,7 @@ public:
                       std::string const& name_suffix = std::string(),
                       int start_value = 1,
                       int value_step = 1,
-                      RationalTime const &frame_duration = RationalTime(1, 24),
+                      double const rate = 1,
                       int image_number_zero_padding = 0,
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
@@ -64,12 +64,12 @@ public:
         _value_step = value_step;
     }
 
-    RationalTime const& frame_duration() const {
-        return _frame_duration;
+    double const& rate() const {
+        return _rate;
     }
 
-    void set_frame_duration(RationalTime const& frame_duration) {
-        _frame_duration = frame_duration;
+    void set_rate(double const rate) {
+        _rate = rate;
     }
 
     int image_number_zero_padding() const {
@@ -100,8 +100,10 @@ private:
     std::string _name_suffix;
     int _start_value;
     int _value_step;
-    RationalTime _frame_duration;
+    double _rate;
     int _image_number_zero_padding;
+    
+    RationalTime frame_duration() const;
 };
 
 } }

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -95,6 +95,7 @@ public:
         return _missing_frame_policy;
     }
 
+    long end_frame() const;
     int number_of_images_in_sequence() const;
 
     std::string

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -7,6 +7,12 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 class ImageSequenceReference final : public MediaReference {
 public:
+    enum MissingFramePolicy {
+        error = 0,
+        hold = 1,
+        black = 2
+    };
+
     struct Schema {
         static auto constexpr name = "ImageSequenceReference";
         static int constexpr version = 1;
@@ -21,6 +27,7 @@ public:
                       int value_step = 1,
                       double const rate = 1,
                       int image_number_zero_padding = 0,
+                      MissingFramePolicy const missing_frame_policy = MissingFramePolicy::error,
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
         
@@ -80,6 +87,14 @@ public:
         _image_number_zero_padding = image_number_zero_padding;
     }
 
+    void set_missing_frame_policy(MissingFramePolicy const missing_frame_policy) {
+        _missing_frame_policy = missing_frame_policy;
+    }
+
+    MissingFramePolicy missing_frame_policy() const {
+        return _missing_frame_policy;
+    }
+
     int number_of_images_in_sequence() const;
 
     std::string
@@ -102,6 +117,7 @@ private:
     int _value_step;
     double _rate;
     int _image_number_zero_padding;
+    MissingFramePolicy _missing_frame_policy;
     
     RationalTime frame_duration() const;
 };

--- a/src/opentimelineio/typeRegistry.cpp
+++ b/src/opentimelineio/typeRegistry.cpp
@@ -9,6 +9,7 @@
 #include "opentimelineio/freezeFrame.h"
 #include "opentimelineio/gap.h"
 #include "opentimelineio/generatorReference.h"
+#include "opentimelineio/imageSequenceReference.h"
 #include "opentimelineio/item.h"
 #include "opentimelineio/linearTimeWarp.h"
 #include "opentimelineio/marker.h"
@@ -55,6 +56,7 @@ TypeRegistry::TypeRegistry() {
     register_type_from_existing_type("Filler", 1, "Gap", nullptr);
 
     register_type<GeneratorReference>();
+    register_type<ImageSequenceReference>();
     register_type<Item>();
     register_type<LinearTimeWarp>();
     register_type<Marker>();

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -10,6 +10,7 @@
 #include "opentimelineio/freezeFrame.h"
 #include "opentimelineio/gap.h"
 #include "opentimelineio/generatorReference.h"
+#include "opentimelineio/imageSequenceReference.h"
 #include "opentimelineio/item.h"
 #include "opentimelineio/linearTimeWarp.h"
 #include "opentimelineio/marker.h"
@@ -625,6 +626,52 @@ static void define_media_references(py::module m) {
              "available_range"_a = nullopt,
              metadata_arg)
         .def_property("target_url", &ExternalReference::target_url, &ExternalReference::set_target_url);
+    
+
+    py:: class_<ImageSequenceReference, MediaReference,
+            managing_ptr<ImageSequenceReference>>(m, "ImageSequenceReference", py::dynamic_attr())
+        .def(py::init([](std::string target_url_base,
+                         std::string name_prefix,
+                         std::string name_suffix,
+                         int start_value,
+                         int value_step,
+                         RationalTime frame_duration,
+                         int image_number_zero_padding,
+                         optional<TimeRange> const& available_range,
+                         py::object metadata) {
+                          return new ImageSequenceReference(target_url_base,
+                                                            name_prefix,
+                                                            name_suffix,
+                                                            start_value,
+                                                            value_step,
+                                                            frame_duration,
+                                                            image_number_zero_padding,
+                                                            available_range,
+                                                            py_to_any_dictionary(metadata)); }),
+                        "target_url_base"_a = std::string(),
+                        "name_prefix"_a = std::string(),
+                        "name_suffix"_a = std::string(),
+                        "start_value"_a = 1L,
+                        "value_step"_a = 1L,
+                        "frame_duration"_a = RationalTime(1, 24),
+                        "image_number_zero_padding"_a = 0,
+                        "available_range"_a = nullopt,
+                        metadata_arg)
+        .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base)
+        .def_property("name_prefix", &ImageSequenceReference::name_prefix, &ImageSequenceReference::set_name_prefix)
+        .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix)
+        .def_property("start_value", &ImageSequenceReference::start_value, &ImageSequenceReference::set_start_value)
+        .def_property("value_step", &ImageSequenceReference::value_step, &ImageSequenceReference::set_value_step)
+        .def_property("frame_duration", &ImageSequenceReference::frame_duration, &ImageSequenceReference::set_frame_duration)
+        .def_property("image_number_zero_padding", &ImageSequenceReference::image_number_zero_padding, &ImageSequenceReference::set_image_number_zero_padding)
+        .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
+        .def("image_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
+                return seq_ref->image_url_for_image_number(
+                        image_number, 
+                        ErrorStatusHandler()
+                ); 
+        }, "image_number"_a);
+
 }
 
 void otio_serializable_object_bindings(py::module m) {

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -674,6 +674,7 @@ static void define_media_references(py::module m) {
         .def_property("rate", &ImageSequenceReference::rate, &ImageSequenceReference::set_rate)
         .def_property("frame_zero_padding", &ImageSequenceReference::frame_zero_padding, &ImageSequenceReference::set_frame_zero_padding)
         .def_property("missing_frame_policy", &ImageSequenceReference::missing_frame_policy, &ImageSequenceReference::set_missing_frame_policy)
+        .def("end_frame", &ImageSequenceReference::end_frame)
         .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
         .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) {
                 return seq_ref->target_url_for_image_number(

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -627,9 +627,15 @@ static void define_media_references(py::module m) {
              metadata_arg)
         .def_property("target_url", &ExternalReference::target_url, &ExternalReference::set_target_url);
     
+    auto imagesequencereference_class = py:: class_<ImageSequenceReference, MediaReference,
+            managing_ptr<ImageSequenceReference>>(m, "ImageSequenceReference", py::dynamic_attr());
 
-    py:: class_<ImageSequenceReference, MediaReference,
-            managing_ptr<ImageSequenceReference>>(m, "ImageSequenceReference", py::dynamic_attr())
+    py::enum_<ImageSequenceReference::MissingFramePolicy>(imagesequencereference_class, "MissingFramePolicy")
+        .value("error", ImageSequenceReference::MissingFramePolicy::error)
+        .value("hold", ImageSequenceReference::MissingFramePolicy::hold)
+        .value("black", ImageSequenceReference::MissingFramePolicy::black);
+
+    imagesequencereference_class
         .def(py::init([](std::string target_url_base,
                          std::string name_prefix,
                          std::string name_suffix,
@@ -637,6 +643,7 @@ static void define_media_references(py::module m) {
                          int value_step,
                          double const rate,
                          int image_number_zero_padding,
+                         ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
                          py::object metadata) {
                           return new ImageSequenceReference(target_url_base,
@@ -646,6 +653,7 @@ static void define_media_references(py::module m) {
                                                             value_step,
                                                             rate,
                                                             image_number_zero_padding,
+                                                            missing_frame_policy,
                                                             available_range,
                                                             py_to_any_dictionary(metadata)); }),
                         "target_url_base"_a = std::string(),
@@ -655,6 +663,7 @@ static void define_media_references(py::module m) {
                         "value_step"_a = 1L,
                         "rate"_a = 1,
                         "image_number_zero_padding"_a = 0,
+                        "missing_frame_policy"_a = ImageSequenceReference::MissingFramePolicy::error,
                         "available_range"_a = nullopt,
                         metadata_arg)
         .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base)
@@ -664,6 +673,7 @@ static void define_media_references(py::module m) {
         .def_property("value_step", &ImageSequenceReference::value_step, &ImageSequenceReference::set_value_step)
         .def_property("rate", &ImageSequenceReference::rate, &ImageSequenceReference::set_rate)
         .def_property("image_number_zero_padding", &ImageSequenceReference::image_number_zero_padding, &ImageSequenceReference::set_image_number_zero_padding)
+        .def_property("missing_frame_policy", &ImageSequenceReference::missing_frame_policy, &ImageSequenceReference::set_missing_frame_policy)
         .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
         .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
                 return seq_ref->target_url_for_image_number(

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -676,6 +676,9 @@ static void define_media_references(py::module m) {
         .def_property("missing_frame_policy", &ImageSequenceReference::missing_frame_policy, &ImageSequenceReference::set_missing_frame_policy)
         .def("end_frame", &ImageSequenceReference::end_frame)
         .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
+        .def("frame_for_time", [](ImageSequenceReference *seq_ref, RationalTime time) {
+                return seq_ref->frame_for_time(time, ErrorStatusHandler());
+        }, "time"_a)
         .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) {
                 return seq_ref->target_url_for_image_number(
                         image_number,

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -670,6 +670,12 @@ static void define_media_references(py::module m) {
                         image_number, 
                         ErrorStatusHandler()
                 ); 
+        }, "image_number"_a)
+        .def("presentation_time_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
+                return seq_ref->presentation_time_for_image_number(
+                        image_number, 
+                        ErrorStatusHandler()
+                ); 
         }, "image_number"_a);
 
 }

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -635,7 +635,7 @@ static void define_media_references(py::module m) {
                          std::string name_suffix,
                          int start_value,
                          int value_step,
-                         RationalTime frame_duration,
+                         double const rate,
                          int image_number_zero_padding,
                          optional<TimeRange> const& available_range,
                          py::object metadata) {
@@ -644,7 +644,7 @@ static void define_media_references(py::module m) {
                                                             name_suffix,
                                                             start_value,
                                                             value_step,
-                                                            frame_duration,
+                                                            rate,
                                                             image_number_zero_padding,
                                                             available_range,
                                                             py_to_any_dictionary(metadata)); }),
@@ -653,7 +653,7 @@ static void define_media_references(py::module m) {
                         "name_suffix"_a = std::string(),
                         "start_value"_a = 1L,
                         "value_step"_a = 1L,
-                        "frame_duration"_a = RationalTime(1, 24),
+                        "rate"_a = 1,
                         "image_number_zero_padding"_a = 0,
                         "available_range"_a = nullopt,
                         metadata_arg)
@@ -662,7 +662,7 @@ static void define_media_references(py::module m) {
         .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix)
         .def_property("start_value", &ImageSequenceReference::start_value, &ImageSequenceReference::set_start_value)
         .def_property("value_step", &ImageSequenceReference::value_step, &ImageSequenceReference::set_value_step)
-        .def_property("frame_duration", &ImageSequenceReference::frame_duration, &ImageSequenceReference::set_frame_duration)
+        .def_property("rate", &ImageSequenceReference::rate, &ImageSequenceReference::set_rate)
         .def_property("image_number_zero_padding", &ImageSequenceReference::image_number_zero_padding, &ImageSequenceReference::set_image_number_zero_padding)
         .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
         .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -665,8 +665,8 @@ static void define_media_references(py::module m) {
         .def_property("frame_duration", &ImageSequenceReference::frame_duration, &ImageSequenceReference::set_frame_duration)
         .def_property("image_number_zero_padding", &ImageSequenceReference::image_number_zero_padding, &ImageSequenceReference::set_image_number_zero_padding)
         .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
-        .def("image_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
-                return seq_ref->image_url_for_image_number(
+        .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
+                return seq_ref->target_url_for_image_number(
                         image_number, 
                         ErrorStatusHandler()
                 ); 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -639,53 +639,53 @@ static void define_media_references(py::module m) {
         .def(py::init([](std::string target_url_base,
                          std::string name_prefix,
                          std::string name_suffix,
-                         int start_value,
-                         int value_step,
+                         int start_frame,
+                         int frame_step,
                          double const rate,
-                         int image_number_zero_padding,
+                         int frame_zero_padding,
                          ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
                          py::object metadata) {
                           return new ImageSequenceReference(target_url_base,
                                                             name_prefix,
                                                             name_suffix,
-                                                            start_value,
-                                                            value_step,
+                                                            start_frame,
+                                                            frame_step,
                                                             rate,
-                                                            image_number_zero_padding,
+                                                            frame_zero_padding,
                                                             missing_frame_policy,
                                                             available_range,
                                                             py_to_any_dictionary(metadata)); }),
                         "target_url_base"_a = std::string(),
                         "name_prefix"_a = std::string(),
                         "name_suffix"_a = std::string(),
-                        "start_value"_a = 1L,
-                        "value_step"_a = 1L,
+                        "start_frame"_a = 1L,
+                        "frame_step"_a = 1L,
                         "rate"_a = 1,
-                        "image_number_zero_padding"_a = 0,
+                        "frame_zero_padding"_a = 0,
                         "missing_frame_policy"_a = ImageSequenceReference::MissingFramePolicy::error,
                         "available_range"_a = nullopt,
                         metadata_arg)
         .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base)
         .def_property("name_prefix", &ImageSequenceReference::name_prefix, &ImageSequenceReference::set_name_prefix)
         .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix)
-        .def_property("start_value", &ImageSequenceReference::start_value, &ImageSequenceReference::set_start_value)
-        .def_property("value_step", &ImageSequenceReference::value_step, &ImageSequenceReference::set_value_step)
+        .def_property("start_frame", &ImageSequenceReference::start_frame, &ImageSequenceReference::set_start_frame)
+        .def_property("frame_step", &ImageSequenceReference::frame_step, &ImageSequenceReference::set_frame_step)
         .def_property("rate", &ImageSequenceReference::rate, &ImageSequenceReference::set_rate)
-        .def_property("image_number_zero_padding", &ImageSequenceReference::image_number_zero_padding, &ImageSequenceReference::set_image_number_zero_padding)
+        .def_property("frame_zero_padding", &ImageSequenceReference::frame_zero_padding, &ImageSequenceReference::set_frame_zero_padding)
         .def_property("missing_frame_policy", &ImageSequenceReference::missing_frame_policy, &ImageSequenceReference::set_missing_frame_policy)
         .def("number_of_images_in_sequence", &ImageSequenceReference::number_of_images_in_sequence)
-        .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
+        .def("target_url_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) {
                 return seq_ref->target_url_for_image_number(
-                        image_number, 
+                        image_number,
                         ErrorStatusHandler()
-                ); 
+                );
         }, "image_number"_a)
-        .def("presentation_time_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) { 
+        .def("presentation_time_for_image_number", [](ImageSequenceReference *seq_ref, int image_number) {
                 return seq_ref->presentation_time_for_image_number(
-                        image_number, 
+                        image_number,
                         ErrorStatusHandler()
-                ); 
+                );
         }, "image_number"_a);
 
 }

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -35,6 +35,7 @@ from .. _otio import (
     FreezeFrame,
     Gap,
     GeneratorReference,
+    ImageSequenceReference,
     Marker,
     MissingReference,
     SerializableCollection,
@@ -54,11 +55,17 @@ from . schemadef import (
 )
 
 from . import (
-    clip, effect, external_reference,
-    generator_reference, marker,
+    clip,
+    effect,
+    external_reference,
+    generator_reference,
+    image_sequence_reference,
+    marker,
     serializable_collection,
-    stack, timeline, track,
-    transition
+    stack,
+    timeline,
+    track,
+    transition,
 )
 
 track.TrackKind = TrackKind

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -62,3 +62,14 @@ def frame_range_for_time_range(self, time_range):
         self.frame_for_time(time_range.start_time),
         self.frame_for_time(time_range.end_time_inclusive())
     )
+
+
+@add_method(_otio.ImageSequenceReference)
+def abstract_target_url(self, symbol):
+    """
+    Generates a target url for a frame where :param:``symbol`` is used in place
+    of the frame number. This is often used to generate wildcard target urls.
+    """
+    return "{}{}{}{}".format(
+        self.target_url_base, self.name_prefix, symbol, self.name_suffix
+    )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -70,6 +70,11 @@ def abstract_target_url(self, symbol):
     Generates a target url for a frame where :param:``symbol`` is used in place
     of the frame number. This is often used to generate wildcard target urls.
     """
+    if not self.target_url_base.endswith("/"):
+        base = self.target_url_base + "/"
+    else:
+        base = self.target_url_base
+
     return "{}{}{}{}".format(
-        self.target_url_base, self.name_prefix, symbol, self.name_suffix
+        base, self.name_prefix, symbol, self.name_suffix
     )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -12,7 +12,7 @@ def __str__(self):
             self.name_suffix,
             self.start_value,
             self.value_step,
-            self.frame_duration,
+            self.rate,
             self.image_number_zero_padding,
             self.available_range,
             self.metadata,
@@ -29,7 +29,7 @@ def __repr__(self):
         'name_suffix={}, '
         'start_value={}, '
         'value_step={}, '
-        'frame_duration={}, '
+        'rate={}, '
         'image_number_zero_padding={}, '
         'available_range={}, '
         'metadata={}'
@@ -39,7 +39,7 @@ def __repr__(self):
             repr(self.name_suffix),
             repr(self.start_value),
             repr(self.value_step),
-            repr(self.frame_duration),
+            repr(self.rate),
             repr(self.image_number_zero_padding),
             repr(self.available_range),
             repr(self.metadata),

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -1,0 +1,47 @@
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.ImageSequenceReference)
+def __str__(self):
+    return (
+        'ImageSequenceReference('
+        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {})' .format(
+            self.target_url_base,
+            self.name_prefix,
+            self.name_suffix,
+            self.start_value,
+            self.value_step,
+            self.frame_duration,
+            self.image_number_zero_padding,
+            self.available_range,
+            self.metadata,
+        )
+    )
+
+
+@add_method(_otio.ImageSequenceReference)
+def __repr__(self):
+    return (
+        'ImageSequenceReference('
+        'target_url_base={}, '
+        'name_prefix={}, '
+        'name_suffix={}, '
+        'start_value={}, '
+        'value_step={}, '
+        'frame_duration={}, '
+        'image_number_zero_padding={}, '
+        'available_range={}, '
+        'metadata={}'
+        ')' .format(
+            repr(self.target_url_base),
+            repr(self.name_prefix),
+            repr(self.name_suffix),
+            repr(self.start_value),
+            repr(self.value_step),
+            repr(self.frame_duration),
+            repr(self.image_number_zero_padding),
+            repr(self.available_range),
+            repr(self.metadata),
+        )
+    )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -10,10 +10,10 @@ def __str__(self):
             self.target_url_base,
             self.name_prefix,
             self.name_suffix,
-            self.start_value,
-            self.value_step,
+            self.start_frame,
+            self.frame_step,
             self.rate,
-            self.image_number_zero_padding,
+            self.frame_zero_padding,
             self.missing_frame_policy,
             self.available_range,
             self.metadata,
@@ -28,10 +28,10 @@ def __repr__(self):
         'target_url_base={}, '
         'name_prefix={}, '
         'name_suffix={}, '
-        'start_value={}, '
-        'value_step={}, '
+        'start_frame={}, '
+        'frame_step={}, '
         'rate={}, '
-        'image_number_zero_padding={}, '
+        'frame_zero_padding={}, '
         'missing_frame_policy={}, '
         'available_range={}, '
         'metadata={}'
@@ -39,10 +39,10 @@ def __repr__(self):
             repr(self.target_url_base),
             repr(self.name_prefix),
             repr(self.name_suffix),
-            repr(self.start_value),
-            repr(self.value_step),
+            repr(self.start_frame),
+            repr(self.frame_step),
             repr(self.rate),
-            repr(self.image_number_zero_padding),
+            repr(self.frame_zero_padding),
             repr(self.missing_frame_policy),
             repr(self.available_range),
             repr(self.metadata),

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -6,7 +6,7 @@ from .. import _otio
 def __str__(self):
     return (
         'ImageSequenceReference('
-        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {})' .format(
+        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {})' .format(
             self.target_url_base,
             self.name_prefix,
             self.name_suffix,
@@ -14,6 +14,7 @@ def __str__(self):
             self.value_step,
             self.rate,
             self.image_number_zero_padding,
+            self.missing_frame_policy,
             self.available_range,
             self.metadata,
         )
@@ -31,6 +32,7 @@ def __repr__(self):
         'value_step={}, '
         'rate={}, '
         'image_number_zero_padding={}, '
+        'missing_frame_policy={}, '
         'available_range={}, '
         'metadata={}'
         ')' .format(
@@ -41,6 +43,7 @@ def __repr__(self):
             repr(self.value_step),
             repr(self.rate),
             repr(self.image_number_zero_padding),
+            repr(self.missing_frame_policy),
             repr(self.available_range),
             repr(self.metadata),
         )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -48,3 +48,17 @@ def __repr__(self):
             repr(self.metadata),
         )
     )
+
+
+@add_method(_otio.ImageSequenceReference)
+def frame_range_for_time_range(self, time_range):
+    """
+    Returns the frame range for the given time range in the reference.
+
+    Raises ValueError if the provided time range is outside the available
+    range.
+    """
+    return (
+        self.frame_for_time(time_range.start_time),
+        self.frame_for_time(time_range.end_time_inclusive())
+    )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -53,7 +53,8 @@ def __repr__(self):
 @add_method(_otio.ImageSequenceReference)
 def frame_range_for_time_range(self, time_range):
     """
-    Returns the frame range for the given time range in the reference.
+    Returns a :class:`tuple` containing the first and last frame numbers for
+    the given time range in the reference.
 
     Raises ValueError if the provided time range is outside the available
     range.

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -311,3 +311,66 @@ class ImageSequenceReferenceTests(
         ]
 
         self.assertEqual(generated_values, reference_values)
+
+    def test_negative_frame_numbers(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(12, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_value=-1,
+            value_step=2,
+            rate=24,
+        )
+
+        self.assertEqual(ref.number_of_images_in_sequence(), 24)
+        self.assertEqual(
+            ref.presentation_time_for_image_number(0),
+            otio.opentime.RationalTime(12, 24),
+        )
+        self.assertEqual(
+            ref.presentation_time_for_image_number(1),
+            otio.opentime.RationalTime(14, 24),
+        )
+        self.assertEqual(
+            ref.presentation_time_for_image_number(2),
+            otio.opentime.RationalTime(16, 24),
+        )
+        self.assertEqual(
+            ref.presentation_time_for_image_number(23),
+            otio.opentime.RationalTime(58, 24),
+        )
+
+        self.assertEqual(
+            ref.target_url_for_image_number(0),
+            "file:///show/seq/shot/rndr/show_shot.-0001.exr",
+        )
+
+        self.assertEqual(
+            ref.target_url_for_image_number(1),
+            "file:///show/seq/shot/rndr/show_shot.0001.exr",
+        )
+        self.assertEqual(
+            ref.target_url_for_image_number(2),
+            "file:///show/seq/shot/rndr/show_shot.0003.exr",
+        )
+        self.assertEqual(
+            ref.target_url_for_image_number(17),
+            "file:///show/seq/shot/rndr/show_shot.0033.exr",
+        )
+        self.assertEqual(
+            ref.target_url_for_image_number(23),
+            "file:///show/seq/shot/rndr/show_shot.0045.exr",
+        )
+
+        # Check values by ones
+        ref.value_step = 1
+        for i in range(1, ref.number_of_images_in_sequence()):
+            self.assertEqual(
+                ref.target_url_for_image_number(i),
+                "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i - 1),
+            )

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -412,6 +412,49 @@ class ImageSequenceReferenceTests(
         with self.assertRaises(ValueError):
             ref.frame_for_time(otio.opentime.RationalTime(73, 30))
 
+    def test_frame_range_for_time_range(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(12, 24),
+                otio.opentime.RationalTime(60, 24),
+            ),
+            start_frame=1,
+            frame_step=1,
+            rate=24,
+        )
+        time_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(24, 24),
+            otio.opentime.RationalTime(17, 24),
+        )
+
+        self.assertEqual(ref.frame_range_for_time_range(time_range), (13, 29))
+
+    def test_frame_range_for_time_range_out_of_bounds(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(12, 24),
+                otio.opentime.RationalTime(60, 24),
+            ),
+            start_frame=1,
+            frame_step=1,
+            rate=24,
+        )
+        time_range = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(24, 24),
+            otio.opentime.RationalTime(60, 24),
+        )
+
+        with self.assertRaises(ValueError):
+            ref.frame_range_for_time_range(time_range)
+
     def test_negative_frame_numbers(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -297,6 +297,26 @@ class ImageSequenceReferenceTests(
         ]
         self.assertEqual(all_images_urls_zero_first, generated_urls_zero_first)
 
+    def test_target_url_for_image_number_with_missing_slash(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_frame=1,
+            frame_step=1,
+            rate=24,
+        )
+
+        self.assertEqual(
+            ref.target_url_for_image_number(0),
+            "file:///show/seq/shot/rndr/show_shot.0001.exr"
+        )
+
     def test_abstract_target_url(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
@@ -312,8 +332,30 @@ class ImageSequenceReferenceTests(
             rate=24,
         )
 
-        expected_url = "file:///show/seq/shot/rndr/show_shot.@@@@.exr"
-        self.assertEqual(ref.abstract_target_url("@@@@"), expected_url)
+        self.assertEqual(
+            ref.abstract_target_url("@@@@"),
+            "file:///show/seq/shot/rndr/show_shot.@@@@.exr"
+        )
+
+    def test_abstract_target_url_with_missing_slash(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_frame=1,
+            frame_step=1,
+            rate=24,
+        )
+
+        self.assertEqual(
+            ref.abstract_target_url("@@@@"),
+            "file:///show/seq/shot/rndr/show_shot.@@@@.exr"
+        )
 
     def test_presentation_time_for_image_number(self):
         ref = otio.schema.ImageSequenceReference(

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -10,6 +10,7 @@ class ImageSequenceReferenceTests(
     unittest.TestCase, otio_test_utils.OTIOAssertions
 ):
     def test_create(self):
+        frame_policy = otio.schema.ImageSequenceReference.MissingFramePolicy.hold
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
@@ -20,6 +21,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             value_step=3,
+            missing_frame_policy=frame_policy,
             rate=30,
             metadata={"custom": {"foo": "bar"}},
         )
@@ -39,6 +41,10 @@ class ImageSequenceReferenceTests(
         self.assertEqual(ref.value_step, 3)
         self.assertEqual(ref.rate, 30)
         self.assertEqual(ref.metadata, {"custom": {"foo": "bar"}})
+        self.assertEqual(
+            ref.missing_frame_policy,
+            otio.schema.ImageSequenceReference.MissingFramePolicy.hold,
+        )
 
     def test_str(self):
         ref = otio.schema.ImageSequenceReference(
@@ -65,6 +71,7 @@ class ImageSequenceReferenceTests(
             '3, '
             '30.0, '
             '5, '
+            'MissingFramePolicy.error, '
             'TimeRange(RationalTime(0, 30), RationalTime(60, 30)), '
             "{'custom': {'foo': 'bar'}}"
             ')'
@@ -94,6 +101,7 @@ class ImageSequenceReferenceTests(
             'value_step=3, '
             'rate=30.0, '
             'image_number_zero_padding=5, '
+            'missing_frame_policy=MissingFramePolicy.error, '
             'available_range={}, '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
             ')'.format(repr(ref.available_range))
@@ -101,6 +109,7 @@ class ImageSequenceReferenceTests(
         self.assertEqual(repr(ref), ref_value)
 
     def test_serialize_roundtrip(self):
+        frame_policy = otio.schema.ImageSequenceReference.MissingFramePolicy.hold
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
@@ -112,6 +121,7 @@ class ImageSequenceReferenceTests(
             ),
             value_step=3,
             rate=30,
+            missing_frame_policy=frame_policy,
             metadata={"custom": {"foo": "bar"}},
         )
 
@@ -138,6 +148,10 @@ class ImageSequenceReferenceTests(
         )
         self.assertEqual(decoded.value_step, 3)
         self.assertEqual(decoded.rate, 30)
+        self.assertEqual(
+            decoded.missing_frame_policy,
+            otio.schema.ImageSequenceReference.MissingFramePolicy.hold
+        )
         self.assertEqual(decoded.metadata, {"custom": {"foo": "bar"}})
 
     def test_number_of_images_in_sequence(self):

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -1,0 +1,250 @@
+"""Test harness for Image Sequence References."""
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+import unittest
+
+
+class ImageSequenceReferenceTests(
+    unittest.TestCase, otio_test_utils.OTIOAssertions
+):
+    def test_create(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=5,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 30),
+                otio.opentime.RationalTime(60, 30),
+            ),
+            value_step=3,
+            frame_duration=otio.opentime.RationalTime(1, 30),
+            metadata={"custom": {"foo": "bar"}},
+        )
+
+        # Check Values
+        self.assertEqual(ref.target_url_base, "file:///show/seq/shot/rndr/")
+        self.assertEqual(ref.name_prefix, "show_shot.")
+        self.assertEqual(ref.name_suffix, ".exr")
+        self.assertEqual(ref.image_number_zero_padding, 5)
+        self.assertEqual(
+            ref.available_range,
+            otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 30),
+                otio.opentime.RationalTime(60, 30),
+            )
+        )
+        self.assertEqual(ref.value_step, 3)
+        self.assertEqual(ref.frame_duration, otio.opentime.RationalTime(1, 30))
+        self.assertEqual(ref.metadata, {"custom": {"foo": "bar"}})
+
+    def test_str(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            start_value=1,
+            value_step=3,
+            frame_duration=otio.opentime.RationalTime(1, 30),
+            image_number_zero_padding=5,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 30),
+                otio.opentime.RationalTime(60, 30),
+            ),
+            metadata={"custom": {"foo": "bar"}},
+        )
+        self.assertEqual(
+            str(ref),
+            'ImageSequenceReference('
+            '"file:///show/seq/shot/rndr/", '
+            '"show_shot.", '
+            '".exr", '
+            '1, '
+            '3, '
+            'RationalTime(1, 30), '
+            '5, '
+            'TimeRange(RationalTime(0, 30), RationalTime(60, 30)), '
+            "{'custom': {'foo': 'bar'}}"
+            ')'
+        )
+
+    def test_repr(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            start_value=1,
+            value_step=3,
+            frame_duration=otio.opentime.RationalTime(1, 30),
+            image_number_zero_padding=5,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 30),
+                otio.opentime.RationalTime(60, 30),
+            ),
+            metadata={"custom": {"foo": "bar"}},
+        )
+        ref_value = (
+            'ImageSequenceReference('
+            "target_url_base='file:///show/seq/shot/rndr/', "
+            "name_prefix='show_shot.', "
+            "name_suffix='.exr', "
+            'start_value=1, '
+            'value_step=3, '
+            'frame_duration={}, '
+            'image_number_zero_padding=5, '
+            'available_range={}, '
+            "metadata={{'custom': {{'foo': 'bar'}}}}"
+            ')'.format(repr(ref.frame_duration), repr(ref.available_range))
+        )
+        self.assertEqual(repr(ref), ref_value)
+
+    def test_serialize_roundtrip(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=5,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 30),
+                otio.opentime.RationalTime(60, 30),
+            ),
+            value_step=3,
+            frame_duration=otio.opentime.RationalTime(1, 30),
+            metadata={"custom": {"foo": "bar"}},
+        )
+
+        encoded = otio.adapters.otio_json.write_to_string(ref)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(ref, decoded)
+
+        encoded2 = otio.adapters.otio_json.write_to_string(decoded)
+        self.assertEqual(encoded, encoded2)
+
+        # Check Values
+        self.assertEqual(
+            decoded.target_url_base, "file:///show/seq/shot/rndr/"
+        )
+        self.assertEqual(decoded.name_prefix, "show_shot.")
+        self.assertEqual(decoded.name_suffix, ".exr")
+        self.assertEqual(decoded.image_number_zero_padding, 5)
+        self.assertEqual(
+            decoded.available_range,
+            otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 30),
+                otio.opentime.RationalTime(60, 30),
+            )
+        )
+        self.assertEqual(decoded.value_step, 3)
+        self.assertEqual(
+            decoded.frame_duration, otio.opentime.RationalTime(1, 30)
+        )
+        self.assertEqual(decoded.metadata, {"custom": {"foo": "bar"}})
+
+    def test_number_of_images_in_sequence(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            frame_duration=otio.opentime.RationalTime(1, 24),
+        )
+
+        self.assertEqual(ref.number_of_images_in_sequence(), 48)
+
+    def test_number_of_images_in_sequence_with_skip(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            value_step=2,
+            frame_duration=otio.opentime.RationalTime(1, 12),
+        )
+
+        self.assertEqual(ref.number_of_images_in_sequence(), 24)
+
+        ref.value_step = 3
+        ref.frame_duration = otio.opentime.RationalTime(3, 24)
+        self.assertEqual(ref.number_of_images_in_sequence(), 16)
+
+    def test_image_url_for_image_number(self):
+        all_images_urls = [
+            "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
+            for i in range(1, 49)
+        ]
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_value=1,
+            value_step=1,
+            frame_duration=otio.opentime.RationalTime(1, 24),
+        )
+
+        generated_urls = [
+            ref.image_url_for_image_number(i)
+            for i in range(ref.number_of_images_in_sequence())
+        ]
+        self.assertEqual(all_images_urls, generated_urls)
+
+    def test_image_url_for_image_number_steps(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_value=1,
+            value_step=2,
+            frame_duration=otio.opentime.RationalTime(2, 24),
+        )
+
+        all_images_urls = [
+            "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
+            for i in range(1, 49, 2)
+        ]
+        generated_urls = [
+            ref.image_url_for_image_number(i)
+            for i in range(ref.number_of_images_in_sequence())
+        ]
+        self.assertEqual(all_images_urls, generated_urls)
+
+        ref.value_step = 3
+        ref.frame_duration = otio.opentime.RationalTime(3, 24)
+        all_images_urls_threes = [
+            "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
+            for i in range(1, 49, 3)
+        ]
+        generated_urls_threes = [
+            ref.image_url_for_image_number(i)
+            for i in range(ref.number_of_images_in_sequence())
+        ]
+        self.assertEqual(all_images_urls_threes, generated_urls_threes)
+
+        ref.value_step = 2
+        ref.frame_duration = otio.opentime.RationalTime(2, 24)
+        ref.start_value = 0
+        all_images_urls_zero_first = [
+            "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
+            for i in range(0, 48, 2)
+        ]
+        generated_urls_zero_first = [
+            ref.image_url_for_image_number(i)
+            for i in range(ref.number_of_images_in_sequence())
+        ]
+        self.assertEqual(all_images_urls_zero_first, generated_urls_zero_first)

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -174,7 +174,7 @@ class ImageSequenceReferenceTests(
         ref.frame_duration = otio.opentime.RationalTime(3, 24)
         self.assertEqual(ref.number_of_images_in_sequence(), 16)
 
-    def test_image_url_for_image_number(self):
+    def test_target_url_for_image_number(self):
         all_images_urls = [
             "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
             for i in range(1, 49)
@@ -194,12 +194,12 @@ class ImageSequenceReferenceTests(
         )
 
         generated_urls = [
-            ref.image_url_for_image_number(i)
+            ref.target_url_for_image_number(i)
             for i in range(ref.number_of_images_in_sequence())
         ]
         self.assertEqual(all_images_urls, generated_urls)
 
-    def test_image_url_for_image_number_steps(self):
+    def test_target_url_for_image_number_steps(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
@@ -219,7 +219,7 @@ class ImageSequenceReferenceTests(
             for i in range(1, 49, 2)
         ]
         generated_urls = [
-            ref.image_url_for_image_number(i)
+            ref.target_url_for_image_number(i)
             for i in range(ref.number_of_images_in_sequence())
         ]
         self.assertEqual(all_images_urls, generated_urls)
@@ -231,7 +231,7 @@ class ImageSequenceReferenceTests(
             for i in range(1, 49, 3)
         ]
         generated_urls_threes = [
-            ref.image_url_for_image_number(i)
+            ref.target_url_for_image_number(i)
             for i in range(ref.number_of_images_in_sequence())
         ]
         self.assertEqual(all_images_urls_threes, generated_urls_threes)
@@ -244,7 +244,7 @@ class ImageSequenceReferenceTests(
             for i in range(0, 48, 2)
         ]
         generated_urls_zero_first = [
-            ref.image_url_for_image_number(i)
+            ref.target_url_for_image_number(i)
             for i in range(ref.number_of_images_in_sequence())
         ]
         self.assertEqual(all_images_urls_zero_first, generated_urls_zero_first)

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -190,7 +190,7 @@ class ImageSequenceReferenceTests(
             "frame_zero_padding": 5,
             "missing_frame_policy": "BOGUS"
         }"""
-        with self.assertRaises(NotImplementedError):
+        with self.assertRaises(ValueError):
             otio.adapters.otio_json.read_from_string(encoded)
 
     def test_number_of_images_in_sequence(self):

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -1,9 +1,12 @@
 """Test harness for Image Sequence References."""
+import unittest
+import sys
 
 import opentimelineio as otio
 import opentimelineio.test_utils as otio_test_utils
 
-import unittest
+
+IS_PYTHON_2 = (sys.version_info < (3, 0))
 
 
 class ImageSequenceReferenceTests(
@@ -46,6 +49,7 @@ class ImageSequenceReferenceTests(
             otio.schema.ImageSequenceReference.MissingFramePolicy.hold,
         )
 
+    @unittest.skipIf(IS_PYTHON_2, "unicode strings do funny things in python2")
     def test_str(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
@@ -77,6 +81,7 @@ class ImageSequenceReferenceTests(
             ')'
         )
 
+    @unittest.skipIf(IS_PYTHON_2, "unicode strings do funny things in python2")
     def test_repr(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -20,7 +20,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             value_step=3,
-            frame_duration=otio.opentime.RationalTime(1, 30),
+            rate=30,
             metadata={"custom": {"foo": "bar"}},
         )
 
@@ -37,7 +37,7 @@ class ImageSequenceReferenceTests(
             )
         )
         self.assertEqual(ref.value_step, 3)
-        self.assertEqual(ref.frame_duration, otio.opentime.RationalTime(1, 30))
+        self.assertEqual(ref.rate, 30)
         self.assertEqual(ref.metadata, {"custom": {"foo": "bar"}})
 
     def test_str(self):
@@ -47,7 +47,7 @@ class ImageSequenceReferenceTests(
             ".exr",
             start_value=1,
             value_step=3,
-            frame_duration=otio.opentime.RationalTime(1, 30),
+            rate=30,
             image_number_zero_padding=5,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 30),
@@ -63,7 +63,7 @@ class ImageSequenceReferenceTests(
             '".exr", '
             '1, '
             '3, '
-            'RationalTime(1, 30), '
+            '30.0, '
             '5, '
             'TimeRange(RationalTime(0, 30), RationalTime(60, 30)), '
             "{'custom': {'foo': 'bar'}}"
@@ -77,7 +77,7 @@ class ImageSequenceReferenceTests(
             ".exr",
             start_value=1,
             value_step=3,
-            frame_duration=otio.opentime.RationalTime(1, 30),
+            rate=30,
             image_number_zero_padding=5,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 30),
@@ -92,11 +92,11 @@ class ImageSequenceReferenceTests(
             "name_suffix='.exr', "
             'start_value=1, '
             'value_step=3, '
-            'frame_duration={}, '
+            'rate=30.0, '
             'image_number_zero_padding=5, '
             'available_range={}, '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
-            ')'.format(repr(ref.frame_duration), repr(ref.available_range))
+            ')'.format(repr(ref.available_range))
         )
         self.assertEqual(repr(ref), ref_value)
 
@@ -111,7 +111,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             value_step=3,
-            frame_duration=otio.opentime.RationalTime(1, 30),
+            rate=30,
             metadata={"custom": {"foo": "bar"}},
         )
 
@@ -137,9 +137,7 @@ class ImageSequenceReferenceTests(
             )
         )
         self.assertEqual(decoded.value_step, 3)
-        self.assertEqual(
-            decoded.frame_duration, otio.opentime.RationalTime(1, 30)
-        )
+        self.assertEqual(decoded.rate, 30)
         self.assertEqual(decoded.metadata, {"custom": {"foo": "bar"}})
 
     def test_number_of_images_in_sequence(self):
@@ -151,7 +149,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            frame_duration=otio.opentime.RationalTime(1, 24),
+            rate=24,
         )
 
         self.assertEqual(ref.number_of_images_in_sequence(), 48)
@@ -165,13 +163,12 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(48, 24),
             ),
             value_step=2,
-            frame_duration=otio.opentime.RationalTime(1, 12),
+            rate=24,
         )
 
         self.assertEqual(ref.number_of_images_in_sequence(), 24)
 
         ref.value_step = 3
-        ref.frame_duration = otio.opentime.RationalTime(3, 24)
         self.assertEqual(ref.number_of_images_in_sequence(), 16)
 
     def test_target_url_for_image_number(self):
@@ -190,7 +187,7 @@ class ImageSequenceReferenceTests(
             ),
             start_value=1,
             value_step=1,
-            frame_duration=otio.opentime.RationalTime(1, 24),
+            rate=24,
         )
 
         generated_urls = [
@@ -211,7 +208,7 @@ class ImageSequenceReferenceTests(
             ),
             start_value=1,
             value_step=2,
-            frame_duration=otio.opentime.RationalTime(2, 24),
+            rate=24,
         )
 
         all_images_urls = [
@@ -225,7 +222,6 @@ class ImageSequenceReferenceTests(
         self.assertEqual(all_images_urls, generated_urls)
 
         ref.value_step = 3
-        ref.frame_duration = otio.opentime.RationalTime(3, 24)
         all_images_urls_threes = [
             "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
             for i in range(1, 49, 3)
@@ -237,7 +233,6 @@ class ImageSequenceReferenceTests(
         self.assertEqual(all_images_urls_threes, generated_urls_threes)
 
         ref.value_step = 2
-        ref.frame_duration = otio.opentime.RationalTime(2, 24)
         ref.start_value = 0
         all_images_urls_zero_first = [
             "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
@@ -261,7 +256,7 @@ class ImageSequenceReferenceTests(
             ),
             start_value=1,
             value_step=2,
-            frame_duration=otio.opentime.RationalTime(2, 24),
+            rate=24,
         )
 
         reference_values = [
@@ -287,7 +282,7 @@ class ImageSequenceReferenceTests(
             ),
             start_value=1,
             value_step=2,
-            frame_duration=otio.opentime.RationalTime(2, 24),
+            rate=24,
         )
 
         first_frame_time = otio.opentime.RationalTime(12, 24)

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -159,6 +159,40 @@ class ImageSequenceReferenceTests(
         )
         self.assertEqual(decoded.metadata, {"custom": {"foo": "bar"}})
 
+    def test_deserialize_invalid_enum_value(self):
+        encoded = """{
+            "OTIO_SCHEMA": "ImageSequenceReference.1",
+            "metadata": {
+                "custom": {
+                    "foo": "bar"
+                }
+            },
+            "name": "",
+            "available_range": {
+                "OTIO_SCHEMA": "TimeRange.1",
+                "duration": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 30.0,
+                    "value": 60.0
+                },
+                "start_time": {
+                    "OTIO_SCHEMA": "RationalTime.1",
+                    "rate": 30.0,
+                    "value": 0.0
+                }
+            },
+            "target_url_base": "file:///show/seq/shot/rndr/",
+            "name_prefix": "show_shot.",
+            "name_suffix": ".exr",
+            "start_frame": 1,
+            "frame_step": 3,
+            "rate": 30.0,
+            "frame_zero_padding": 5,
+            "missing_frame_policy": "BOGUS"
+        }"""
+        with self.assertRaises(NotImplementedError):
+            otio.adapters.otio_json.read_from_string(encoded)
+
     def test_number_of_images_in_sequence(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -263,6 +263,24 @@ class ImageSequenceReferenceTests(
         ]
         self.assertEqual(all_images_urls_zero_first, generated_urls_zero_first)
 
+    def test_abstract_target_url(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_frame=1,
+            frame_step=1,
+            rate=24,
+        )
+
+        expected_url = "file:///show/seq/shot/rndr/show_shot.@@@@.exr"
+        self.assertEqual(ref.abstract_target_url("@@@@"), expected_url)
+
     def test_presentation_time_for_image_number(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -18,12 +18,12 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=5,
+            frame_zero_padding=5,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
             ),
-            value_step=3,
+            frame_step=3,
             missing_frame_policy=frame_policy,
             rate=30,
             metadata={"custom": {"foo": "bar"}},
@@ -33,7 +33,7 @@ class ImageSequenceReferenceTests(
         self.assertEqual(ref.target_url_base, "file:///show/seq/shot/rndr/")
         self.assertEqual(ref.name_prefix, "show_shot.")
         self.assertEqual(ref.name_suffix, ".exr")
-        self.assertEqual(ref.image_number_zero_padding, 5)
+        self.assertEqual(ref.frame_zero_padding, 5)
         self.assertEqual(
             ref.available_range,
             otio.opentime.TimeRange(
@@ -41,7 +41,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             )
         )
-        self.assertEqual(ref.value_step, 3)
+        self.assertEqual(ref.frame_step, 3)
         self.assertEqual(ref.rate, 30)
         self.assertEqual(ref.metadata, {"custom": {"foo": "bar"}})
         self.assertEqual(
@@ -55,10 +55,10 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            start_value=1,
-            value_step=3,
+            start_frame=1,
+            frame_step=3,
             rate=30,
-            image_number_zero_padding=5,
+            frame_zero_padding=5,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
@@ -87,10 +87,10 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            start_value=1,
-            value_step=3,
+            start_frame=1,
+            frame_step=3,
             rate=30,
-            image_number_zero_padding=5,
+            frame_zero_padding=5,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
@@ -102,10 +102,10 @@ class ImageSequenceReferenceTests(
             "target_url_base='file:///show/seq/shot/rndr/', "
             "name_prefix='show_shot.', "
             "name_suffix='.exr', "
-            'start_value=1, '
-            'value_step=3, '
+            'start_frame=1, '
+            'frame_step=3, '
             'rate=30.0, '
-            'image_number_zero_padding=5, '
+            'frame_zero_padding=5, '
             'missing_frame_policy=MissingFramePolicy.error, '
             'available_range={}, '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
@@ -119,12 +119,12 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=5,
+            frame_zero_padding=5,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
             ),
-            value_step=3,
+            frame_step=3,
             rate=30,
             missing_frame_policy=frame_policy,
             metadata={"custom": {"foo": "bar"}},
@@ -143,7 +143,7 @@ class ImageSequenceReferenceTests(
         )
         self.assertEqual(decoded.name_prefix, "show_shot.")
         self.assertEqual(decoded.name_suffix, ".exr")
-        self.assertEqual(decoded.image_number_zero_padding, 5)
+        self.assertEqual(decoded.frame_zero_padding, 5)
         self.assertEqual(
             decoded.available_range,
             otio.opentime.TimeRange(
@@ -151,7 +151,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             )
         )
-        self.assertEqual(decoded.value_step, 3)
+        self.assertEqual(decoded.frame_step, 3)
         self.assertEqual(decoded.rate, 30)
         self.assertEqual(
             decoded.missing_frame_policy,
@@ -181,13 +181,13 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            value_step=2,
+            frame_step=2,
             rate=24,
         )
 
         self.assertEqual(ref.number_of_images_in_sequence(), 24)
 
-        ref.value_step = 3
+        ref.frame_step = 3
         self.assertEqual(ref.number_of_images_in_sequence(), 16)
 
     def test_target_url_for_image_number(self):
@@ -199,13 +199,13 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=4,
+            frame_zero_padding=4,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            start_value=1,
-            value_step=1,
+            start_frame=1,
+            frame_step=1,
             rate=24,
         )
 
@@ -220,13 +220,13 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=4,
+            frame_zero_padding=4,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            start_value=1,
-            value_step=2,
+            start_frame=1,
+            frame_step=2,
             rate=24,
         )
 
@@ -240,7 +240,7 @@ class ImageSequenceReferenceTests(
         ]
         self.assertEqual(all_images_urls, generated_urls)
 
-        ref.value_step = 3
+        ref.frame_step = 3
         all_images_urls_threes = [
             "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
             for i in range(1, 49, 3)
@@ -251,8 +251,8 @@ class ImageSequenceReferenceTests(
         ]
         self.assertEqual(all_images_urls_threes, generated_urls_threes)
 
-        ref.value_step = 2
-        ref.start_value = 0
+        ref.frame_step = 2
+        ref.start_frame = 0
         all_images_urls_zero_first = [
             "file:///show/seq/shot/rndr/show_shot.{:04}.exr".format(i)
             for i in range(0, 48, 2)
@@ -268,13 +268,13 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=4,
+            frame_zero_padding=4,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            start_value=1,
-            value_step=2,
+            start_frame=1,
+            frame_step=2,
             rate=24,
         )
 
@@ -294,13 +294,13 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=4,
+            frame_zero_padding=4,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(12, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            start_value=1,
-            value_step=2,
+            start_frame=1,
+            frame_step=2,
             rate=24,
         )
 
@@ -322,13 +322,13 @@ class ImageSequenceReferenceTests(
             "file:///show/seq/shot/rndr/",
             "show_shot.",
             ".exr",
-            image_number_zero_padding=4,
+            frame_zero_padding=4,
             available_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(12, 24),
                 otio.opentime.RationalTime(48, 24),
             ),
-            start_value=-1,
-            value_step=2,
+            start_frame=-1,
+            frame_step=2,
             rate=24,
         )
 
@@ -373,7 +373,7 @@ class ImageSequenceReferenceTests(
         )
 
         # Check values by ones
-        ref.value_step = 1
+        ref.frame_step = 1
         for i in range(1, ref.number_of_images_in_sequence()):
             self.assertEqual(
                 ref.target_url_for_image_number(i),

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -317,6 +317,50 @@ class ImageSequenceReferenceTests(
 
         self.assertEqual(generated_values, reference_values)
 
+    def test_end_frame(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(12, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_frame=1,
+            frame_step=1,
+            rate=24,
+        )
+
+        self.assertEqual(ref.end_frame(), 48)
+
+        # Frame step should not affect this
+        ref.frame_step = 2
+        self.assertEqual(ref.end_frame(), 48)
+
+
+    def test_end_frame_with_offset(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(12, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_frame=101,
+            frame_step=1,
+            rate=24,
+        )
+
+        self.assertEqual(ref.end_frame(), 148)
+
+        # Frame step should not affect this
+        ref.frame_step = 2
+        self.assertEqual(ref.end_frame(), 148)
+
+
     def test_negative_frame_numbers(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -248,3 +248,57 @@ class ImageSequenceReferenceTests(
             for i in range(ref.number_of_images_in_sequence())
         ]
         self.assertEqual(all_images_urls_zero_first, generated_urls_zero_first)
+
+    def test_presentation_time_for_image_number(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(0, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_value=1,
+            value_step=2,
+            frame_duration=otio.opentime.RationalTime(2, 24),
+        )
+
+        reference_values = [
+            otio.opentime.RationalTime(i * 2, 24) for i in range(24)
+        ]
+
+        generated_values = [
+            ref.presentation_time_for_image_number(i)
+            for i in range(ref.number_of_images_in_sequence())
+        ]
+
+        self.assertEqual(generated_values, reference_values)
+
+    def test_presentation_time_for_image_number_with_offset(self):
+        ref = otio.schema.ImageSequenceReference(
+            "file:///show/seq/shot/rndr/",
+            "show_shot.",
+            ".exr",
+            image_number_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.RationalTime(12, 24),
+                otio.opentime.RationalTime(48, 24),
+            ),
+            start_value=1,
+            value_step=2,
+            frame_duration=otio.opentime.RationalTime(2, 24),
+        )
+
+        first_frame_time = otio.opentime.RationalTime(12, 24)
+        reference_values = [
+            first_frame_time + otio.opentime.RationalTime(i * 2, 24)
+            for i in range(24)
+        ]
+
+        generated_values = [
+            ref.presentation_time_for_image_number(i)
+            for i in range(ref.number_of_images_in_sequence())
+        ]
+
+        self.assertEqual(generated_values, reference_values)


### PR DESCRIPTION
This is meant to be an alternate approach to the one @apetrynet took in pr #536 as a point of discussion. This resolves #69. I wanted to try an approach that more explicitly broke out image sequence parameters and had awareness of timing associated with frames. This also avoids using format strings in urls which could become ambiguous or need complex escaping logic if a url encoding includes a `%` (e.x. `%20` for a space).

The image sequence is expressed with:
- `target_url_base` - everything leading up to the file name in the `target_url`
- `name_prefix` - everything in the file name leading up to the frame number
- `name_suffix` - everything after the frame number in the file name
- `start_frame` - first frame number used in file names
- `frame_step` - step between frame numbers in file names (every other frame is a step of 2)
- `rate` - double frame rate if every frame in the sequence were played back (ignoring skip frames)
- `frame_zero_padding` - Number of digits to pad zeros out to (e.x. frame 10 with a pad of 4 would be `0010`)
- `missing_frame_policy` - enum `ImageSequenceReference.MissingFramePolicy` {`error`, `hold`, `black`} allows hinting about how a consuming app should behave if an image for which a url is returned should be handled when missing from disk

An example for 24fps media with a sample provided each frame numbered 1-1000 with a path `/show/sequence/shot/sample_image_sequence.%04d.exr` might be:

```
{
  "available_range": {
    "start_time": {
      "value": 0,
      "rate": 24
    },
    "duration": {
      "value": 1000,
      "rate": 24
    }
  },
  "start_frame": 1,
  "frame_step": 1,
  "rate": 24,
  "target_url_base": "file:///show/sequence/shot/",
  "name_prefix": "sample_image_sequence.",
  "name_suffix": ".exr"
  "frame_zero_padding": 4,
}
```

The same duration sequence but with only every 2nd frame available in the sequence would be:

```
{
  "available_range": {
    "start_time": {
      "value": 0,
      "rate": 24
    },
    "duration": {
      "value": 1000,
      "rate": 24
    }
  },
  "start_frame": 1,
  "frame_step": 2,
  "rate": 24,
  "target_url_base": "file:///show/sequence/shot/",
  "name_prefix": "sample_image_sequence.",
  "name_suffix": ".exr"
  "frame_zero_padding": 4,
}
```

A target url is generated using the equivalent of the following python format string:
`f"{target_url_prefix}{(start_frame + (sample_number * frame_step)):0{value_zero_padding}}{target_url_postfix}"`

Negative `start_frame` is also handled. The above example with a `start_frame` of `-1` would yield the first three target urls as:

- `file:///show/sequence/shot/sample_image_sequence.-0001.exr`
- `file:///show/sequence/shot/sample_image_sequence.-0000.exr`
- `file:///show/sequence/shot/sample_image_sequence.0001.exr`

Benefits of this approach include:

- The ability to derive the times each image map to
- Avoids having to support and potentially implement a rich format string system in otio

Downsides:

- A bit heavier than using format strings
- Not as flexible/extensible as format strings

Questions:

- Should `number_of_images_in_sequence` be a property or method in python?
- Should the negative behavior match the python format string `{:04d}` and make a number section of `-001` rather than `-0001`?
- Should I go ahead and implement `image_number_for_time`? This would be useful for people building time-based playback engines but it would also take the opinion a frame starts at a given time and holds until the next frame's start time.

References:

- [RV negative frame number support](http://www.tweaksoftware.com/static/documentation/rv/current/html/rv_manual.html#Command_Line_Options_Image_Sequence_Notation_Negative_Frame_Numbers)

TODO:

- [x] Implement `frame_for_time`
- [X] Implement `frame_range_for_time_range`
- [X] Implement `abstract_target_url`
- [x] Validate choices of C++ data types (mostly `int` vs. `long` in a number of places)

Co-authored by: @apetrynet