### PR TITLE
Add hook function args to otioview and otioconvert

### DIFF
--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -58,6 +58,16 @@ def _parsed_args():
         'False, etc. Can be used multiple times: -a burrito="bar" -a taco=12.'
     )
     parser.add_argument(
+        '-H',
+        '--hook-function-arg',
+        type=str,
+        default=[],
+        action='append',
+        help='Extra arguments to be passed to the hook functions in the form of '
+        'key=value. Values are strings, numbers or Python literals: True, '
+        'False, etc. Can be used multiple times: -H burrito="bar" -H taco=12.'
+    )
+    parser.add_argument(
         '-m',
         '--media-linker',
         type=str,
@@ -93,6 +103,7 @@ class Main(QtWidgets.QMainWindow):
     def __init__(
             self,
             adapter_argument_map,
+            hook_function_argument_map,
             media_linker,
             media_linker_argument_map,
             *args,
@@ -102,6 +113,7 @@ class Main(QtWidgets.QMainWindow):
         self.adapter_argument_map = adapter_argument_map or {}
         self.media_linker = media_linker
         self.media_linker_argument_map = media_linker_argument_map
+        self.hook_function_argument_map = hook_function_argument_map
 
         self._current_file = None
 
@@ -193,6 +205,7 @@ class Main(QtWidgets.QMainWindow):
         self.tracks_widget.clear()
         file_contents = otio.adapters.read_from_file(
             path,
+            hook_function_argument_map=self.hook_function_argument_map,
             media_linker_name=self.media_linker,
             media_linker_argument_map=self.media_linker_argument_map,
             **self.adapter_argument_map
@@ -263,6 +276,10 @@ def main():
             args.media_linker_arg,
             "media linker"
         )
+        hook_function_argument_map = otio_console.console_utils.arg_list_to_map(
+            args.hook_function_arg,
+            "hook function"
+        )
     except ValueError as exc:
         sys.stderr.write("\n" + str(exc) + "\n")
         sys.exit(1)
@@ -271,6 +288,7 @@ def main():
 
     window = Main(
         read_adapter_arg_map,
+        hook_function_argument_map,
         media_linker_name,
         media_linker_argument_map
     )

--- a/src/py-opentimelineio/opentimelineio/console/otiocat.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiocat.py
@@ -67,6 +67,16 @@ def _parsed_args():
         )
     )
     parser.add_argument(
+        '-H',
+        '--hook-function-arg',
+        type=str,
+        default=[],
+        action='append',
+        help='Extra arguments to be passed to the hook functions in the form of '
+        'key=value. Values are strings, numbers or Python literals: True, '
+        'False, etc. Can be used multiple times: -H burrito="bar" -H taco=12.'
+    )
+    parser.add_argument(
         '-M',
         '--media-linker-arg',
         type=str,
@@ -83,6 +93,7 @@ def _parsed_args():
 def _otio_compatible_file_to_json_string(
         fpath,
         media_linker_name,
+        hooks_args,
         media_linker_argument_map,
         adapter_argument_map
 ):
@@ -94,6 +105,7 @@ def _otio_compatible_file_to_json_string(
     return adapter.write_to_string(
         otio.adapters.read_from_file(
             fpath,
+            hook_function_argument_map=hooks_args,
             media_linker_name=media_linker_name,
             media_linker_argument_map=media_linker_argument_map,
             **adapter_argument_map
@@ -115,6 +127,10 @@ def main():
             args.adapter_arg,
             "adapter"
         )
+        hooks_args = otio.console.console_utils.arg_list_to_map(
+            args.hook_function_arg,
+            "hook function"
+        )
         media_linker_argument_map = otio.console.console_utils.arg_list_to_map(
             args.media_linker_arg,
             "media linker"
@@ -128,6 +144,7 @@ def main():
             _otio_compatible_file_to_json_string(
                 fpath,
                 media_linker_name,
+                hooks_args,
                 media_linker_argument_map,
                 read_adapter_arg_map
             )

--- a/src/py-opentimelineio/opentimelineio/console/otioconvert.py
+++ b/src/py-opentimelineio/opentimelineio/console/otioconvert.py
@@ -213,7 +213,7 @@ def main():
         )
         hooks_args = otio.console.console_utils.arg_list_to_map(
             args.hook_function_arg,
-            "media linker"
+            "hook function"
         )
         ml_args = otio.console.console_utils.arg_list_to_map(
             args.media_linker_arg,

--- a/src/py-opentimelineio/opentimelineio/console/otioconvert.py
+++ b/src/py-opentimelineio/opentimelineio/console/otioconvert.py
@@ -91,6 +91,16 @@ def _parsed_args():
         )
     )
     parser.add_argument(
+        '-H',
+        '--hook-function-arg',
+        type=str,
+        default=[],
+        action='append',
+        help='Extra arguments to be passed to the hook functions in the form of '
+        'key=value. Values are strings, numbers or Python literals: True, '
+        'False, etc. Can be used multiple times: -H burrito="bar" -H taco=12.'
+    )
+    parser.add_argument(
         '-M',
         '--media-linker-arg',
         type=str,
@@ -201,6 +211,10 @@ def main():
             args.adapter_arg,
             "input adapter"
         )
+        hooks_args = otio.console.console_utils.arg_list_to_map(
+            args.hook_function_arg,
+            "media linker"
+        )
         ml_args = otio.console.console_utils.arg_list_to_map(
             args.media_linker_arg,
             "media linker"
@@ -212,6 +226,7 @@ def main():
     result_tl = otio.adapters.read_from_file(
         args.input,
         in_adapter,
+        hook_function_argument_map=hooks_args,
         media_linker_name=media_linker_name,
         media_linker_argument_map=ml_args,
         **read_adapter_arg_map
@@ -247,6 +262,7 @@ def main():
         result_tl,
         args.output,
         out_adapter,
+        hook_function_argument_map=hooks_args,
         **write_adapter_arg_map
     )
 


### PR DESCRIPTION
Adding access to the Hooks Arguments from `otioview` and `otioconvert`
I used the -H switch, which I think is appropriate as long as no one confuses it with the `--help` switch