### PR TITLE
fix otioconvert for Kdenlive with python3

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/kdenlive.py
+++ b/contrib/opentimelineio_contrib/adapters/kdenlive.py
@@ -339,7 +339,7 @@ def write_to_string(input_otio):
         mlt.append(subtractor)
     mlt.append(maintractor)
 
-    return ET.tostring(mlt, encoding='utf-8')
+    return ET.tostring(mlt).decode()
 
 
 if __name__ == '__main__':

--- a/contrib/opentimelineio_contrib/adapters/kdenlive.py
+++ b/contrib/opentimelineio_contrib/adapters/kdenlive.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 Kdenlive developers <kdenlive@kde.org>
+# Copyright Contributors to the OpenTimelineIO project
 #
 # Licensed under the Apache License, Version 2.0 (the "Apache License")
 # with the following modification; you may not use this file except in


### PR DESCRIPTION
Hello,
A minor change that avoids unicode/utf-8 XML encoding failures when switching between python2 & python3.
Best regards,
Vincent