### PR TITLE
[DRAFT] Project schema proposal

### DIFF
--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -61,6 +61,9 @@ from . import (
     transition
 )
 
+# Import Project like this since it's a python class at the moment
+from .project import Project
+
 track.TrackKind = TrackKind
 
 def timeline_from_clips(clips):

--- a/src/py-opentimelineio/opentimelineio/schema/project.py
+++ b/src/py-opentimelineio/opentimelineio/schema/project.py
@@ -1,0 +1,76 @@
+from .. import core
+
+
+@core.register_type
+class Project(core.SerializableObjectWithMetadata):
+    _serializable_label = "Project.1"
+    _name = 'Project'
+
+    def __init__(self, name="", metadata=None):
+        core.SerializableObjectWithMetadata.__init__(self, name, metadata)
+
+        self.name = name
+
+        self.collections = []
+        self.timelines = []
+
+        self.viewer_rate = None
+        self.viewer_resolution = [None, None]
+        self.viewer_lut = None
+
+        if metadata:
+            self.metadata.update(metadata)
+
+        # Example of a quite common meta attribute
+        self.metadata['OCIO_PATH'] = None
+
+    timelines = core.serializable_field(
+        "timelines",
+        list,
+        "collection of timelines"
+    )
+
+    collections = core.serializable_field(
+        "collections",
+        list,
+        "collection of bins"
+    )
+
+    viewer_rate = core.serializable_field(
+        "viewer_rate",
+        float,
+        "viewer playback rate"
+    )
+
+    viewer_resolution = core.serializable_field(
+        "viewer_resolution",
+        list,
+        "viewer resolution"
+    )
+
+    viewer_lut = core.serializable_field(
+        "viewer_lut",
+        str,
+        "viewer LUT"
+    )
+
+    def __repr__(self):
+        return (
+            'otio.schema.Project('
+            'name={}, '
+            'viewer_rate={}, '
+            'viewer_resolution={}, '
+            'viewer_lut={}, '
+            'collections={}, '
+            'timelines={}, '
+            'metadata={}'
+            ')'.format(
+                repr(self.name),
+                repr(self.viewer_rate),
+                repr(self.viewer_resolution),
+                repr(self.viewer_lut),
+                repr(self.collections),
+                repr(self.timelines),
+                repr(self.metadata),
+            )
+        )

--- a/src/py-opentimelineio/opentimelineio/schema/project.py
+++ b/src/py-opentimelineio/opentimelineio/schema/project.py
@@ -33,7 +33,7 @@ class Project(core.SerializableObjectWithMetadata):
     collections = core.serializable_field(
         "collections",
         list,
-        "collection of bins"
+        "collection of 'bins' or other collectibles"
     )
 
     viewer_rate = core.serializable_field(

--- a/src/py-opentimelineio/opentimelineio/schema/project.py
+++ b/src/py-opentimelineio/opentimelineio/schema/project.py
@@ -6,7 +6,9 @@ class Project(core.SerializableObjectWithMetadata):
     _serializable_label = "Project.1"
     _name = 'Project'
 
-    def __init__(self, name="", metadata=None):
+    def __init__(self, name="", viewer_rate=None, viewer_resolution=None,
+                 viewer_lut=None, metadata=None):
+
         core.SerializableObjectWithMetadata.__init__(self, name, metadata)
 
         self.name = name
@@ -14,9 +16,15 @@ class Project(core.SerializableObjectWithMetadata):
         self.collections = []
         self.timelines = []
 
-        self.viewer_rate = None
-        self.viewer_resolution = [None, None]
-        self.viewer_lut = None
+        self.viewer_rate = viewer_rate
+
+        if viewer_resolution:
+            self.viewer_resolution = viewer_resolution
+
+        else:
+            self.viewer_resolution = [None, None]
+
+        self.viewer_lut = viewer_lut
 
         if metadata:
             self.metadata.update(metadata)


### PR DESCRIPTION
Hi!
As touched upon briefly in the last couple of TSC meetings, here is an initial proposal for a Project schema definition.
It's written i python at the moment so this PR is mostly for discussion and to get the ball rolling on a full fledged Project schema.

Some motivation for a Project schema:
* Have a single entry point for collecting several timelines (sequences, episodes, etc.), collection of clips, media references and so on.
* Some metadata is more natural to store under a project umbrella than a timeline like: OCIO config path, media search paths, etc.
* Adding a Project schema will allow users to exchange not only individual timelines, but complete project structures across applications.
* In combination with something like the proposed file bundle #561 adapter one could archive/consolidate a complete project including clips/media references outside of a timeline.

I did a quick "survey" of the project settings of Premiere, Final Cut, Hiero and Davinci and naturally they all have some variations, but all of them share the concept of "bins" and have a notion of these settings:
* frame rate (default frame rate for new timelines)
* resolution (viewer/render resolution)
* colorspace (viewer lut or colorspace of media)

In my proposal I chose to name our "bins" holder; `collections` to refer to the `SerializableCollection` objects that it could store, and a separate `timelines` attribute which should hold `Timeline` objects (duh..)  
I also chose to call the rate, resolution and colorspace:
* `viewer_rate`
* `viewer_resolution`
* `viewer_lut`

as these settings usually only apply to the viewer of an applications project file.

Example in python:
``` python
import opentimelineio as otio

p = otio.schema.Project('myProject')
bin = otio.schema.SerializableCollection('myclips')
t = otio.schema.Timeline('myTimeline')
p.collections.append(bin)
p.timelines.append(t)

otio.adapters.write_to_file(p, 'project_test.otio')
```

Results:
``` bash
otiocat project_test.otio 
{
    "OTIO_SCHEMA": "Project.1",
    "collections": [
        {
            "OTIO_SCHEMA": "SerializableCollection.1",
            "metadata": {},
            "name": "myclips",
            "children": []
        }
    ],
    "timelines": [
        {
            "OTIO_SCHEMA": "Timeline.1",
            "metadata": {},
            "name": "myTimeline",
            "global_start_time": null,
            "tracks": {
                "OTIO_SCHEMA": "Stack.1",
                "metadata": {},
                "name": "tracks",
                "source_range": null,
                "effects": [],
                "markers": [],
                "children": []
            }
        }
    ],
    "viewer_lut": null,
    "viewer_rate": null,
    "viewer_resolution": [
        null,
        null
    ],
    "metadata": {
        "OCIO_PATH": null
    },
    "name": "myProject"
}
```

Again, this is an initial proposal to get the ball rolling. All comments, ideas and views are welcome :)
Thanks!