### PR TITLE
Indicate Empty track in otioview and display track name

### DIFF
--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -134,7 +134,7 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
 
     def mouseMoveEvent(self, mouse_event):
         pos = self.mapToScene(mouse_event.pos())
-        self.setPos(QtCore.QPointF(pos.x(),
+        self.setPos(QtCore.QPointF(max(pos.x() - track_widgets.CURRENT_ZOOM_LEVEL * track_widgets.TRACK_NAME_WIDGET_WIDTH, 0),
                                    track_widgets.TIME_SLIDER_HEIGHT -
                                    track_widgets.MARKER_SIZE))
         self.update_frame()

--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -134,7 +134,8 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
 
     def mouseMoveEvent(self, mouse_event):
         pos = self.mapToScene(mouse_event.pos())
-        self.setPos(QtCore.QPointF(max(pos.x() - track_widgets.CURRENT_ZOOM_LEVEL * track_widgets.TRACK_NAME_WIDGET_WIDTH, 0),
+        self.setPos(QtCore.QPointF(max(pos.x() - track_widgets.CURRENT_ZOOM_LEVEL *
+                                       track_widgets.TRACK_NAME_WIDGET_WIDTH, 0),
                                    track_widgets.TIME_SLIDER_HEIGHT -
                                    track_widgets.MARKER_SIZE))
         self.update_frame()

--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -193,7 +193,9 @@ class Ruler(QtWidgets.QGraphicsPolygonItem):
         is_tail = False
         f = "-?-"
 
-        ratio = (self.x() - item.x()) / float(item.rect().width())
+        ratio = (self.x() - item.x() +
+                 track_widgets.CURRENT_ZOOM_LEVEL *
+                 track_widgets.TRACK_NAME_WIDGET_WIDTH) / float(item.rect().width())
 
         # The 'if' condition should be : ratio < 0 or ration >= 1
         # However, we are cheating in order to display the last frame of

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -468,10 +468,8 @@ class CompositionView(QtWidgets.QGraphicsView):
         # inverse the effect of the zoom
         items_to_scale = [
             i for i in self.scene().items()
-            if isinstance(i, track_widgets.BaseItem) or
-            isinstance(i, track_widgets.Marker) or
-            isinstance(i, ruler_widget.Ruler) or
-            isinstance(i, track_widgets.TimeSlider)
+            if (isinstance(i, (track_widgets.BaseItem, track_widgets.Marker,
+                               ruler_widget.Ruler, track_widgets.TimeSlider)))
         ]
 
         for item in items_to_scale:
@@ -716,12 +714,8 @@ class CompositionView(QtWidgets.QGraphicsView):
         track_widgets.CURRENT_ZOOM_LEVEL = zoom_level
         items_to_scale = [
             i for i in self.scene().items()
-            if (
-                isinstance(i, track_widgets.BaseItem) or
-                isinstance(i, track_widgets.Marker) or
-                isinstance(i, ruler_widget.Ruler) or
-                isinstance(i, track_widgets.TimeSlider)
-            )
+            if (isinstance(i, (track_widgets.BaseItem, track_widgets.Marker,
+                               ruler_widget.Ruler, track_widgets.TimeSlider)))
         ]
         # some items we do want to keep the same visual size. So we need to
         # inverse the effect of the zoom

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -205,11 +205,11 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
         if isinstance(self.composition, otio.schema.Stack):
             video_tracks = [
                 t for t in self.composition
-                if t.kind == otio.schema.TrackKind.Video and list(t)
+                if t.kind == otio.schema.TrackKind.Video
             ]
             audio_tracks = [
                 t for t in self.composition
-                if t.kind == otio.schema.TrackKind.Audio and list(t)
+                if t.kind == otio.schema.TrackKind.Audio
             ]
             video_tracks.reverse()
 
@@ -219,8 +219,7 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
                     t.kind not in (
                         otio.schema.TrackKind.Video,
                         otio.schema.TrackKind.Audio
-                    ) and
-                    list(t)
+                    )
                 )
             ]
         else:
@@ -463,6 +462,7 @@ class CompositionView(QtWidgets.QGraphicsView):
         scale_by = 1.0 + float(event.delta()) / 1000
         self.scale(scale_by, 1)
         zoom_level = 1.0 / self.matrix().m11()
+        track_widgets.CURRENT_ZOOM_LEVEL = zoom_level
 
         # some items we do want to keep the same visual size. So we need to
         # inverse the effect of the zoom
@@ -470,7 +470,8 @@ class CompositionView(QtWidgets.QGraphicsView):
             i for i in self.scene().items()
             if isinstance(i, track_widgets.BaseItem) or
             isinstance(i, track_widgets.Marker) or
-            isinstance(i, ruler_widget.Ruler)
+            isinstance(i, ruler_widget.Ruler) or
+            isinstance(i, track_widgets.TimeSlider)
         ]
 
         for item in items_to_scale:
