### PR TITLE
Do not require media_reference when deserializing Clip

### DIFF
--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -25,7 +25,7 @@ void  Clip::set_media_reference(MediaReference* media_reference) {
 
 
 bool Clip::read_from(Reader& reader) {
-    return reader.read("media_reference", &_media_reference) &&
+    return reader.read_if_present("media_reference", &_media_reference) &&
            Parent::read_from(reader);
 }
 

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -159,6 +159,14 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.schema.ExternalReference()
         )
 
+        decoded = otio.adapters.otio_json.read_from_string(
+            '{ "OTIO_SCHEMA":"Clip.1" }'
+        )
+        self.assertIsOTIOEquivalentTo(
+            decoded.media_reference,
+            otio.schema.MissingReference()
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A potential fix for https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/670.