### PR TITLE
Adding support for negative time strings when converting a negative

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -282,6 +282,15 @@ RationalTime::to_timecode(
 std::string
 RationalTime::to_time_string() const {
     double total_seconds = to_seconds();
+    bool is_negative = false;
+
+    // We always want to compute with positive numbers to get the right string
+    // result and return the string at the end with a '-'. This provides
+    // compatibility with ffmpeg, which allows negative time strings.
+    if (std::signbit(total_seconds)) {
+        total_seconds = abs(total_seconds);
+        is_negative = true;
+    }
 
     // @TODO: fun fact, this will print the wrong values for numbers at a
     // certain number of decimal places, if you just std::cerr << total_seconds
@@ -322,9 +331,14 @@ RationalTime::to_time_string() const {
         microseconds_str.resize(7, '\0');
     }
 
+    // if the initial time value was negative, return the string with a '-'
+    // sign
+    std::string sign = is_negative ? "-" : "";
+
     return string_printf(
             // decimal should already be in the microseconds_str
-            "%02d:%02d:%s%s",
+            "%s%02d:%02d:%s%s",
+            sign.c_str(),
             hours,
             minutes,
             seconds_str.c_str(),

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -419,6 +419,17 @@ class TestTime(unittest.TestCase):
         time_obj = otio.opentime.from_time_string(time_string, 25)
         self.assertTrue(t.almost_equal(time_obj, delta=0.001))
 
+    def test_time_time_string_negative_rational_time(self):
+        """
+        Negative rational time should return a valid time string
+        with a '-' signage. (This is making it ffmpeg compatible)
+        """
+
+        baseline_time_string = "-00:00:01.0"
+        rt = otio.opentime.RationalTime(-24, 24)
+        time_string = otio.opentime.to_time_string(rt)
+        self.assertEqual(baseline_time_string, time_string)
+
     def test_time_time_string_zero(self):
         t = otio.opentime.RationalTime()
         time_string = "00:00:00.0"


### PR DESCRIPTION
RationalTime object to a string.

Before this change, doing

negativeRationalTime = otio.opentime.RationalTime(-24,24)
timeString = otio.opentime.to_time_string(negativeRationalTime)

timeString would be "-1:-1:-10", which is not a useful time string.

This change introduces a 'negative' time string, i.e. generate the
same string value as a positive RationalTime value would do but
with a '-' sign in front of the string:

timeString is now: '-00:00:01.0'

This is actually a valid string format for ffmpeg and useful if you
for example want to add silence to an audio file at the beginning.