### PR TITLE
Updating Copyright notices

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,9 +1,6 @@
 OpenTimelineIO   
-Copyright 2017 Pixar
-   
+Copyright Contributors to the OpenTimelineIO project.
 All rights reserved.
-
-   
 
 This product includes software developed at:
        

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ with the pep8 style.  We ask that before you submit a pull request, you:
 
 PEP8: https://www.python.org/dev/peps/pep-0008/
 
+License
+-------
+OpenTimelineIO is open source software. Please see ![LICENSE.txt](LICENSE.txt) for details.
+
+Nothing in the license file or this project grants any right to use Pixar or any other contributor’s trade names, trademarks, service marks, or product names.
+
 Contact
 -------
 

--- a/contrib/opentimelineio_contrib/__init__.py
+++ b/contrib/opentimelineio_contrib/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
+++ b/contrib/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -124,7 +124,6 @@ def _find_timecode_mobs(item):
         else:
             # This could be 'EssenceGroup', 'Pulldown' or other segment
             # subclasses
-            # See also: https://jira.pixar.com/browse/SE-3457
             # For example:
             # An EssenceGroup is a Segment that has one or more
             # alternate choices, each of which represent different variations

--- a/contrib/opentimelineio_contrib/adapters/ale.py
+++ b/contrib/opentimelineio_contrib/adapters/ale.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/burnins.py
+++ b/contrib/opentimelineio_contrib/adapters/burnins.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/extern_maya_sequencer.py
+++ b/contrib/opentimelineio_contrib/adapters/extern_maya_sequencer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/extern_rv.py
+++ b/contrib/opentimelineio_contrib/adapters/extern_rv.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
+++ b/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/hls_playlist.py
+++ b/contrib/opentimelineio_contrib/adapters/hls_playlist.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/maya_sequencer.py
+++ b/contrib/opentimelineio_contrib/adapters/maya_sequencer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/rv.py
+++ b/contrib/opentimelineio_contrib/adapters/rv.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/tests/test_ale_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_ale_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/tests/test_burnins.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_burnins.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/tests/test_maya_sequencer.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_maya_sequencer.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/adapters/tests/test_rvsession.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_rvsession.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/PACKAGE
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/PACKAGE
@@ -1,6 +1,6 @@
 package: Example OTIO Reader
-author: Robyn Rindge
-organization: Pixar Animation Studios
+author: Contributors to the OpenTimelineIO project
+organization: OpenTimelineIO project
 contact: opentimelineio@pixar.com
 version: 1.0
 url: http://opentimeline.io

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/example_otio_reader_plugin.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/example_otio_reader_plugin.py
@@ -2,7 +2,7 @@
 Example plugin showing how otio files can be loaded into an RV context
 """
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ import opentimelineio
 PACKAGE_TITLE = 'OpenTimelineIO'
 PACKAGE_NAME = 'opentimelineio'
 PACKAGE_DIR = 'src/py-opentimelineio/opentimelineio'
-AUTHOR_NAME = 'Pixar Animation Studios'
+AUTHOR_NAME = 'Contributors to the OpenTimelineIO project'
 
 try:
     RELEASE = opentimelineio.__version__
@@ -53,7 +53,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = PACKAGE_TITLE
-copyright = u"2018, Pixar Animation Studios"
+copyright = u"Copyright Contributors to the OpenTimelineIO project"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/tutorials/contributing.md
+++ b/docs/tutorials/contributing.md
@@ -28,7 +28,7 @@ Clone your fork to your local machine, like this:
 git clone https://github.com/you/OpenTimelineIO.git
 ```
 
-Add Pixar's OpenTimelineIO repo as upstream to make it easier to update your remote and local repos with the latest changes:
+Add the primary OpenTimelineIO repo as upstream to make it easier to update your remote and local repos with the latest changes:
 
 ```
 cd OpenTimelineIO

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/examples/flatten_video_tracks.py
+++ b/examples/flatten_video_tracks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/examples/sample_plugin/setup.py
+++ b/examples/sample_plugin/setup.py
@@ -35,7 +35,7 @@ setup(
     version='1.0.0',
     description='Adapter writes number of tracks to file.',
     license='Modified Apache 2.0 License',
-    author='Pixar Animation Studios',
+    author='Contributors to the OpenTimelineIO project',
     author_email='opentimelineio@pixar.com',
     url='http://opentimeline.io',
 )

--- a/examples/shot_detect.py
+++ b/examples/shot_detect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/examples/summarize_timing.py
+++ b/examples/summarize_timing.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ if (
 # Metadata that gets stamped into the __init__ files during the build phase.
 PROJECT_METADATA = {
     "version": "0.12.0.dev1",
-    "author": 'Pixar Animation Studios',
+    "author": 'Contributors to the OpenTimelineIO project',
     "author_email": 'opentimelineio@pixar.com',
     "license": 'Modified Apache 2.0 License',
 }

--- a/src/opentimelineview/__init__.py
+++ b/src/opentimelineview/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/opentimelineview/details_widget.py
+++ b/src/opentimelineview/details_widget.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/__init__.py
@@ -26,7 +26,7 @@
 
 see: http://opentimeline.io
 
-.. moduleauthor:: Pixar Animation Studios <opentimelineio@pixar.com>
+.. moduleauthor:: Contributors to the OpenTimelineIO project <opentimelineio@pixar.com>
 """
 
 # flake8: noqa

