### PR TITLE
RV adapter metadata updates

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/extern_rv.py
+++ b/contrib/opentimelineio_contrib/adapters/extern_rv.py
@@ -271,13 +271,16 @@ def _create_media_reference(item, src, track_kind=None):
 def _write_item(it, to_session, track_kind=None):
     src = to_session.newNode("Source", str(it.name) or "clip")
 
-    src.setProperty(
-        "RVSourceGroup",
-        "source",
-        "otio",
-        "metadata",
-        rvSession.gto.STRING, str(it.metadata)
-    )
+    if it.metadata:
+        src.setProperty(
+            "RVSourceGroup",
+            "source",
+            "otio",
+            "metadata",
+            rvSession.gto.STRING,
+            # Serialize to a string as it seems gto has issues with unicode
+            str(otio.adapters.write_to_string(it.metadata))
+        )
 
     range_to_read = it.trimmed_range()
 

--- a/contrib/opentimelineio_contrib/adapters/extern_rv.py
+++ b/contrib/opentimelineio_contrib/adapters/extern_rv.py
@@ -279,7 +279,7 @@ def _write_item(it, to_session, track_kind=None):
             "metadata",
             rvSession.gto.STRING,
             # Serialize to a string as it seems gto has issues with unicode
-            str(otio.adapters.write_to_string(it.metadata))
+            str(otio.core.serialize_json_to_string(it.metadata, indent=-1))
         )
 
     range_to_read = it.trimmed_range()

