### PR TITLE
RTD is breaking on StrictVersion in setup.py

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,15 +2,15 @@
 version: 2
 
 build:
-    image: latest
+  image: latest
 
 python:
-    version: 3.6
-    install:
-      - method: pip
-        path: .
-        extra_requirements:
-          - cmake
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - cmake
 
 submodules:
   include: all

--- a/setup.py
+++ b/setup.py
@@ -227,8 +227,8 @@ class CMakeBuild(setuptools.command.build_ext.build_ext):
 PIP_VERSION = pip.__version__
 REQUIRED_PIP_VERSION = "6.0.0"
 if (
-        distutils.version.StrictVersion(PIP_VERSION)
-        <= distutils.version.StrictVersion(REQUIRED_PIP_VERSION)
+        distutils.version.LooseVersion(PIP_VERSION)
+        <= distutils.version.LooseVersion(REQUIRED_PIP_VERSION)
 ):
     sys.stderr.write(
         "Your pip version is: '{}', OpenTimelineIO requires at least "
@@ -250,8 +250,8 @@ except ImportError:
 
 REQUIRED_SETUPTOOLS_VERSION = '20.5.0'
 if (
-    distutils.version.StrictVersion(SETUPTOOLS_VERSION)
-    <= distutils.version.StrictVersion(REQUIRED_SETUPTOOLS_VERSION)
+    distutils.version.LooseVersion(SETUPTOOLS_VERSION)
+    <= distutils.version.LooseVersion(REQUIRED_SETUPTOOLS_VERSION)
 ):
     sys.stderr.write(
         "Your setuptools version is: '{}', OpenTimelineIO requires at least "


### PR DESCRIPTION
RTD is getting a crazy traceback in setup.py.  from this line:
```
      File "/tmp/pip-req-build-i6tc3y8j/setup.py", line 253, in <module>
        distutils.version.StrictVersion(SETUPTOOLS_VERSION)
      File "/home/docs/checkouts/readthedocs.org/user_builds/opentimelineio/conda/latest/lib/python3.7/distutils/version.py", line 40, in __init__
        self.parse(vstring)
      File "/home/docs/checkouts/readthedocs.org/user_builds/opentimelineio/conda/latest/lib/python3.7/distutils/version.py", line 137, in parse
        raise ValueError("invalid version number '%s'" % vstring)
```

Doing some googling on `StrictVersion` vs `LooseVersion`, it sounds like what we really want is `LooseVersion`?  If python packaging folks know more, please speak up!

Also bumping RTD to use python3.7 instead of 3.6.