--- a/src/py-opentimelineio/opentimelineio/adapters/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/adapters/otio_json.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/otio_json.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/algorithms/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/algorithms/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/algorithms/filter.py
+++ b/src/py-opentimelineio/opentimelineio/algorithms/filter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/algorithms/stack_algo.py
+++ b/src/py-opentimelineio/opentimelineio/algorithms/stack_algo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/algorithms/timeline_algo.py
+++ b/src/py-opentimelineio/opentimelineio/algorithms/timeline_algo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/algorithms/track_algo.py
+++ b/src/py-opentimelineio/opentimelineio/algorithms/track_algo.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/console/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/console/__init__.py
@@ -24,7 +24,7 @@
 
 """Console scripts for OpenTimelineIO
 
-.. moduleauthor:: Pixar Animation Studios <opentimelineio@pixar.com>
+.. moduleauthor:: Contributors to the OpenTimelineIO project <opentimelineio@pixar.com>
 """
 
 # flake8: noqa

--- a/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# copyright 2019 pixar animation studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # licensed under the apache license, version 2.0 (the "apache license")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/autogen_serialized_datamodel.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_serialized_datamodel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/console_utils.py
+++ b/src/py-opentimelineio/opentimelineio/console/console_utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/otiocat.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiocat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/otioconvert.py
+++ b/src/py-opentimelineio/opentimelineio/console/otioconvert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# copyright 2019 pixar animation studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # licensed under the apache license, version 2.0 (the "apache license")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/console/otiostat.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiostat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/exceptions.py
+++ b/src/py-opentimelineio/opentimelineio/exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/hooks.py
+++ b/src/py-opentimelineio/opentimelineio/hooks.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/media_linker.py
+++ b/src/py-opentimelineio/opentimelineio/media_linker.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/plugins/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/plugins/python_plugin.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/python_plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/src/py-opentimelineio/opentimelineio/test_utils.py
+++ b/src/py-opentimelineio/opentimelineio/test_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/baseline_reader.py
+++ b/tests/baseline_reader.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/baselines/example.py
+++ b/tests/baselines/example.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/baselines/example_schemadef.py
+++ b/tests/baselines/example_schemadef.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_cdl.py
+++ b/tests/test_cdl.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_composable.py
+++ b/tests/test_composable.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_effect.py
+++ b/tests/test_effect.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_filter_algorithms.py
+++ b/tests/test_filter_algorithms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_hooks_plugins.py
+++ b/tests/test_hooks_plugins.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_json_backend.py
+++ b/tests/test_json_backend.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_media_linker.py
+++ b/tests/test_media_linker.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2018 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_schemadef_plugin.py
+++ b/tests/test_schemadef_plugin.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_serializable_collection.py
+++ b/tests/test_serializable_collection.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_serialized_schema.py
+++ b/tests/test_serialized_schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_stack_algo.py
+++ b/tests/test_stack_algo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_timeline_algo.py
+++ b/tests/test_timeline_algo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2019 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_track_algo.py
+++ b/tests/test_track_algo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_transition.py
+++ b/tests/test_transition.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/test_unknown_schema.py
+++ b/tests/test_unknown_schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 Pixar Animation Studios
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in


### PR DESCRIPTION
As part of our transition into ASWF, we are updating the Copyright notices in the project. We intend to switch all of the copyright notices from the various individual or company contributors to the broader phrasing "Copyright Contributors to the OpenTimelineIO project".
This does not change the actual copyright ownership at all. Each contributor still retains the copyright to their own contributions.
This change makes it easier to see that most of the project contains contributions from many people, and makes it clear that this is a community project.
This initial change only addresses the Pixar notices. After this change, we will ask each contributor to change any copyright notices with their names, so it is clear that they are agreeing to this change in terminology.