--- a/contrib/opentimelineio_contrib/adapters/extern_rv.py
+++ b/contrib/opentimelineio_contrib/adapters/extern_rv.py
@@ -274,8 +274,8 @@ def _write_item(it, to_session, track_kind=None):
     src.setProperty(
         "RVSourceGroup",
         "source",
-        "attributes",
-        "otio_metadata",
+        "otio",
+        "metadata",
         rvSession.gto.STRING, str(it.metadata)
     )
 

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.otio
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.otio
@@ -1,0 +1,140 @@
+{
+    "OTIO_SCHEMA": "Timeline.1", 
+    "metadata": {}, 
+    "name": "OTIO_Test_ppjoshm1.Exported.01", 
+    "tracks": {
+        "OTIO_SCHEMA": "Stack.1", 
+        "children": [
+            {
+                "OTIO_SCHEMA": "Track.1", 
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.1", 
+                        "effects": [], 
+                        "markers": [], 
+                        "media_reference": {
+                            "OTIO_SCHEMA": "ExternalReference.1", 
+                            "available_range": {
+                                "OTIO_SCHEMA": "TimeRange.1",
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 192
+                                },
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 1
+                                }
+                            },
+                            "metadata": {}, 
+                            "name": null, 
+                            "target_url": "sample_data/one_clip.mov"
+                        }, 
+                        "metadata": {
+                            "cmx_3600": {
+                                "comments": [
+                                    "SOURCE FILE: ZZ100_507C.LAY2.01"
+                                ],
+                                "reel": "ZZ100_50"
+                            }
+                        }, 
+                        "name": "ppjoshm_1 (SIM1)", 
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1", 
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1", 
+                                "rate": 24.0, 
+                                "value": 10
+                            }, 
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1", 
+                                "rate": 24.0, 
+                                "value": 101
+                            }
+                        }
+                    }
+                ], 
+                "effects": [], 
+                "kind": "Video", 
+                "markers": [], 
+                "metadata": {}, 
+                "name": "TimelineMobSlot", 
+                "source_range": null
+            }, 
+            {
+                "OTIO_SCHEMA": "Track.1", 
+                "children": [
+                    {
+                        "OTIO_SCHEMA": "Clip.1", 
+                        "effects": [], 
+                        "markers": [], 
+                        "media_reference": {
+                            "OTIO_SCHEMA": "ExternalReference.1", 
+                            "available_range": {
+                                "OTIO_SCHEMA": "TimeRange.1",
+                                "duration": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 192
+                                },
+                                "start_time": {
+                                    "OTIO_SCHEMA": "RationalTime.1",
+                                    "rate": 24,
+                                    "value": 1
+                                }
+                            },
+                            "metadata": {}, 
+                            "name": null, 
+                            "target_url": "sample_data/one_clip.mov"
+                        }, 
+                        "metadata": {
+                            "pixar": {
+                                "OTIO_SCHEMA": "PixarMetadata.1", 
+                                "cache": {
+                                    "hitech": {
+                                        "OTIO_SCHEMA": "PixarHitech.1", 
+                                        "shot": null, 
+                                        "take": null
+                                    }
+                                }, 
+                                "take": {
+                                    "OTIO_SCHEMA": "PixarTake.1", 
+                                    "globaltake": 1, 
+                                    "prod": "ppjoshm", 
+                                    "shot": "ppjoshm_1", 
+                                    "unit": "none"
+                                }
+                            }
+                        }, 
+                        "name": "ppjoshm_1 (SIM1)", 
+                        "source_range": {
+                            "OTIO_SCHEMA": "TimeRange.1", 
+                            "duration": {
+                                "OTIO_SCHEMA": "RationalTime.1", 
+                                "rate": 24.0, 
+                                "value": 10
+                            }, 
+                            "start_time": {
+                                "OTIO_SCHEMA": "RationalTime.1", 
+                                "rate": 24.0, 
+                                "value": 0
+                            }
+                        }
+                    }
+                ], 
+                "effects": [], 
+                "kind": "Audio", 
+                "markers": [], 
+                "metadata": {}, 
+                "name": "TimelineMobSlot", 
+                "source_range": null
+            }
+        ], 
+        "effects": [], 
+        "markers": [], 
+        "metadata": {}, 
+        "name": "tracks", 
+        "source_range": null
+    }
+}

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
@@ -1,0 +1,111 @@
+GTOa (4)
+
+rv : RVSession (4)
+{
+    session
+    {
+        string viewNode = "Stack000000"
+    }
+
+    writer
+    {
+        string name = "rvSession.py"
+        string version = "0.5"
+    }
+}
+
+connections : connection (2)
+{
+    evaluation
+    {
+        string[2] connections = [ [ "sourceGroup000001" "Sequence000001" ] [ "sourceGroup000000" "Sequence000000" ] [ "Sequence000000" "Stack000000" ] [ "Sequence000001" "Stack000000" ] ]
+    }
+}
+
+Sequence000000 : RVSequenceGroup (1)
+{
+    ui
+    {
+        string name = "TimelineMobSlot"
+    }
+}
+
+Sequence000001 : RVSequenceGroup (1)
+{
+    ui
+    {
+        string name = "TimelineMobSlot"
+    }
+}
+
+Stack000000 : RVStackGroup (1)
+{
+    ui
+    {
+        string name = "tracks"
+    }
+}
+
+sourceGroup000000 : RVSourceGroup (1)
+{
+    ui
+    {
+        string name = "ppjoshm_1 (SIM1)"
+    }
+}
+
+sourceGroup000000_source : RVFileSource (1)
+{
+    cut
+    {
+        int in = 101
+        int out = 110
+    }
+
+    group
+    {
+        float fps = 24
+    }
+
+    media
+    {
+        string movie = "sample_data/one_clip.mov"
+    }
+
+    otio
+    {
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_507C.LAY2.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+    }
+}
+
+sourceGroup000001 : RVSourceGroup (1)
+{
+    ui
+    {
+        string name = "ppjoshm_1 (SIM1)"
+    }
+}
+
+sourceGroup000001_source : RVFileSource (1)
+{
+    cut
+    {
+        int in = 0
+        int out = 9
+    }
+
+    group
+    {
+        float fps = 24
+    }
+
+    media
+    {
+        string movie = [ "blank,start=1.0,end=192.0,fps=24.0.movieproc" "blank,start=1.0,end=192.0,fps=24.0.movieproc" "sample_data/one_clip.mov" ]
+    }
+
+    otio
+    {
+        string metadata = "{\n    \"pixar\": {\n        \"OTIO_SCHEMA\": \"PixarMetadata.1\",\n        \"cache\": {\n            \"hitech\": {\n                \"OTIO_SCHEMA\": \"PixarHitech.1\",\n                \"shot\": null,\n                \"take\": null\n            }\n        },\n        \"take\": {\n            \"OTIO_SCHEMA\": \"PixarTake.1\",\n            \"globaltake\": 1,\n            \"prod\": \"ppjoshm\",\n            \"shot\": \"ppjoshm_1\",\n            \"unit\": \"none\"\n        }\n    }\n}"
+    }
+}

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
@@ -74,7 +74,7 @@ sourceGroup000000_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_507C.LAY2.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_507C.LAY2.01\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -106,6 +106,6 @@ sourceGroup000001_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"pixar\": {\n        \"OTIO_SCHEMA\": \"PixarMetadata.1\",\n        \"cache\": {\n            \"hitech\": {\n                \"OTIO_SCHEMA\": \"PixarHitech.1\",\n                \"shot\": null,\n                \"take\": null\n            }\n        },\n        \"take\": {\n            \"OTIO_SCHEMA\": \"PixarTake.1\",\n            \"globaltake\": 1,\n            \"prod\": \"ppjoshm\",\n            \"shot\": \"ppjoshm_1\",\n            \"unit\": \"none\"\n        }\n    }\n}"
+        string metadata = "{\"pixar\":{\"OTIO_SCHEMA\":\"PixarMetadata.1\",\"cache\":{\"hitech\":{\"OTIO_SCHEMA\":\"PixarHitech.1\",\"shot\":null,\"take\":null}},\"take\":{\"OTIO_SCHEMA\":\"PixarTake.1\",\"globaltake\":1,\"prod\":\"ppjoshm\",\"shot\":\"ppjoshm_1\",\"unit\":\"none\"}}}"
     }
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
@@ -64,9 +64,9 @@ sourceGroup000000_source : RVFileSource (1)
         string movie = "smptebars,start=86501.0,end=86531.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_501.LAY3.01']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_501.LAY3.01']}}"
     }
 }
 
