### PR TITLE
Toggle 'complete track name' display on double click in otioview

### DIFF
--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -36,6 +36,7 @@ MARKER_SIZE = 10
 EFFECT_HEIGHT = (1.0 / 3.0) * TRACK_HEIGHT
 HIGHLIGHT_WIDTH = 5
 TRACK_NAME_WIDGET_WIDTH = 100.0
+SHORT_NAME_LENGTH = 7
 CURRENT_ZOOM_LEVEL = 1.0
 
 
@@ -242,10 +243,10 @@ class TrackNameItem(BaseItem):
         super(TrackNameItem, self).__init__(None, None, rect,
                                             *args, **kwargs)
         self.track = track
-        self.track_name = 'Track' if track.name == '' else track.name
+        self.track_name = 'Track' if not track.name else track.name
         self.full_track_name = self.track_name
-        if len(self.track_name) > 7:
-            self.track_name = self.track_name[:7] + '...'
+        if len(self.track_name) > SHORT_NAME_LENGTH:
+            self.track_name = self.track_name[:SHORT_NAME_LENGTH] + '...'
         self.source_name_label.setText(self.track_name + '\n({})'.format(track.kind))
         self.source_name_label.setY(
             (TRACK_HEIGHT -

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -24,6 +24,7 @@
 
 from PySide2 import QtGui, QtCore, QtWidgets
 import opentimelineio as otio
+from PySide2.QtGui import QFontMetrics
 
 TIME_SLIDER_HEIGHT = 20
 MEDIA_TYPE_SEPARATOR_HEIGHT = 5
@@ -69,6 +70,7 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self._set_tooltip()
 
         self.x_value = 0.0
+        self.current_x_offset = TRACK_NAME_WIDGET_WIDTH
 
     def paint(self, *args, **kwargs):
         new_args = [args[0],
@@ -188,7 +190,7 @@ class BaseItem(QtWidgets.QGraphicsRectItem):
         self.setToolTip(self.item.name)
 
     def counteract_zoom(self, zoom_level=1.0):
-        self.setX(self.x_value + TRACK_NAME_WIDGET_WIDTH * zoom_level)
+        self.setX(self.x_value + self.current_x_offset * zoom_level)
         for label in (
                 self.source_name_label,
                 self.source_in_label,
@@ -239,15 +241,54 @@ class TrackNameItem(BaseItem):
     def __init__(self, track, rect, *args, **kwargs):
         super(TrackNameItem, self).__init__(None, None, rect,
                                             *args, **kwargs)
-        track_name = 'Track' if track.name == '' else track.name
-        if len(track_name) > 7:
-            track_name = track_name[:7] + '...'
-        self.source_name_label.setText(track_name + '\n({})'.format(track.kind))
+        self.track = track
+        self.track_name = 'Track' if track.name == '' else track.name
+        self.full_track_name = self.track_name
+        if len(self.track_name) > 7:
+            self.track_name = self.track_name[:7] + '...'
+        self.source_name_label.setText(self.track_name + '\n({})'.format(track.kind))
         self.source_name_label.setY(
             (TRACK_HEIGHT -
              self.source_name_label.boundingRect().height()) / 2.0
         )
         self.setToolTip('{} items'.format(len(track)))
+        self.track_widget = None
+        self.name_toggle = False
+        self.font = self.source_name_label.font()
+        self.short_width = TRACK_NAME_WIDGET_WIDTH
+        font_metrics = QFontMetrics(self.font)
+        self.full_width = font_metrics.width(self.full_track_name) + 40
+
+    def mouseDoubleClickEvent(self, event):
+        super(TrackNameItem, self).mouseDoubleClickEvent(event)
+        if self.name_toggle:
+            track_name_rect = QtCore.QRectF(
+                0,
+                0,
+                TRACK_NAME_WIDGET_WIDTH,
+                TRACK_HEIGHT
+            )
+            self.setRect(track_name_rect)
+            self.source_name_label.setText(
+                self.track_name + '\n({})'.format(self.track.kind))
+            for widget in self.track_widget.widget_items:
+                widget.current_x_offset = self.short_width
+                widget.counteract_zoom(CURRENT_ZOOM_LEVEL)
+            self.name_toggle = False
+        else:
+            track_name_rect = QtCore.QRectF(
+                0,
+                0,
+                self.full_width,
+                TRACK_HEIGHT
+            )
+            self.setRect(track_name_rect)
+            self.source_name_label.setText(
+                self.full_track_name + '\n({})'.format(self.track.kind))
+            for widget in self.track_widget.widget_items:
+                widget.current_x_offset = self.full_width
+                widget.counteract_zoom(CURRENT_ZOOM_LEVEL)
+            self.name_toggle = True
 
     def itemChange(self, change, value):
         return super(BaseItem, self).itemChange(change, value)
@@ -401,7 +442,8 @@ class Track(QtWidgets.QGraphicsRectItem):
     def __init__(self, track, *args, **kwargs):
         super(Track, self).__init__(*args, **kwargs)
         self.track = track
-
+        self.widget_items = []
+        self.track_name_item = None
         self.setBrush(QtGui.QBrush(QtGui.QColor(43, 52, 59, 255)))
         self._populate()
 
@@ -413,10 +455,11 @@ class Track(QtWidgets.QGraphicsRectItem):
             TRACK_NAME_WIDGET_WIDTH,
             TRACK_HEIGHT
         )
-        track_name_item = TrackNameItem(self.track, track_name_rect)
-        track_name_item.setParentItem(self)
-        track_name_item.setX(0)
-        track_name_item.counteract_zoom()
+        self.track_name_item = TrackNameItem(self.track, track_name_rect)
+        self.track_name_item.setParentItem(self)
+        self.track_name_item.setX(0)
+        self.track_name_item.counteract_zoom()
+        self.track_name_item.track_widget = self
         for n, item in enumerate(self.track):
             timeline_range = track_map[item]
 
@@ -450,6 +493,7 @@ class Track(QtWidgets.QGraphicsRectItem):
                 TIME_MULTIPLIER
             )
             new_item.counteract_zoom()
+            self.widget_items.append(new_item)
 
 
 class Marker(QtWidgets.QGraphicsPolygonItem):


### PR DESCRIPTION
@ssteinbach as per your suggestion to have an option to view long track names in otioview, I've added an option to do that on double-clicking on the TrackName widget.

This is how it looks:

![Screenshot from 2020-05-01 16-18-36](https://user-images.githubusercontent.com/35020024/80801299-84beb700-8bc9-11ea-9801-6a7687308fb6.png)

![Screenshot from 2020-05-01 16-18-53](https://user-images.githubusercontent.com/35020024/80801303-88523e00-8bc9-11ea-9384-e22e9f5036d9.png)
