### PR TITLE
Detect if plugin doesn't have a docstring and return an error

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/ale.py
+++ b/contrib/opentimelineio_contrib/adapters/ale.py
@@ -22,7 +22,10 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-"""OpenTimelineIO Avid Log Exchange (ALE) Adapter"""
+
+__doc__ = """OpenTimelineIO Avid Log Exchange (ALE) Adapter"""
+
+
 import re
 import opentimelineio as otio
 

--- a/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
@@ -121,7 +121,14 @@ def _docs_formatted(docstring, arg_map, indent=4):
     initial_indent = prefix
     subsequent_indent = " " * len(prefix)
 
-    block = docstring.split("\n")
+    try:
+        block = docstring.split("\n")
+    except AttributeError:
+        raise RuntimeError(
+            "Plugin: '{}' is missing a docstring.  Make sure the doctring is "
+            "assigned to the __doc__ variable name.".format(arg_map['plugname'])
+        )
+
     fmt_block = []
     for line in block:
         line = textwrap.fill(
@@ -223,7 +230,8 @@ def main():
                     key,
                     val,
                     long_docs=args.long_docs,
-                    attribs=args.attribs
+                    attribs=args.attribs,
+                    plugname=plug.name,
                 )
 
     # hooks aren't really plugin objects, instead they're a mapping of hook


### PR DESCRIPTION
… which says which plugin it is that doesn't have the docstring.