### PR TITLE
Added support for ImageSequenceReference to example RV plugin

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/extern_rv.py
+++ b/contrib/opentimelineio_contrib/adapters/extern_rv.py
@@ -309,15 +309,15 @@ def _write_item(it, to_session, track_kind=None):
             )
 
     if not in_frame and not out_frame:
-        # because OTIO has no global concept of FPS, the rate of the duration is
-        # used as the rate for the range of the source.
-        # RationalTime.value_rescaled_to returns the time value of the object in
-        # time rate of the argument.
-        in_frame = range_to_read.start_time.value_rescaled_to(
-            range_to_read.duration
+        # because OTIO has no global concept of FPS, the rate of the duration
+        # is used as the rate for the range of the source.
+        in_frame = otio.opentime.to_frames(
+            range_to_read.start_time,
+            rate=range_to_read.duration.rate
         )
-        out_frame = range_to_read.end_time_inclusive().value_rescaled_to(
-            range_to_read.duration
+        out_frame = otio.opentime.to_frames(
+            range_to_read.end_time_inclusive(),
+            rate=range_to_read.duration.rate
         )
 
     src.setCutIn(in_frame)

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -207,6 +207,18 @@ def _create_media_reference(item, track_kind=None):
                 media.append(blank)
 
             return media
+        elif isinstance(item.media_reference,
+                        otio.schema.ImageSequenceReference):
+            frame_sub = "%0{n}d".format(
+                n=item.media_reference.frame_zero_padding
+            )
+
+            media = [
+                str(item.media_reference.abstract_target_url(symbol=frame_sub))
+            ]
+            print("ImageSequenceReference media: %s" % media)
+
+            return media
         elif isinstance(item.media_reference, otio.schema.GeneratorReference):
             if item.media_reference.generator_kind == "SMPTEBars":
                 kind = "smptebars"
@@ -250,19 +262,28 @@ def _create_item(it, track_kind=None):
     if hasattr(it, "media_reference") and it.media_reference:
         _add_metadata_to_node(it.media_reference, src)
 
-    # because OTIO has no global concept of FPS, the rate of the duration is
-    # used as the rate for the range of the source.
-    # RationalTime.value_rescaled_to returns the time value of the object in
-    # time rate of the argument.
-    cut_in = range_to_read.start_time.value_rescaled_to(
-        range_to_read.duration
-    )
-    commands.setIntProperty(src + ".cut.in", [int(cut_in)])
+    in_frame = out_frame = None
+    if hasattr(it, "media_reference") and it.media_reference:
+        if isinstance(it.media_reference, otio.schema.ImageSequenceReference):
+            in_frame, out_frame = \
+                it.media_reference.frame_range_for_time_range(
+                    range_to_read
+                )
 
-    cut_out = range_to_read.end_time_inclusive().value_rescaled_to(
-        range_to_read.duration
-    )
-    commands.setIntProperty(src + ".cut.out", [int(cut_out)])
+    if not in_frame and not out_frame:
+        # because OTIO has no global concept of FPS, the rate of the duration
+        # is used as the rate for the range of the source.
+        # RationalTime.value_rescaled_to returns the time value of the object
+        # in time rate of the argument.
+        in_frame = range_to_read.start_time.value_rescaled_to(
+            range_to_read.duration
+        )
+        out_frame = range_to_read.end_time_inclusive().value_rescaled_to(
+            range_to_read.duration
+        )
+
+    commands.setIntProperty(src + ".cut.in", [int(in_frame)])
+    commands.setIntProperty(src + ".cut.out", [int(out_frame)])
 
     commands.setFloatProperty(src + ".group.fps",
                               [float(range_to_read.duration.rate)])

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -216,7 +216,6 @@ def _create_media_reference(item, track_kind=None):
             media = [
                 str(item.media_reference.abstract_target_url(symbol=frame_sub))
             ]
-            print("ImageSequenceReference media: %s" % media)
 
             return media
         elif isinstance(item.media_reference, otio.schema.GeneratorReference):

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -272,17 +272,17 @@ def _create_item(it, track_kind=None):
     if not in_frame and not out_frame:
         # because OTIO has no global concept of FPS, the rate of the duration
         # is used as the rate for the range of the source.
-        # RationalTime.value_rescaled_to returns the time value of the object
-        # in time rate of the argument.
-        in_frame = range_to_read.start_time.value_rescaled_to(
-            range_to_read.duration
+        in_frame = otio.opentime.to_frames(
+            range_to_read.start_time,
+            rate=range_to_read.duration.rate
         )
-        out_frame = range_to_read.end_time_inclusive().value_rescaled_to(
-            range_to_read.duration
+        out_frame = otio.opentime.to_frames(
+            range_to_read.end_time_inclusive(),
+            rate=range_to_read.duration.rate
         )
 
-    commands.setIntProperty(src + ".cut.in", [int(in_frame)])
-    commands.setIntProperty(src + ".cut.out", [int(out_frame)])
+    commands.setIntProperty(src + ".cut.in", [in_frame])
+    commands.setIntProperty(src + ".cut.out", [out_frame])
 
     commands.setFloatProperty(src + ".group.fps",
                               [float(range_to_read.duration.rate)])


### PR DESCRIPTION
This syncs the example OTIO reader plugin with the recent changes in the RV adapter wrt support for the ImageSequenceReference schema