### PR TITLE
Timecode rate is ignored

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -193,8 +193,13 @@ RationalTime::to_timecode(
 ) const {
 
     *error_status = ErrorStatus();
+
+    double value_in_target_rate = _value;
+    if (rate != _rate) {
+        value_in_target_rate = this->value_rescaled_to(rate);
+    }
     
-    if (_value < 0) {
+    if (value_in_target_rate < 0) {
         *error_status = ErrorStatus(ErrorStatus::NEGATIVE_VALUE);
         return std::string();
     }
@@ -252,7 +257,7 @@ RationalTime::to_timecode(
             (std::round(rate) * 60) - dropframes);
 
     // If the number of frames is more than 24 hours, roll over clock
-    double value = std::fmod(_value, frames_per_24_hours);
+    double value = std::fmod(value_in_target_rate, frames_per_24_hours);
 
     if (rate_is_dropframe) {
         int ten_minute_chunks = static_cast<int>(std::floor(value/frames_per_10_minutes));

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -194,12 +194,9 @@ RationalTime::to_timecode(
 
     *error_status = ErrorStatus();
 
-    double value_in_target_rate = _value;
-    if (rate != _rate) {
-        value_in_target_rate = this->value_rescaled_to(rate);
-    }
+    double frames_in_target_rate = this->value_rescaled_to(rate);
     
-    if (value_in_target_rate < 0) {
+    if (frames_in_target_rate < 0) {
         *error_status = ErrorStatus(ErrorStatus::NEGATIVE_VALUE);
         return std::string();
     }
@@ -257,7 +254,7 @@ RationalTime::to_timecode(
             (std::round(rate) * 60) - dropframes);
 
     // If the number of frames is more than 24 hours, roll over clock
-    double value = std::fmod(value_in_target_rate, frames_per_24_hours);
+    double value = std::fmod(frames_in_target_rate, frames_per_24_hours);
 
     if (rate_is_dropframe) {
         int ten_minute_chunks = static_cast<int>(std::floor(value/frames_per_10_minutes));

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -632,7 +632,8 @@ class TestTime(unittest.TestCase):
 
         tc2 = otio.opentime.to_timecode(
             otio.opentime.RationalTime(frames, 29.97),
-            30
+            29.97,
+            drop_frame = False
         )
         self.assertEqual(tc2, NDF_TC)
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -633,7 +633,7 @@ class TestTime(unittest.TestCase):
         tc2 = otio.opentime.to_timecode(
             otio.opentime.RationalTime(frames, 29.97),
             29.97,
-            drop_frame = False
+            drop_frame=False
         )
         self.assertEqual(tc2, NDF_TC)
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -993,6 +993,13 @@ class TestTimeRange(unittest.TestCase):
         self.assertEqual(timecode, otio.opentime.to_timecode(t, 24))
         self.assertNotEqual(timecode, otio.opentime.to_timecode(t, 12))
 
+        time1 = otio.opentime.RationalTime(24.0, 24.0)
+        time2 = otio.opentime.RationalTime(1.0, 1.0)
+        self.assertEqual(
+            otio.opentime.to_timecode(time1, 24.0),
+            otio.opentime.to_timecode(time2, 24.0)
+        )
+
     def test_to_frames_mixed_rates(self):
         frame = 100
         t = otio.opentime.from_frames(frame, 24)


### PR DESCRIPTION
Fix: #606 

This addresses the issue as written... but because having an implicit `rescale` in `to_timecode` seems iffy, I'm also proposing another PR that drops the `rate` argument from `to_timecode` entirely in favor of explicitly calling `rescale_to` in calling code.  Thoughts?