### PR TITLE
Fixed deepcopy for opentime.TimeRange

### DIFF
--- a/src/py-opentimelineio/opentime-bindings/opentime_timeRange.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_timeRange.cpp
@@ -49,7 +49,7 @@ void opentime_timeRange_bindings(py::module m) {
         .def("__copy__", [](TimeRange tr) {
                 return tr;
             })
-        .def("__deepcopy__", [](TimeRange tr) {
+        .def("__deepcopy__", [](TimeRange tr, py::object memo) {
                 return tr;
             })
         .def_static("range_from_start_end_time", &TimeRange::range_from_start_end_time,

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -81,6 +81,18 @@ class TestTime(unittest.TestCase):
         self.assertFalse(t1 < t2)
         self.assertFalse(t1 <= t2)
 
+    def test_copy(self):
+        t1 = otio.opentime.RationalTime(18, 24)
+
+        t2 = copy.copy(t1)
+        self.assertEqual(t2, otio.opentime.RationalTime(18, 24))
+
+    def test_deepcopy(self):
+        t1 = otio.opentime.RationalTime(18, 24)
+
+        t2 = copy.deepcopy(t1)
+        self.assertEqual(t2, otio.opentime.RationalTime(18, 24))
+
     def test_base_conversion(self):
 
         # from a number
@@ -803,6 +815,34 @@ class TestTimeRange(unittest.TestCase):
         tr3 = otio.opentime.TimeRange(start_time3, duration3)
         self.assertNotEqual(tr1, tr3)
         self.assertFalse(tr1 == tr3)
+
+    def test_copy(self):
+        start_time1 = otio.opentime.RationalTime(18, 24)
+        duration1 = otio.opentime.RationalTime(7, 24)
+        tr1 = otio.opentime.TimeRange(start_time1, duration1)
+
+        tr2 = copy.copy(tr1)
+        self.assertEqual(
+            tr2,
+            otio.opentime.TimeRange(
+                otio.opentime.RationalTime(18, 24),
+                otio.opentime.RationalTime(7, 24),
+            ),
+        )
+
+    def test_deepcopy(self):
+        start_time1 = otio.opentime.RationalTime(18, 24)
+        duration1 = otio.opentime.RationalTime(7, 24)
+        tr1 = otio.opentime.TimeRange(start_time1, duration1)
+
+        tr2 = copy.deepcopy(tr1)
+        self.assertEqual(
+            tr2,
+            otio.opentime.TimeRange(
+                otio.opentime.RationalTime(18, 24),
+                otio.opentime.RationalTime(7, 24),
+            ),
+        )
 
     def test_clamped(self):
         test_point_min = otio.opentime.RationalTime(-2, 24)


### PR DESCRIPTION
The bindings for `__deepcopy__` on `TimeRange` previously didn't accept the `memo` arg. This was causing the following error:

```
>>> copy.deepcopy(otio.opentime.TimeRange())
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ereinecke/.newt-cache/pyenv/versions/3.8.2/lib/python3.8/copy.py", line 153, in deepcopy
    y = copier(memo)
TypeError: __deepcopy__(): incompatible function arguments. The following argument types are supported:
    1. (self: opentimelineio._opentime.TimeRange) -> opentimelineio._opentime.TimeRange

Invoked with: otio.opentime.TimeRange(start_time=otio.opentime.RationalTime(value=0, rate=1), duration=otio.opentime.RationalTime(value=0, rate=1)), {}
```

I've also added unitests for copy and deepcopy on `RationalTime` and `TimeRange` to protect against regression.