@@ -96,9 +96,9 @@ sourceGroup000001_source : RVFileSource (1)
         string movie = "smptebars,start=86557.0,end=86606.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_502A.LAY3.02']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_502A.LAY3.02']}}"
     }
 }
 
@@ -128,9 +128,9 @@ sourceGroup000002_source : RVFileSource (1)
         string movie = "smptebars,start=86601.0,end=86628.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_503A.LAY1.01']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_503A.LAY1.01']}}"
     }
 }
 
@@ -160,9 +160,9 @@ sourceGroup000003_source : RVFileSource (1)
         string movie = "smptebars,start=86641.0,end=86755.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_504C.LAY1.02']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_504C.LAY1.02']}}"
     }
 }
 
@@ -192,9 +192,9 @@ sourceGroup000004_source : RVFileSource (1)
         string movie = "smptebars,start=86753.0,end=86853.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_504B.LAY1.02']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_504B.LAY1.02']}}"
     }
 }
 
@@ -224,9 +224,9 @@ sourceGroup000005_source : RVFileSource (1)
         string movie = "smptebars,start=86501.0,end=86661.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_507C.LAY2.01']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_507C.LAY2.01']}}"
     }
 }
 
@@ -256,9 +256,9 @@ sourceGroup000006_source : RVFileSource (1)
         string movie = "smptebars,start=86628.0,end=86797.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_508.LAY2.02']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_508.LAY2.02']}}"
     }
 }
 
@@ -288,9 +288,9 @@ sourceGroup000007_source : RVFileSource (1)
         string movie = "smptebars,start=86722.0,end=86857.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_51', 'comments': [u'SOURCE FILE: ZZ100_510.LAY1.02']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_51', 'comments': [u'SOURCE FILE: ZZ100_510.LAY1.02']}}"
     }
 }
 