@@ -712,13 +713,14 @@ class CompositionView(QtWidgets.QGraphicsView):
         scaleFactor = self.size().width() / self.sceneRect().width()
         self.scale(scaleFactor * zoom_level, 1)
         zoom_level = 1.0 / self.matrix().m11()
-
+        track_widgets.CURRENT_ZOOM_LEVEL = zoom_level
         items_to_scale = [
             i for i in self.scene().items()
             if (
                 isinstance(i, track_widgets.BaseItem) or
                 isinstance(i, track_widgets.Marker) or
-                isinstance(i, ruler_widget.Ruler)
+                isinstance(i, ruler_widget.Ruler) or
+                isinstance(i, track_widgets.TimeSlider)
             )
         ]
         # some items we do want to keep the same visual size. So we need to

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -35,10 +35,12 @@ LABEL_MARGIN = 5
 MARKER_SIZE = 10
 EFFECT_HEIGHT = (1.0 / 3.0) * TRACK_HEIGHT
 HIGHLIGHT_WIDTH = 5
+TRACK_NAME_WIDGET_WIDTH = 100.0
+CURRENT_ZOOM_LEVEL = 1.0
 
 
 class BaseItem(QtWidgets.QGraphicsRectItem):
-
+    x_value = 0.0
     def __init__(self, item, timeline_range, *args, **kwargs):
         super(BaseItem, self).__init__(*args, **kwargs)
         self.item = item
@@ -185,6 +187,7 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self.setToolTip(self.item.name)
 
     def counteract_zoom(self, zoom_level=1.0):
+        self.setX(self.x_value + TRACK_NAME_WIDGET_WIDTH*zoom_level)
         for label in (
             self.source_name_label,
             self.source_in_label,
@@ -228,6 +231,42 @@ class GapItem(BaseItem):
             QtGui.QBrush(QtGui.QColor(100, 100, 100, 255))
         )
         self.source_name_label.setText('GAP')
+
+
+class TrackNameItem(BaseItem):
+
+    def __init__(self, track, rect, *args, **kwargs):
+        super(TrackNameItem, self).__init__(
+        None,
+        None,
+        rect,
+        *args,
+        **kwargs)
+        track_name = 'Track' if track.name is '' else track.name
+        # track_name = track_name + ('\n(Video)' if track.kind is
+        self.source_name_label.setText(track_name + '\n({})'.format(track.kind))
+        self.source_name_label.setY(
+            (TRACK_HEIGHT -
+             self.source_name_label.boundingRect().height()) / 2.0
+        )
+        self.setToolTip(track.name)
+
+    def itemChange(self, change, value):
+        return super(BaseItem, self).itemChange(change, value)
+
+    def _add_markers(self):
+        return
+
+    def _set_labels(self):
+        return
+
+    def _set_tooltip(self):
+        return
+
+    def counteract_zoom(self, zoom_level=1.0):
+        name_width = self.source_name_label.boundingRect().width()
+        self.source_name_label.setX(0.5 * (self.boundingRect().width() - name_width))
+        self.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
 
 
 class EffectItem(QtWidgets.QGraphicsRectItem):
