### PR TITLE
Add List of Supported Formats to Conform.py Help Text

### DIFF
--- a/examples/conform.py
+++ b/examples/conform.py
@@ -59,7 +59,8 @@ def parse_args():
         type=str,
         required=True,
         help='Timeline file(s) to read. Any format supported by OTIO will'
-        ' work.'
+        ' work: fcp_xml, fcpx_xml, EDL, AAF, and more via community '
+        'developed adapters.'
     )
     parser.add_argument(
         '-f',

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -58,9 +58,8 @@ def parse_args():
         'input',
         type=str,
         required=True,
-        help='Timeline file(s) to read. Any format supported by OTIO will'
-        ' work: fcp_xml, fcpx_xml, EDL, AAF, and more via community '
-        'developed adapters.'
+        help='Timeline file(s) to read. Supported formats: {adapters}'
+             ''.format(adapters=otio.adapters.available_adapter_names())
     )
     parser.add_argument(
         '-f',
@@ -128,7 +127,7 @@ def _conform_timeline(timeline, folder):
         # if we found one, then relink to the new path
         clip.media_reference = otio.schema.ExternalReference(
             target_url="file://" + new_path,
-            available_range=None    # we don't know the available range
+            available_range=None  # we don't know the available range
         )
         count += 1
 


### PR DESCRIPTION
Add list of supported files to tooltip for the conform.py example script.