@@ -320,8 +320,8 @@ sourceGroup000008_source : RVFileSource (1)
         string movie = "smptebars,start=86501.0,end=86757.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{'cmx_3600': {'reel': u'ZZ100_51', 'comments': [u'AVX2 EFFECT, RESIZE', u'SOURCE FILE: ZZ100_510B.LAY1.02']}}"
+        string metadata = "{'cmx_3600': {'reel': u'ZZ100_51', 'comments': [u'AVX2 EFFECT, RESIZE', u'SOURCE FILE: ZZ100_510B.LAY1.02']}}"
     }
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
@@ -66,7 +66,7 @@ sourceGroup000000_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_501.LAY3.01']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_501.LAY3.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -98,7 +98,7 @@ sourceGroup000001_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_502A.LAY3.02']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_502A.LAY3.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -130,7 +130,7 @@ sourceGroup000002_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_503A.LAY1.01']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_503A.LAY1.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -162,7 +162,7 @@ sourceGroup000003_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_504C.LAY1.02']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_504C.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -194,7 +194,7 @@ sourceGroup000004_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_504B.LAY1.02']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_504B.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -226,7 +226,7 @@ sourceGroup000005_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_507C.LAY2.01']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_507C.LAY2.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -258,7 +258,7 @@ sourceGroup000006_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_50', 'comments': [u'SOURCE FILE: ZZ100_508.LAY2.02']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_508.LAY2.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
     }
 }
 
@@ -290,7 +290,7 @@ sourceGroup000007_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_51', 'comments': [u'SOURCE FILE: ZZ100_510.LAY1.02']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_510.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_51\"\n    }\n}"
     }
 }
 
@@ -322,6 +322,6 @@ sourceGroup000008_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{'cmx_3600': {'reel': u'ZZ100_51', 'comments': [u'AVX2 EFFECT, RESIZE', u'SOURCE FILE: ZZ100_510B.LAY1.02']}}"
+        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"AVX2 EFFECT, RESIZE\",\n            \"SOURCE FILE: ZZ100_510B.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_51\"\n    }\n}"
     }
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/screening_example.rv
@@ -66,7 +66,7 @@ sourceGroup000000_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_501.LAY3.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_501.LAY3.01\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -98,7 +98,7 @@ sourceGroup000001_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_502A.LAY3.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_502A.LAY3.02\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -130,7 +130,7 @@ sourceGroup000002_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_503A.LAY1.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_503A.LAY1.01\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -162,7 +162,7 @@ sourceGroup000003_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_504C.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_504C.LAY1.02\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -194,7 +194,7 @@ sourceGroup000004_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_504B.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_504B.LAY1.02\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -226,7 +226,7 @@ sourceGroup000005_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_507C.LAY2.01\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_507C.LAY2.01\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -258,7 +258,7 @@ sourceGroup000006_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_508.LAY2.02\"\n        ],\n        \"reel\": \"ZZ100_50\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_508.LAY2.02\"],\"reel\":\"ZZ100_50\"}}"
     }
 }
 
@@ -290,7 +290,7 @@ sourceGroup000007_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"SOURCE FILE: ZZ100_510.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_51\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"SOURCE FILE: ZZ100_510.LAY1.02\"],\"reel\":\"ZZ100_51\"}}"
     }
 }
 
