### PR TITLE
Not all clip’s media_reference have `target_url`

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
+++ b/contrib/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
@@ -220,14 +220,21 @@ def _gather_clip_mob_ids(input_otio,
 
     def _from_aaf_file(clip):
         """ Get the MobID from the AAF file itself."""
-        mob_id = None
-        target_url = clip.media_reference.target_url
+
+        try:
+            target_url = clip.media_reference.target_url
+
+        except AttributeError:
+            # media_reference like `opentimelineio._otio.GeneratorReference` does not have target_url
+            return None
+
         if os.path.isfile(target_url) and target_url.endswith("aaf"):
             with aaf2.open(clip.media_reference.target_url) as aaf_file:
                 mastermobs = list(aaf_file.content.mastermobs())
                 if len(mastermobs) == 1:
-                    mob_id = mastermobs[0].mob_id
-        return mob_id
+                    return mastermobs[0].mob_id
+
+        return None
 
     def _generate_empty_mobid(clip):
         """Generate a meaningless MobID."""

--- a/contrib/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
+++ b/contrib/opentimelineio_contrib/adapters/aaf_adapter/aaf_writer.py
@@ -225,7 +225,8 @@ def _gather_clip_mob_ids(input_otio,
             target_url = clip.media_reference.target_url
 
         except AttributeError:
-            # media_reference like `opentimelineio._otio.GeneratorReference` does not have target_url
+            # media_reference like `opentimelineio._otio.GeneratorReference`
+            # does not have target_url
             return None
 
         if os.path.isfile(target_url) and target_url.endswith("aaf"):


### PR DESCRIPTION
This came up when there’s a clip like the following in the timeline:
```JSON
{
    "OTIO_SCHEMA": "Clip.1",
    "metadata": {},
    "name": "[Black]",
    "source_range": null,
    "effects": [],
    "markers": [],
    "media_reference": {
        "OTIO_SCHEMA": "GeneratorReference.1",
        "metadata": {},
        "name": "[Black]",
        "available_range": {
            "OTIO_SCHEMA": "TimeRange.1",
            "duration": {
                "OTIO_SCHEMA": "RationalTime.1",
                "rate": 24.0,
                "value": 24.0
            },
            "start_time": {
                "OTIO_SCHEMA": "RationalTime.1",
                "rate": 24.0,
                "value": 1.0
            }
        },
        "generator_kind": "Slug",
        "parameters": {}
    }
}

```
This change will return None and let caller deciding the next mobid strategy  to use.