### PR TITLE
CMX3600: Fixed issue with clips going to multiple target tracks

### DIFF
--- a/tests/sample_data/multi_audio.edl
+++ b/tests/sample_data/multi_audio.edl
@@ -1,0 +1,6 @@
+TITLE: MultiAudio
+FCM: NON-DROP FRAME
+
+001  AX       AA    C        00:00:00:00 00:56:55:22 00:00:00:00 00:56:55:22
+* FROM CLIP NAME: AX
+AUD  3    

--- a/tests/test_cmx_3600_adapter.py
+++ b/tests/test_cmx_3600_adapter.py
@@ -48,6 +48,7 @@ SPEED_EFFECTS_TEST_SMALL = os.path.join(
     SAMPLE_DATA_DIR,
     "speed_effects_small.edl"
 )
+MULTIPLE_TARGET_AUDIO_PATH = os.path.join(SAMPLE_DATA_DIR, "multi_audio.edl")
 
 
 class EDLAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
@@ -811,6 +812,24 @@ V     C        00:00:00:00 00:00:00:05 00:00:00:00 00:00:00:05
 '''
 
         self.assertMultiLineEqual(result, expected)
+
+    def test_read_edl_with_multiple_target_audio_tracks(self):
+        tl = otio.adapters.read_from_file(MULTIPLE_TARGET_AUDIO_PATH)
+
+        self.assertEqual(len(tl.audio_tracks()), 2)
+
+        first_track, second_track = tl.audio_tracks()
+        self.assertEqual(first_track.name, "A1")
+        self.assertEqual(second_track.name, "A2")
+
+        self.assertEqual(first_track[0].name, "AX")
+        self.assertEqual(second_track[0].name, "AX")
+
+        expected_range = otio.opentime.TimeRange(
+            duration=otio.opentime.from_timecode("00:56:55:22", rate=24)
+        )
+        self.assertEqual(first_track[0].source_range, expected_range)
+        self.assertEqual(second_track[0].source_range, expected_range)
 
     def test_custom_reel_names(self):
         track = otio.schema.Track()


### PR DESCRIPTION
Fixed issue where CMX3600 adapter would try to add the same clip to multiple tracks.
Also addressed an issue where certain clip properties were being set up in per-track a loop when they didn't need to be.

Fixes #642 