@@ -322,6 +322,6 @@ sourceGroup000008_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\n    \"cmx_3600\": {\n        \"comments\": [\n            \"AVX2 EFFECT, RESIZE\",\n            \"SOURCE FILE: ZZ100_510B.LAY1.02\"\n        ],\n        \"reel\": \"ZZ100_51\"\n    }\n}"
+        string metadata = "{\"cmx_3600\":{\"comments\":[\"AVX2 EFFECT, RESIZE\",\"SOURCE FILE: ZZ100_510B.LAY1.02\"],\"reel\":\"ZZ100_51\"}}"
     }
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
@@ -121,9 +121,9 @@ sourceGroup000000_source : RVFileSource (1)
         string movie = "blank,start=0.0,end=19.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -153,9 +153,9 @@ sourceGroup000001_source : RVFileSource (1)
         string movie = "smptebars,start=-10.0,end=9.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -185,9 +185,9 @@ sourceGroup000002_source : RVFileSource (1)
         string movie = "smptebars,start=10.0,end=39.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -217,9 +217,9 @@ sourceGroup000003_source : RVFileSource (1)
         string movie = "smptebars,start=40.0,end=59.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -249,9 +249,9 @@ sourceGroup000004_source : RVFileSource (1)
         string movie = "smptebars,start=-10.0,end=9.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -281,9 +281,9 @@ sourceGroup000005_source : RVFileSource (1)
         string movie = "smptebars,start=10.0,end=49.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -313,9 +313,9 @@ sourceGroup000006_source : RVFileSource (1)
         string movie = "smptebars,start=0.0,end=39.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -345,9 +345,9 @@ sourceGroup000007_source : RVFileSource (1)
         string movie = "smptebars,start=40.0,end=59.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }
 
@@ -377,8 +377,8 @@ sourceGroup000008_source : RVFileSource (1)
         string movie = "blank,start=-10.0,end=9.0,fps=24.0.movieproc"
     }
 
-    attributes
+    otio
     {
-        string otio_metadata = "{}"
+        string metadata = "{}"
     }
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/transition_test.rv
@@ -120,11 +120,6 @@ sourceGroup000000_source : RVFileSource (1)
     {
         string movie = "blank,start=0.0,end=19.0,fps=24.0.movieproc"
     }
-
-    otio
-    {
-        string metadata = "{}"
-    }
 }
 
 sourceGroup000001 : RVSourceGroup (1)
@@ -151,11 +146,6 @@ sourceGroup000001_source : RVFileSource (1)
     media
     {
         string movie = "smptebars,start=-10.0,end=9.0,fps=24.0.movieproc"
-    }
-
-    otio
-    {
-        string metadata = "{}"
     }
 }
 
@@ -184,11 +174,6 @@ sourceGroup000002_source : RVFileSource (1)
     {
         string movie = "smptebars,start=10.0,end=39.0,fps=24.0.movieproc"
     }
-
-    otio
-    {
-        string metadata = "{}"
-    }
 }
 
 sourceGroup000003 : RVSourceGroup (1)
@@ -215,11 +200,6 @@ sourceGroup000003_source : RVFileSource (1)
     media
     {
         string movie = "smptebars,start=40.0,end=59.0,fps=24.0.movieproc"
-    }
-
-    otio
-    {
-        string metadata = "{}"
     }
 }
 
@@ -248,11 +228,6 @@ sourceGroup000004_source : RVFileSource (1)
     {
         string movie = "smptebars,start=-10.0,end=9.0,fps=24.0.movieproc"
     }
-
-    otio
-    {
-        string metadata = "{}"
-    }
 }
 
 sourceGroup000005 : RVSourceGroup (1)
@@ -279,11 +254,6 @@ sourceGroup000005_source : RVFileSource (1)
     media
     {
         string movie = "smptebars,start=10.0,end=49.0,fps=24.0.movieproc"
-    }
-
-    otio
-    {
-        string metadata = "{}"
     }
 }
 
@@ -312,11 +282,6 @@ sourceGroup000006_source : RVFileSource (1)
     {
         string movie = "smptebars,start=0.0,end=39.0,fps=24.0.movieproc"
     }
-
-    otio
-    {
-        string metadata = "{}"
-    }
 }
 
 sourceGroup000007 : RVSourceGroup (1)
@@ -344,11 +309,6 @@ sourceGroup000007_source : RVFileSource (1)
     {
         string movie = "smptebars,start=40.0,end=59.0,fps=24.0.movieproc"
     }