@@ -370,6 +409,16 @@ class Track(QtWidgets.QGraphicsRectItem):
 
     def _populate(self):
         track_map = self.track.range_of_all_children()
+        track_name_rect = QtCore.QRectF(
+        0,
+        0,
+        TRACK_NAME_WIDGET_WIDTH,
+        TRACK_HEIGHT
+        )
+        track_name_item = TrackNameItem(self.track, track_name_rect)
+        track_name_item.setParentItem(self)
+        track_name_item.setX(0)
+        track_name_item.counteract_zoom()
         for n, item in enumerate(self.track):
             timeline_range = track_map[item]
 
@@ -396,6 +445,7 @@ class Track(QtWidgets.QGraphicsRectItem):
                 continue
 
             new_item.setParentItem(self)
+            new_item.x_value = otio.opentime.to_seconds(timeline_range.start_time) * TIME_MULTIPLIER
             new_item.setX(
                 otio.opentime.to_seconds(timeline_range.start_time) *
                 TIME_MULTIPLIER
@@ -450,7 +500,7 @@ class TimeSlider(QtWidgets.QGraphicsRectItem):
 
     def mousePressEvent(self, mouse_event):
         pos = self.mapToScene(mouse_event.pos())
-        self._ruler.setPos(QtCore.QPointF(pos.x(),
+        self._ruler.setPos(QtCore.QPointF(max(pos.x() - TRACK_NAME_WIDGET_WIDTH * CURRENT_ZOOM_LEVEL, 0),
                                           TIME_SLIDER_HEIGHT -
                                           MARKER_SIZE))
         self._ruler.update_frame()
@@ -459,3 +509,6 @@ class TimeSlider(QtWidgets.QGraphicsRectItem):
 
     def add_ruler(self, ruler):
         self._ruler = ruler
+
+    def counteract_zoom(self, zoom_level=1.0):
+        self.setX(zoom_level * TRACK_NAME_WIDGET_WIDTH)

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -239,6 +239,8 @@ class TrackNameItem(BaseItem):
         super(TrackNameItem, self).__init__(None, None, rect,
                                             *args, **kwargs)
         track_name = 'Track' if track.name == '' else track.name
+        if len(track_name) > 7:
+            track_name = track_name[:7] + '...'
         self.source_name_label.setText(track_name + '\n({})'.format(track.kind))
         self.source_name_label.setY(
             (TRACK_HEIGHT -

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -39,7 +39,6 @@ CURRENT_ZOOM_LEVEL = 1.0
 
 
 class BaseItem(QtWidgets.QGraphicsRectItem):
-    x_value = 0.0
 
     def __init__(self, item, timeline_range, *args, **kwargs):
         super(BaseItem, self).__init__(*args, **kwargs)
@@ -68,6 +67,8 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self._add_effects()
         self._set_labels()
         self._set_tooltip()
+
+        self.x_value = 0.0
 
     def paint(self, *args, **kwargs):
         new_args = [args[0],
@@ -246,7 +247,7 @@ class TrackNameItem(BaseItem):
             (TRACK_HEIGHT -
              self.source_name_label.boundingRect().height()) / 2.0
         )
-        self.setToolTip(track.name)
+        self.setToolTip('{} items'.format(len(track)))
 
     def itemChange(self, change, value):
         return super(BaseItem, self).itemChange(change, value)

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -25,7 +25,6 @@
 from PySide2 import QtGui, QtCore, QtWidgets
 import opentimelineio as otio
 
-
 TIME_SLIDER_HEIGHT = 20
 MEDIA_TYPE_SEPARATOR_HEIGHT = 5
 TRACK_HEIGHT = 45
@@ -41,6 +40,7 @@ CURRENT_ZOOM_LEVEL = 1.0
 
 class BaseItem(QtWidgets.QGraphicsRectItem):
     x_value = 0.0
+
     def __init__(self, item, timeline_range, *args, **kwargs):
         super(BaseItem, self).__init__(*args, **kwargs)
         self.item = item
@@ -187,11 +187,11 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self.setToolTip(self.item.name)
 
     def counteract_zoom(self, zoom_level=1.0):
-        self.setX(self.x_value + TRACK_NAME_WIDGET_WIDTH*zoom_level)
+        self.setX(self.x_value + TRACK_NAME_WIDGET_WIDTH * zoom_level)
         for label in (
-            self.source_name_label,
-            self.source_in_label,
-            self.source_out_label
+                self.source_name_label,
+                self.source_in_label,
+                self.source_out_label
         ):
             label.setTransform(QtGui.QTransform.fromScale(zoom_level, 1.0))
 
@@ -236,14 +236,9 @@ class GapItem(BaseItem):
 class TrackNameItem(BaseItem):
 
     def __init__(self, track, rect, *args, **kwargs):
-        super(TrackNameItem, self).__init__(
-        None,
-        None,
-        rect,
-        *args,
-        **kwargs)
-        track_name = 'Track' if track.name is '' else track.name
-        # track_name = track_name + ('\n(Video)' if track.kind is
+        super(TrackNameItem, self).__init__(None, None, rect,
+                                            *args, **kwargs)
+        track_name = 'Track' if track.name == '' else track.name
         self.source_name_label.setText(track_name + '\n({})'.format(track.kind))
         self.source_name_label.setY(
             (TRACK_HEIGHT -
@@ -410,10 +405,10 @@ class Track(QtWidgets.QGraphicsRectItem):
     def _populate(self):
         track_map = self.track.range_of_all_children()
         track_name_rect = QtCore.QRectF(
-        0,
-        0,
-        TRACK_NAME_WIDGET_WIDTH,
-        TRACK_HEIGHT
+            0,
+            0,
+            TRACK_NAME_WIDGET_WIDTH,
+            TRACK_HEIGHT
         )
         track_name_item = TrackNameItem(self.track, track_name_rect)
         track_name_item.setParentItem(self)
@@ -445,7 +440,8 @@ class Track(QtWidgets.QGraphicsRectItem):
                 continue
 
             new_item.setParentItem(self)
-            new_item.x_value = otio.opentime.to_seconds(timeline_range.start_time) * TIME_MULTIPLIER
+            new_item.x_value = otio.opentime.to_seconds(
+                timeline_range.start_time) * TIME_MULTIPLIER
             new_item.setX(
                 otio.opentime.to_seconds(timeline_range.start_time) *
                 TIME_MULTIPLIER
@@ -500,9 +496,10 @@ class TimeSlider(QtWidgets.QGraphicsRectItem):
 
     def mousePressEvent(self, mouse_event):
         pos = self.mapToScene(mouse_event.pos())
-        self._ruler.setPos(QtCore.QPointF(max(pos.x() - TRACK_NAME_WIDGET_WIDTH * CURRENT_ZOOM_LEVEL, 0),
-                                          TIME_SLIDER_HEIGHT -
-                                          MARKER_SIZE))
+        self._ruler.setPos(QtCore.QPointF(
+            max(pos.x() - TRACK_NAME_WIDGET_WIDTH * CURRENT_ZOOM_LEVEL, 0),
+            TIME_SLIDER_HEIGHT -
+            MARKER_SIZE))
         self._ruler.update_frame()
 
         super(TimeSlider, self).mousePressEvent(mouse_event)


### PR DESCRIPTION
Fixes #654 

I've removed the exclusion check for empty tracks and also displayed the name of the Tracks along with the kind of track.

Here's how it looks:
![vid_gif](https://user-images.githubusercontent.com/35020024/78190233-42526f00-7491-11ea-9a9b-59e95c11c972.gif)

![image](https://user-images.githubusercontent.com/35020024/78190344-7168e080-7491-11ea-8f5c-82fd64a44e94.png)

After changing the code I've introduced a bug in the FrameNumber displayed on the slider. I'll fix that tomorrow.

Meanwhile I look forward to your thoughts on this.

@jminor @ssteinbach @reinecke 