### PR TITLE
Remove "rate" argument from "opentime.to_timecode"

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/ale.py
+++ b/contrib/opentimelineio_contrib/adapters/ale.py
@@ -290,19 +290,19 @@ def write_to_string(input_otio, columns=None, fps=None, video_format=None):
             if not clip.source_range:
                 return ""
             return otio.opentime.to_timecode(
-                clip.source_range.start_time, fps
+                clip.source_range.start_time.rescaled_to(fps)
             )
         elif column == "Duration":
             if not clip.source_range:
                 return ""
             return otio.opentime.to_timecode(
-                clip.source_range.duration, fps
+                clip.source_range.duration.rescaled_to(fps)
             )
         elif column == "End":
             if not clip.source_range:
                 return ""
             return otio.opentime.to_timecode(
-                clip.source_range.end_time_exclusive(), fps
+                clip.source_range.end_time_exclusive().rescaled_to(fps)
             )
         else:
             return clip.metadata.get("ALE", {}).get(column)

--- a/contrib/opentimelineio_contrib/adapters/ffmpeg_burnins.py
+++ b/contrib/opentimelineio_contrib/adapters/ffmpeg_burnins.py
@@ -274,8 +274,9 @@ class Burnins(object):
         :param dict options: recommended to use TimeCodeOptions
         """
         options = options or TimeCodeOptions()
-        timecode = _frames_to_timecode(options['frame_offset'],
-                                       self.frame_rate)
+        timecode = _frames_to_timecode(
+            options['frame_offset'].rescaled_to(self.frame_rate)
+        )
         options = options.copy()
         if not options.get('fps'):
             options['fps'] = self.frame_rate

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -193,8 +193,13 @@ RationalTime::to_timecode(
 ) const {
 
     *error_status = ErrorStatus();
+
+    double value_in_target_rate = _value;
+    if (rate != _rate) {
+        value_in_target_rate = this->value_rescaled_to(rate);
+    }
     
-    if (_value < 0) {
+    if (value_in_target_rate < 0) {
         *error_status = ErrorStatus(ErrorStatus::NEGATIVE_VALUE);
         return std::string();
     }
@@ -252,7 +257,7 @@ RationalTime::to_timecode(
             (std::round(rate) * 60) - dropframes);
 
     // If the number of frames is more than 24 hours, roll over clock
-    double value = std::fmod(_value, frames_per_24_hours);
+    double value = std::fmod(value_in_target_rate, frames_per_24_hours);
 
     if (rate_is_dropframe) {
         int ten_minute_chunks = static_cast<int>(std::floor(value/frames_per_10_minutes));

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -187,23 +187,19 @@ RationalTime::from_time_string(std::string const& time_string, double rate, Erro
 
 std::string
 RationalTime::to_timecode(
-        double rate,
         IsDropFrameRate drop_frame,
         ErrorStatus* error_status
 ) const {
 
     *error_status = ErrorStatus();
 
-    double value_in_target_rate = _value;
-    if (rate != _rate) {
-        value_in_target_rate = this->value_rescaled_to(rate);
-    }
-    
-    if (value_in_target_rate < 0) {
+    if (_value < 0) {
         *error_status = ErrorStatus(ErrorStatus::NEGATIVE_VALUE);
         return std::string();
     }
         
+    double rate = _rate;
+    
     if (!is_valid_timecode_rate(rate)) {
         *error_status = ErrorStatus(ErrorStatus::INVALID_TIMECODE_RATE);
         return std::string();
@@ -257,7 +253,7 @@ RationalTime::to_timecode(
             (std::round(rate) * 60) - dropframes);
 
     // If the number of frames is more than 24 hours, roll over clock
-    double value = std::fmod(value_in_target_rate, frames_per_24_hours);
+    double value = std::fmod(_value, frames_per_24_hours);
 
     if (rate_is_dropframe) {
         int ten_minute_chunks = static_cast<int>(std::floor(value/frames_per_10_minutes));

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -88,13 +88,12 @@ public:
     }
     
     std::string to_timecode(
-            double rate,
             IsDropFrameRate drop_frame,
             ErrorStatus *error_status
     ) const;
 
     std::string to_timecode(ErrorStatus *error_status) const {
-        return to_timecode(_rate, IsDropFrameRate::InferFromRate, error_status);
+        return to_timecode(IsDropFrameRate::InferFromRate, error_status);
     }
     
     std::string to_time_string() const;

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -153,12 +153,10 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self.source_in_label.setText(
             '{timeline}\n{source}'.format(
                 timeline=otio.opentime.to_timecode(
-                    self.timeline_range.start_time,
-                    self.timeline_range.start_time.rate
+                    self.timeline_range.start_time
                 ),
                 source=otio.opentime.to_timecode(
-                    self.item.trimmed_range.start_time,
-                    self.item.trimmed_range.start_time.rate
+                    self.item.trimmed_range.start_time
                 )
             )
         )
@@ -166,12 +164,10 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self.source_out_label.setText(
             '{timeline}\n{source}'.format(
                 timeline=otio.opentime.to_timecode(
-                    self.timeline_range.end_time_exclusive(),
-                    self.timeline_range.end_time_exclusive().rate
+                    self.timeline_range.end_time_exclusive()
                 ),
                 source=otio.opentime.to_timecode(
-                    self.item.trimmed_range.end_time_exclusive(),
-                    self.item.trimmed_range.end_time_exclusive().rate
+                    self.item.trimmed_range.end_time_exclusive()
                 )
             )
         )

--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -84,23 +84,14 @@ void opentime_rationalTime_bindings(py::module m) {
         .def("to_frames", (int (RationalTime::*)() const) &RationalTime::to_frames)
         .def("to_frames", (int (RationalTime::*)(double) const) &RationalTime::to_frames, "rate"_a)
         .def("to_seconds", &RationalTime::to_seconds)
-        .def("to_timecode", [](RationalTime rt, double rate, py::object drop_frame) { 
+        .def("to_timecode", [](RationalTime rt, py::object drop_frame) { 
                 return rt.to_timecode(
-                        rate, 
                         df_enum_converter(drop_frame),
                         ErrorStatusConverter()
                 ); 
-        }, "rate"_a, "drop_frame"_a)
-        .def("to_timecode", [](RationalTime rt, double rate) { 
-                return rt.to_timecode(
-                        rate, 
-                        IsDropFrameRate::InferFromRate,
-                        ErrorStatusConverter()
-                ); 
-        }, "rate"_a)
+        }, "drop_frame"_a)
         .def("to_timecode", [](RationalTime rt) {
                 return rt.to_timecode(
-                        rt.rate(),
                         IsDropFrameRate::InferFromRate,
                         ErrorStatusConverter()); 
                 })

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -556,8 +556,7 @@ class ClipHandler(object):
                         opentime.from_frames(
                             int(getattr(self, prop)),
                             self.edl_rate
-                        ),
-                        self.edl_rate
+                        )
                     )
                 )
 
@@ -1124,10 +1123,10 @@ class EventLine(object):
             'edit': edit_number,
             'reel': self.reel,
             'kind': self._kind,
-            'src_in': opentime.to_timecode(self.source_in, self._rate),
-            'src_out': opentime.to_timecode(self.source_out, self._rate),
-            'rec_in': opentime.to_timecode(self.record_in, self._rate),
-            'rec_out': opentime.to_timecode(self.record_out, self._rate),
+            'src_in': opentime.to_timecode(self.source_in.rescaled_to(self._rate)),
+            'src_out': opentime.to_timecode(self.source_out.rescaled_to(self._rate)),
+            'rec_in': opentime.to_timecode(self.record_in.rescaled_to(self._rate)),
+            'rec_out': opentime.to_timecode(self.record_out.rescaled_to(self._rate)),
             'diss': int(
                 opentime.to_frames(self.dissolve_length, self._rate)
             ),
@@ -1182,8 +1181,7 @@ def _generate_comment_lines(
                 clip.name,
                 timing_effect.time_scalar * edl_rate,
                 opentime.to_timecode(
-                    clip.trimmed_range().start_time,
-                    edl_rate
+                    clip.trimmed_range().start_time.rescaled_to(edl_rate)
                 )
             )
         )
@@ -1241,8 +1239,7 @@ def _generate_comment_lines(
     # Output any markers on this clip
     for marker in clip.markers:
         timecode = opentime.to_timecode(
-            marker.marked_range.start_time,
-            edl_rate
+            marker.marked_range.start_time.rescaled_to(edl_rate)
         )
 
         color = marker.color

--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -1360,7 +1360,7 @@ def _build_timecode(time, fps, drop_frame=False, additional_metadata=None):
 
     # Get the time values
     tc_time = opentime.RationalTime(time.value_rescaled_to(fps), tc_fps)
-    tc_string = opentime.to_timecode(tc_time, tc_fps, drop_frame)
+    tc_string = opentime.to_timecode(tc_time.rescaled_to(tc_fps), drop_frame)
 
     _append_new_sub_element(tc_element, "string", text=tc_string)
 

--- a/src/py-opentimelineio/opentimelineio/console/otiostat.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiostat.py
@@ -125,7 +125,7 @@ def _total_duration(input):
 def _total_duration_timecode(input):
     try:
         d = input.tracks.duration()
-        return otio.opentime.to_timecode(d, d.rate)
+        return otio.opentime.to_timecode(d)
     except AttributeError:
         return "n/a"
 

--- a/src/py-opentimelineio/opentimelineio/opentime.py
+++ b/src/py-opentimelineio/opentimelineio/opentime.py
@@ -13,11 +13,11 @@ range_from_start_end_time = TimeRange.range_from_start_end_time
 duration_from_start_end_time = RationalTime.duration_from_start_end_time
 
 
-def to_timecode(rt, rate=None, drop_frame=None):
+def to_timecode(rt, drop_frame=None):
     return (
         rt.to_timecode()
-        if rate is None and drop_frame is None
-        else rt.to_timecode(rate, drop_frame)
+        if drop_frame is None
+        else rt.to_timecode(drop_frame)
     )
 
 

--- a/src/swift-opentimelineio/opentime.h
+++ b/src/swift-opentimelineio/opentime.h
@@ -68,7 +68,7 @@ bool rational_time_is_valid_timecode_rate(double);
 
 CxxRationalTime rational_time_from_timecode(NSString* timecode, double rate, CxxErrorStruct* err);
 CxxRationalTime rational_time_from_timestring(NSString* timestring, double rate, CxxErrorStruct* err);
-NSString* rational_time_to_timecode(CxxRationalTime, double rate, CxxErrorStruct* err);
+NSString* rational_time_to_timecode(CxxRationalTime, CxxErrorStruct* err);
 NSString* rational_time_to_timestring(CxxRationalTime);
 CxxRationalTime rational_time_add(CxxRationalTime, CxxRationalTime);
 CxxRationalTime rational_time_subtract(CxxRationalTime, CxxRationalTime);

--- a/src/swift-opentimelineio/opentime.mm
+++ b/src/swift-opentimelineio/opentime.mm
@@ -66,9 +66,9 @@ CxxRationalTime rational_time_from_timestring(NSString* timestring, double rate,
     return result;
 }
 
-NSString* rational_time_to_timecode(CxxRationalTime rt, double rate, CxxErrorStruct* err) {
+NSString* rational_time_to_timecode(CxxRationalTime rt, CxxErrorStruct* err) {
     opentime::ErrorStatus error_status;
-    std::string result = otioRationalTime(rt).to_timecode(rate, &error_status);
+    std::string result = otioRationalTime(rt).to_timecode(&error_status);
     deal_with_error(error_status, err);
     return [NSString stringWithUTF8String: result.c_str()];
 }

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -632,7 +632,8 @@ class TestTime(unittest.TestCase):
 
         tc2 = otio.opentime.to_timecode(
             otio.opentime.RationalTime(frames, 29.97),
-            30
+            29.97,
+            drop_frame = False
         )
         self.assertEqual(tc2, NDF_TC)
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -633,7 +633,7 @@ class TestTime(unittest.TestCase):
         tc2 = otio.opentime.to_timecode(
             otio.opentime.RationalTime(frames, 29.97),
             29.97,
-            drop_frame = False
+            drop_frame=False
         )
         self.assertEqual(tc2, NDF_TC)
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -30,7 +30,7 @@ import unittest
 import copy
 
 
-# @TODO: replace "29.97" and similar strings with the correct NTSC values: 
+# @TODO: replace "29.97" and similar strings with the correct NTSC values:
 #        30000/1001
 
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -993,6 +993,13 @@ class TestTimeRange(unittest.TestCase):
         self.assertEqual(timecode, otio.opentime.to_timecode(t, 24))
         self.assertNotEqual(timecode, otio.opentime.to_timecode(t, 12))
 
+        time1 = otio.opentime.RationalTime(24.0, 24.0)
+        time2 = otio.opentime.RationalTime(1.0, 1.0)
+        self.assertEqual(
+            otio.opentime.to_timecode(time1, 24.0),
+            otio.opentime.to_timecode(time2, 24.0)
+        )
+
     def test_to_frames_mixed_rates(self):
         frame = 100
         t = otio.opentime.from_frames(frame, 24)


### PR DESCRIPTION
follow on to #612 - remove the rate argument and avoid the implicit `rescale_to` in `to_timecode`.

The confusing thing is when rate and dropframe/non-dropframe get conflated.
See this:
```
>>> import opentimelineio as otio 
>>> rt = otio.opentime.from_frames(107957, 29.97)
# "I want a non drop frame timecode for this 29.97 media (ignoring the 29.97
# being the wrong NTSC value for a second)"

# because 30 is the non-drop frame rate, I pass that in as an argument, not 
# realizing it'll rescale to 30
>>> otio.opentime.to_timecode(rt, 30, drop_frame=False)
u'01:00:02:05' 

# What the author (probably) intended
>>> otio.opentime.to_timecode(rt, 29.97, drop_frame=False)
u'00:59:58:17

# Gets you back to #1, but this time with the ; instead of the :
>>> otio.opentime.to_timecode(rt, 29.97, drop_frame=True)
u'01:00:02;05' (also probably not what you wanted?)

# (btw these are from one of the unit tests that we needed to adjust)
```