-
-    otio
-    {
-        string metadata = "{}"
-    }
 }
 
 sourceGroup000008 : RVSourceGroup (1)
@@ -375,10 +335,5 @@ sourceGroup000008_source : RVFileSource (1)
     media
     {
         string movie = "blank,start=-10.0,end=9.0,fps=24.0.movieproc"
-    }
-
-    otio
-    {
-        string metadata = "{}"
     }
 }

--- a/contrib/opentimelineio_contrib/adapters/tests/test_rvsession.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_rvsession.py
@@ -45,6 +45,8 @@ TRANSITION_EXAMPLE_PATH = os.path.join(OTIO_SAMPLE_DATA_DIR, "transition_test.ot
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 BASELINE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.rv")
 BASELINE_TRANSITION_PATH = os.path.join(SAMPLE_DATA_DIR, "transition_test.rv")
+METADATA_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "rv_metadata.otio")
+METADATA_BASELINE_PATH = os.path.join(SAMPLE_DATA_DIR, "rv_metadata.rv")
 
 
 SAMPLE_DATA = """{
@@ -564,6 +566,22 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             rv_session = f.read()
             self.assertEqual(rv_session.count(video_source), 2)
             self.assertEqual(rv_session.count(audio_video_source), 2)
+
+    def test_metadata_read(self):
+        timeline = otio.adapters.read_from_file(METADATA_EXAMPLE_PATH)
+        tmp_path = tempfile.mkstemp(suffix=".rv", text=True)[1]
+
+        otio.adapters.write_to_file(timeline, tmp_path)
+        self.assertTrue(os.path.exists(tmp_path))
+
+        with open(tmp_path) as fo:
+            test_data = fo.read()
+
+        with open(METADATA_BASELINE_PATH) as fo:
+            baseline_data = fo.read()
+
+        self.maxDiff = None
+        self.assertMultiLineEqual(baseline_data, test_data)
 
 
 if __name__ == '__main__':

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -286,7 +286,8 @@ def _add_metadata_to_node(item, rv_node):
     """
     if item.metadata:
         otio_metadata_property = rv_node + ".otio.metadata"
-        otio_metadata = otio.adapters.write_to_string(item.metadata)
+        otio_metadata = otio.core.serialize_json_to_string(item.metadata,
+                                                           indent=-1)
         commands.newProperty(otio_metadata_property, commands.StringType, 1)
         commands.setStringProperty(otio_metadata_property,
                                    [otio_metadata],

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -285,8 +285,8 @@ def _add_metadata_to_node(item, rv_node):
     Add metadata from otio "item" to rv_node
     """
     if item.metadata:
-        otio_metatada_property = rv_node + ".otio.metadata"
-        commands.newProperty(otio_metatada_property, commands.StringType, 1)
-        commands.setStringProperty(otio_metatada_property,
+        otio_metadata_property = rv_node + ".otio.metadata"
+        commands.newProperty(otio_metadata_property, commands.StringType, 1)
+        commands.setStringProperty(otio_metadata_property,
                                    [str(item.metadata)],
                                    True)

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -286,7 +286,8 @@ def _add_metadata_to_node(item, rv_node):
     """
     if item.metadata:
         otio_metadata_property = rv_node + ".otio.metadata"
+        otio_metadata = otio.adapters.write_to_string(item.metadata)
         commands.newProperty(otio_metadata_property, commands.StringType, 1)
         commands.setStringProperty(otio_metadata_property,
-                                   [str(item.metadata)],
+                                   [otio_metadata],
                                    True)


### PR DESCRIPTION
This is the start of a discussion around changes to how the rv adapter stores metadata.

This first part is me trying to align the example rv plugin and this adapter with the location of where the metadata is stored in the rv session by changing it from "attributes.otio_metadata" to "otio.metadata". The thinking here is that the would allow future other properties in the "otio" namespace in the rv session. This does break any existing consumers of this data though. 

Next, I want to have a discussion on the best way to serialize the meatadata so I am leaving this as WIP for now. 

-Robyn 