### PR TITLE
Fix the windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
-cmake_minimum_required(VERSION 2.8.12)
+if (WINDOWS)
+cmake_minimum_required(VERSION 3.17.0)
+else()
+cmake_minimum_required(VERSION 3.9.4)
+endif()
 
 project(OPENTIMELINEIO_ROOT)
 
 add_subdirectory(src)
+

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you want to contribute to the project, please see: https://opentimelineio.rea
 
 You can get the latest development version via:
 
-`git clone --recursive git@github.com:PixarAnimationStudios/OpenTimelineIO.git OpenTimelineIO`
+`git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git OpenTimelineIO`
 
 You can install development dependencies with `pip install .[dev]`
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you want to contribute to the project, please see: https://opentimelineio.rea
 
 You can get the latest development version via:
 
-`git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git OpenTimelineIO`
+`git clone --recursive git@github.com:PixarAnimationStudios/OpenTimelineIO.git OpenTimelineIO`
 
 You can install development dependencies with `pip install .[dev]`
 

--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -30,7 +30,7 @@ Once you have pip installed OpenTimelineIO, you should be able to run:
 # Developer Quickstart
 
 0.  Get the source and submodules:
-    + `git clone --recursive git@github.com:PixarAnimationStudios/OpenTimelineIO.git`
+    + `git clone git@github.com:PixarAnimationStudios/OpenTimelineIO.git`
 
 1. To build OTIO for C++ development:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,9 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.9.4)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if(MSVC)
 	set(PYBIND11_CPP_STANDARD /std:c++14)
 	set(CMAKE_CXX_FLAGS "/W4 /EHsc")

--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -14,7 +14,10 @@ add_library(opentime SHARED
 target_include_directories(opentime PUBLIC "${PROJECT_SOURCE_DIR}/src")
 set_target_properties(opentime PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
 			MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
-install(TARGETS opentime LIBRARY DESTINATION lib)
+install(TARGETS opentime
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib)
+
 if (NOT OTIO_CXX_NOINSTALL)
     install(FILES ${OPENTIME_HEADER_FILES} DESTINATION include/opentime)
 endif (NOT OTIO_CXX_NOINSTALL)

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -77,7 +77,9 @@ target_include_directories(opentimelineio PUBLIC
 target_link_libraries(opentimelineio PUBLIC opentime)
 set_target_properties(opentimelineio PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib"
 			MACOSX_RPATH true WINDOWS_EXPORT_ALL_SYMBOLS true)
-install(TARGETS opentimelineio LIBRARY DESTINATION lib)
+install(TARGETS opentimelineio 
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib)
 
 if (NOT OTIO_CXX_NOINSTALL)
     install(FILES ${OPENTIMELINEIO_HEADER_FILES} DESTINATION include/opentimelineio)


### PR DESCRIPTION
Add a bin target to satisfy cmake windows requirement, bump the version to cmake 3.

The cmake version for Linux is per vfx-platform 2018, the version for Windows is the latest, otherwise VS2019 can't be supported.

