### PR TITLE
Addressing a handful of lint issues.

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
+++ b/contrib/opentimelineio_contrib/adapters/fcpx_xml.py
@@ -1140,7 +1140,7 @@ class FcpxXml(object):
     # --------------------
     @staticmethod
     def _track_type(lane_items):
-        audio_only_items = [l for l in lane_items if l["audio_only"]]
+        audio_only_items = [item for item in lane_items if item["audio_only"]]
         if len(audio_only_items) == len(lane_items):
             return otio.schema.TrackKind.Audio
         return otio.schema.TrackKind.Video

--- a/contrib/opentimelineio_contrib/adapters/kdenlive.py
+++ b/contrib/opentimelineio_contrib/adapters/kdenlive.py
@@ -164,7 +164,10 @@ def clock(time):
 
 def write_keyframes(kfdict):
     """Build a MLT keyframe string"""
-    return ';'.join('{}={}'.format(str(int(t.value))).format(v)
+    # TODO: The following line is causing a lint error:
+    #       F524 '...'.format(...) is missing argument(s) for placeholder(s): 1
+    # This will likely cause an exception at runtime and should be addressed.
+    return ';'.join('{}={}'.format(str(int(t.value))).format(v)  # noqa: F524
                     for t, v in kfdict.items())
 
 

--- a/contrib/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_hls_playlist_adapter.py
@@ -260,8 +260,8 @@ class HLSPMedialaylistAdapterTest(unittest.TestCase):
         os.remove(media_pl_tmp_path)
 
         # Strip newline chars
-        reference_lines = [l.strip('\n') for l in reference_lines]
-        adapter_out_lines = [l.strip('\n') for l in adapter_out_lines]
+        reference_lines = [line.strip('\n') for line in reference_lines]
+        adapter_out_lines = [line.strip('\n') for line in adapter_out_lines]
 
         # Compare the lines
         self.assertEqual(reference_lines, adapter_out_lines)
@@ -346,7 +346,7 @@ class HLSPMedialaylistAdapterTest(unittest.TestCase):
         in_timeline = otio.adapters.read_from_file(media_pl_tmp_path)
         with open(media_pl_tmp_path) as f:
             pl_lines = f.readlines()
-        pl_lines = [l.strip('\n') for l in pl_lines]
+        pl_lines = [line.strip('\n') for line in pl_lines]
         os.remove(media_pl_tmp_path)
 
         # validate the TARGETDURATION value is correct

--- a/contrib/opentimelineio_contrib/adapters/tests/test_maya_sequencer.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_maya_sequencer.py
@@ -44,20 +44,20 @@ SETATTR_TO_CHECK = (".ef", ".sf", ".sn", ".se", ".ssf")
 
 def filter_maya_file(contents):
     return '\n'.join(
-        l for l in contents.split('\n')
+        line for line in contents.split('\n')
         if (
-            l.strip().startswith('setAttr') and
-            any(a in l for a in SETATTR_TO_CHECK) or
+            line.strip().startswith('setAttr') and
+            any(a in line for a in SETATTR_TO_CHECK) or
             (
-                not l.startswith('//') and
-                not l.startswith('requires') and
-                not l.startswith('fileInfo') and
-                not l.startswith('currentUnit') and
-                not l.strip().startswith('rename') and
-                not l.strip().startswith('select') and
-                not l.strip().startswith('setAttr') and
-                not l.strip().startswith('0') and
-                not l.strip().startswith('1')
+                not line.startswith('//') and
+                not line.startswith('requires') and
+                not line.startswith('fileInfo') and
+                not line.startswith('currentUnit') and
+                not line.strip().startswith('rename') and
+                not line.strip().startswith('select') and
+                not line.strip().startswith('setAttr') and
+                not line.strip().startswith('0') and
+                not line.strip().startswith('1')
             )
         )
     )

--- a/contrib/opentimelineio_contrib/adapters/xges.py
+++ b/contrib/opentimelineio_contrib/adapters/xges.py
@@ -2752,13 +2752,14 @@ class GstStructure(otio.core.SerializableObject):
 
     # see GST_ASCII_IS_STRING in gst_private.h
     GST_ASCII_CHARS = [
-        ord(l) for l in "abcdefghijklmnopqrstuvwxyz"
-                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-                        "0123456789"
-                        "_-+/:."
+        ord(letter) for letter in
+        "abcdefghijklmnopqrstuvwxyz"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "0123456789"
+        "_-+/:."
     ]
-    LEADING_OCTAL_CHARS = [ord(l) for l in "0123"]
-    OCTAL_CHARS = [ord(l) for l in "01234567"]
+    LEADING_OCTAL_CHARS = [ord(letter) for letter in "0123"]
+    OCTAL_CHARS = [ord(letter) for letter in "01234567"]
 
     @classmethod
     def serialize_string(cls, value):

--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -278,7 +278,8 @@ class EDLParser(object):
 
         # remove all blank lines from the edl
         edl_lines = [
-            l for l in (l.strip() for l in edl_string.splitlines()) if l
+            line for line in
+            (line.strip() for line in edl_string.splitlines()) if line
         ]
 
         while edl_lines:

--- a/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
@@ -320,7 +320,7 @@ def _manifest_formatted(
 
             pt_lines.append(plug_lines)
 
-        display_map[pt] = "\n".join((str(l) for l in pt_lines))
+        display_map[pt] = "\n".join((str(line) for line in pt_lines))
 
     return MANIFEST_CONTENT_TEMPLATE.format(
         adapters=display_map['adapters'],

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -259,7 +259,7 @@ def _add_mutable_sequence_methods(
                 if len(item) != len(indices):
                     raise ValueError(
                         "attempt to assign sequence of size {} to extended "
-                        "slice of size {}".format((len(item), len(indices)))
+                        "slice of size {}".format(len(item), len(indices))
                     )
                 if not side_effecting_insertions:
                     for i, e in enumerate(item):


### PR DESCRIPTION
Somehow lint started failing for people on a lot of their branches due to issues in master, here is one such example: https://travis-ci.com/github/PixarAnimationStudios/OpenTimelineIO/jobs/333466701

Worth noting, there was one function in the kdenlive adapter I didn't know the correct fix for so I just muted the warning. This is likely broken and will require someone with more experience in that realm to address:

```
def write_keyframes(kfdict):
    """Build a MLT keyframe string"""
    # TODO: The following line is causing a lint error:
    #       F524 '...'.format(...) is missing argument(s) for placeholder(s): 1
    # This will likely cause an exception at runtime and should be addressed.
    return ';'.join('{}={}'.format(str(int(t.value))).format(v)  # noqa: F524
                    for t, v in kfdict.items())
```