### PR TITLE
Fix documentation on read the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,4 +113,7 @@ doc-plugins-update:
 
 # generate documentation in html
 doc-html:
+	@# if you just want to build the docs yourself outside of RTD and don't want
+	@# to bother with tox, uncomment this line:
+	@# cd docs ; sphinx-build -j8 -E -b html -d /var/tmp/otio-docs/doctrees . /var/tmp/otio-docs/html
 	@tox -e build-docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ except AttributeError:
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
+    'recommonmark',
     # uncomment the next line if you are writing in Google Napoleon docstrings
     # 'sphinx.ext.napoleon'
 ]
@@ -39,7 +40,7 @@ autodoc_mock_imports = ['aaf']
 templates_path = ['_templates']
 
 source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
+    '.md': 'recommonmark.parser.CommonMarkParser',
 }
 
 # The suffix of source filenames.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,7 @@ except AttributeError:
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.doctest',
+    # this plugin is used to format our markdown correctly
     'recommonmark',
     # uncomment the next line if you are writing in Google Napoleon docstrings
     # 'sphinx.ext.napoleon'
@@ -283,6 +284,9 @@ def run_apidoc(_):
         '--module-first',
         '--output-dir',
         './api/modules',
+        # this is expected to be run from the `docs` directory.  Its possible
+        # to set it up to run from other places, but so far this has worked for
+        # us
         '../src/py-opentimelineio/opentimelineio',
     ] + ignore_paths
 

--- a/docs/cxx/cxx.rst
+++ b/docs/cxx/cxx.rst
@@ -1,5 +1,5 @@
 C++ Implementation Details
-====================
+==========================
 
 Dependencies
 ++++++++++++
@@ -614,7 +614,7 @@ raise, and what their semantic meaning is.
     OBJECT_WITHOUT_DURATION, ``ValueError``,
     CANNOT_TRIM_TRANSITION, ``ValueError``,
 
-.. todo:: Add a section discussing how to add additional error types.
+.. todo: Add a section discussing how to add additional error types.
 
 Thread Safety
 ++++++++++++++

--- a/docs/cxx/older.md
+++ b/docs/cxx/older.md
@@ -2,7 +2,7 @@
 
 Here are some initial thoughts about the subject, from around June 2018,
 about providing languages other than Python.  The actual current
-plan is [here](cxx.html).
+plan is [here](./cxx).
 
 The current python implementation of OTIO has been super helpful for defining the library and getting studio needs settled, but in order to integrate the library into vendor tools, a C/C++ implementation is required.  We don't want to give up the Python API, however, so the plan is to port the library to C/C++ with a Python wrapper that implements an interface to the library as it currently stands; existing Python code shouldn't notice the switch.  We can use the existing unit tests to vet the implementation and make sure that it matches the Python API.
 

--- a/docs/tutorials/architecture.md
+++ b/docs/tutorials/architecture.md
@@ -39,28 +39,29 @@ The `otio.schema.Clip` objects can reference media through a `otio.media_referen
 
 Schema composition objects (`otio.schema.Stack` and `otio.schema.Track`) implement the python mutable sequence API.  A simple script that prints out each shot might look like:
 
-```
+
+```python
 import opentimelineio as otio
 
 # read the timeline into memory
 tl = otio.adapters.read_from_file("my_file.otio")
 
 for each_seq in tl.tracks:
-  for each_item in each_seq:
-   if isinstance(each_item, otio.schema.Clip):
-    print each_item.media_reference
+    for each_item in each_seq:
+        if isinstance(each_item, otio.schema.Clip):
+            print each_item.media_reference
 ```
 
 or, in the case of any nested composition, like this:
 
-```
+```python
 import opentimelineio as otio
 
 # read the timeline into memory
 tl = otio.adapters.read_from_file("my_file.otio")
 
 for clip in tl.each_clip():
-  print clip.media_reference
+    print clip.media_reference
 ```
 
 ## Time on otio.schema.Clip
@@ -72,13 +73,15 @@ A clip may set its timing information (which is used to compute its `duration()`
  The range of media that is cut into the sequence, in the space of the available range (if it is set). In other words, it further truncates the available_range.
 
 A clip must have at least one set or else its duration is not computable.
-```
+
+```python
 cl.duration()
-CannotComputeAvailableRangeError: No available_range set on media reference on clip: Clip("example", External("file:///example.mov"), None, {})
+# raises: CannotComputeAvailableRangeError: No available_range set on media reference on clip: Clip("example", External("file:///example.mov"), None, {})
 ```
 
 You may query the `available_range` and `trimmed_range` via accessors on the `Clip()` itself, for example:
-```
+
+```python
 cl.trimmed_range()
 cl.available_range() # == cl.media_reference.available_range
 ```
@@ -116,15 +119,15 @@ Most common usage only cares about:
 
 The native format serialization (`.otio` files) is handled via the "otio_json" adapter, `otio.adapters.otio_json`.
 
-In most cases you don't need to worry about adapter names, just use `otio.adapters.read_from_file` and `otio.adapters.write_to_file` and it will figure out which one to use based on the filename extension.
+In most cases you don't need to worry about adapter names, just use `otio.adapters.read_from_file()` and `otio.adapters.write_to_file` and it will figure out which one to use based on the filename extension.
 
 For more information, see <a href="write-an-adapter.html" target="_blank">How To Write An OpenTimelineIO Adapter</a>
 
 ## otio.media_linkers
 
-Media linkers run on the otio file after an adapter calls `.read_from_file` or `.read_from_string`.  They are intended to replace media references that exist after the adapter runs (which depending on the adapter are likely to be `MissingReference`) with ones that point to valid files in the local system.  Since media linkers are plugins, they can use proprietary knowledge or context and do not need to be part of OTIO itself.
+Media linkers run on the otio file after an adapter calls `.read_from_file()` or `.read_from_string()`.  They are intended to replace media references that exist after the adapter runs (which depending on the adapter are likely to be `MissingReference`) with ones that point to valid files in the local system.  Since media linkers are plugins, they can use proprietary knowledge or context and do not need to be part of OTIO itself.
 
-You may also specify a media linker to be run after the adapter, either via the `media_linker_name` argument to `.read_from_file` or `.read_from_string` or via the `OTIO_DEFAULT_MEDIA_LINKER` environment variable.  You can also turn the media linker off completely by setting the `media_linker_name` argument to `otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia`.
+You may also specify a media linker to be run after the adapter, either via the `media_linker_name` argument to `.read_from_file()` or `.read_from_string()` or via the `OTIO_DEFAULT_MEDIA_LINKER` environment variable.  You can also turn the media linker off completely by setting the `media_linker_name` argument to `otio.media_linker.MediaLinkingPolicy.DoNotLinkMedia`.
 
 For more information about writing media linkers, see <a href="write-a-media-linker.html" target="_blank">How To Write An OpenTimelineIO Media Linker</a>
 

--- a/docs/tutorials/contributing.md
+++ b/docs/tutorials/contributing.md
@@ -24,26 +24,26 @@ Use the github website to fork your own private repository.
 
 Clone your fork to your local machine, like this:
 
-```
+```bash
 git clone https://github.com/you/OpenTimelineIO.git
 ```
 
 Add the primary OpenTimelineIO repo as upstream to make it easier to update your remote and local repos with the latest changes:
 
-```
+```bash
 cd OpenTimelineIO
 git remote add upstream https://github.com/PixarAnimationStudios/OpenTimelineIO.git
 ```
 
 Now you fetch the latest changes from Pixar's OpenTimelineIO repo like this:
 
-```
+```bash
 git fetch upstream
 ```
 
 All the development should happen against the `master` branch.  We recommend you create a new branch for each feature or fix that you'd like to make and give it a descriptive name so that you can remember it later.  You can checkout a new branch and create it simultaneously like this:
 
-```
+```bash
 git checkout -b mybugfix upstream/master
 ```
 
@@ -51,14 +51,14 @@ Now you can work in your branch locally.
 
 Once you are happy with your change, you can verify that the change didn't cause tests failures by running tests like this:
 
-```
+```bash
 make test
 make lint
 ```
 
 If all the tests pass and you'd like to send your change in for consideration, push it to your remote repo:
 
-```
+```bash
 git push origin mybugfix
 ```
 

--- a/docs/tutorials/otio-file-format-specification.md
+++ b/docs/tutorials/otio-file-format-specification.md
@@ -66,7 +66,7 @@ TODO: Explain how metadata works and why we do it that way.
 
 ## Example:
 
-```
+```json
 {
     "OTIO_SCHEMA": "Timeline.1", 
     "metadata": {}, 

--- a/docs/tutorials/otio-plugins.md
+++ b/docs/tutorials/otio-plugins.md
@@ -143,10 +143,11 @@ De-serializes an OpenTimelineIO object from a json string
 Serializes an OpenTimelineIO object into a file
 
   Args:
+
       input_otio (OpenTimeline): An OpenTimeline object
       filepath (str): The name of an otio file to write to
-      indent (int): number of spaces for each json indentation level. Use
-          -1 for no indentation or newlines.
+      indent (int): number of spaces for each json indentation level.
+  Use -1 for no indentation or newlines.
 
   Returns:
       bool: Write success
@@ -164,7 +165,7 @@ Serializes an OpenTimelineIO object into a string
   Args:
       input_otio (OpenTimeline): An OpenTimeline object
       indent (int): number of spaces for each json indentation level. Use
-          -1 for no indentation or newlines.
+  -1 for no indentation or newlines.
 
   Returns:
       str: A json serialized string representation

--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -25,7 +25,7 @@ This plugin can then be registered with the system by configuring a plugin manif
  
 To create a new OTIO hook script, you need to create a file myhooks.py. Then add a manifest that points at that python file:
 
-```
+```json
 {
     "OTIO_SCHEMA" : "PluginManifest.1",
     "hook_scripts" : [
@@ -60,7 +60,7 @@ This will call the ``some_hook`` hook script and pass in ``some_timeline`` and `
 
 To query which hook scripts are attached to a given hook, you can call:
 
-```
+```python
 import opentimelineio as otio
 hook_list = otio.hooks.scripts_attached_to("some_hook") 
 ```
@@ -68,7 +68,7 @@ hook_list = otio.hooks.scripts_attached_to("some_hook")
 Note that ``hook_list`` will be in order of execution.  You can rearrange this list, or edit it to change which scripts will run (or not run) and in which order.
 
 To Edit the order, change the order in the list:
-```
+```python
 hook_list[0], hook_list[2] = hook_list[2], hook_list[0]
 print hook_list # ['c','b','a']
 ```
@@ -76,7 +76,7 @@ print hook_list # ['c','b','a']
 Now c will run, then b, then a.
 
 To delete a function the list:
-```
+```python
 del hook_list[1]
 ```
 

--- a/docs/tutorials/write-a-schemadef.md
+++ b/docs/tutorials/write-a-schemadef.md
@@ -13,7 +13,7 @@ and registered in one plugin, or you can use a separate plugin for each of them.
 
 Here's an example of defining a very simple class called ``MyThing``:
 
-```
+```python
 import opentimelineio as otio
 
 @otio.core.register_type
@@ -69,7 +69,7 @@ To create a new SchemaDef plugin, you need to create a Python source file
 as shown in the example above.  Let's call it ``mything.py``.
 Then you must add it to a plugin manifest:
 
-```
+```json
 {
     "OTIO_SCHEMA" : "PluginManifest.1",
     "schemadefs" : [
@@ -106,7 +106,7 @@ Once the plugin has been loaded, SchemaDef plugin modules are magically inserted
 into a namespace called ``otio.schemadef``, so you can create a class instance 
 just like this:
 
-```
+```python
 import opentimelineio as otio
 
 mine = otio.schemadef.my_thing.MyThing(arg1, argN)
@@ -115,7 +115,7 @@ mine = otio.schemadef.my_thing.MyThing(arg1, argN)
 An alternative approach is to use the ``instance_from_schema``
 mechanism, which requires that you create and provide a dict of the parameters:
 
-```
+```python
     mything = otio.core.instance_from_schema("MyThing", 1, {
         "arg1": arg1,
         "argN": argN

--- a/docs/tutorials/write-an-adapter.md
+++ b/docs/tutorials/write-an-adapter.md
@@ -113,19 +113,19 @@ And a `plugin_manifest.json` like:
 Each adapter must implement at least one of these functions:
 ```python
 def read_from_file(filepath):
-    ...
+    # ...
     return timeline
 
 def read_from_string(input_str):
-    ...
+    # ...
     return timeline
 
 def write_to_string(input_otio):
-    ...
+    # ...
     return text
 
 def write_to_file(input_otio, filepath):
-    ...
+    # ...
     return
 ```
 
@@ -229,13 +229,13 @@ def export_otio_item(item):
 If the format your adapter supports has strict expectations about the structure, then you should validate that the input has the expected structure and then traverse it based on those expectations, like this:
 ```python
 def export_timeline(timeline):
-    result = MyTimeline(timeline.name, ...)
+    result = MyTimeline(timeline.name)
     for track in timeline.tracks:
-        if !isinstance(track, otio.schema.Sequence):
+        if not isinstance(track, otio.schema.Sequence):
             raise Exception("This adapter requires each track to be a sequence, not a "+typeof(track))
-      t = result.AddTrack(track.name, ...)
+      t = result.AddTrack(track.name)
       for clip in track.each_clip():
-          c = result.AddClip(clip.name, ...)
+          c = result.AddClip(clip.name)
     return result
 ```
 

--- a/docs/tutorials/write-an-adapter.md
+++ b/docs/tutorials/write-an-adapter.md
@@ -4,7 +4,7 @@ OpenTimelineIO Adapters are plugins that allow OTIO to read and/or write other t
 
 Users of OTIO can read and write files like this:
 
-```
+```python
 #/usr/bin/env python
 import opentimelineio as otio
 mytimeline = otio.adapters.read_from_file("something.edl")
@@ -111,7 +111,7 @@ And a `plugin_manifest.json` like:
 ## Required Functions
 
 Each adapter must implement at least one of these functions:
-```
+```python
 def read_from_file(filepath):
     ...
     return timeline
@@ -134,7 +134,7 @@ If your format is text-based, then we recommend that you implement `read_from_st
 ## Constructing a Timeline
 
 To construct a Timeline in the `read_from_string` or `read_from_file` functions, you can use the API like this:
-```
+```python
 timeline = otio.schema.Timeline()
 timeline.name = "Example Timeline"
 track = otio.schema.Sequence()
@@ -148,7 +148,7 @@ track.append(clip)
 ### Metadata
 
 If your timeline, tracks, clips or other objects have format-specific, application-specific or studio-specific metadata, then you can add metadata to any of the OTIO schema objects like this:
-```
+```python
 timeline.metadata["mystudio"] = {
     "showID": "zz"
 }
@@ -164,7 +164,7 @@ Note that all metadata should be nested inside a sub-dictionary (in this example
 ### Media References
 
 Clip media (if known) should be linked like this:
-```
+```python
 clip.media_reference = otio.media_reference.External(
     target_url="file://example/movie.mov"
 )
@@ -175,7 +175,7 @@ Some formats don't support direct links to media, but focus on metadata instead.
 ### Source Range vs Available Range
 
 To specify the range of media used in the Clip, you must set the Clip's source_range like this:
-```
+```python
 clip.source_range = otio.opentime.TimeRange(
     start_time=otio.opentime.RationalTime(150, 24), # frame 150 @ 24fps
     duration=otio.opentime.RationalTime(200, 24) # 200 frames @ 24fps
@@ -185,7 +185,7 @@ clip.source_range = otio.opentime.TimeRange(
 Note that the source_range of the clip is not necessarily the same as the available_range of the media reference. You may have a clip that uses only a portion of a longer piece of media, or you might have some media that is too short for the desired clip length. Both of these are fine in OTIO. Also, clips can be relinked to different media, in which case the source_range of the clip stays the same, but the media_reference (and its available_range) will change after the relink. For example, you might relink from an old render to a newer render which has been extended to cover the source_range references by the clip.
 
 If you know the range of media available at that Media Reference's URL, then you can specify it like this:
-```
+```python
 clip.media_reference = otio.media_reference.External(
   target_url="file://example/movie.mov",
   available_range=otio.opentime.TimeRange(
@@ -200,7 +200,7 @@ It is fine to leave the Media Reference's available_range empty if you don't kno
 ## Traversing a Timeline
 
 When exporting a Timeline in the `write_to_string` or `write_to_file` functions, you will need to traverse the Timeline data structure. Some formats only support a single track, so a simple adapter might work like this:
-```
+```python
 def write_to_string(input_otio):
     """Turn a single track timeline into a very simple CSV."""
     result = "Clip,Start,Duration\n"
@@ -218,7 +218,7 @@ More complex timelines will contain multiple tracks and nested sequences. OTIO s
 In typical usage, you are likely to find that a Timeline has a Stack (the property called 'tracks'), and each item within that Stack is a Sequence. Each item within a Sequence will usually be a Clip, Transition or Gap. If you don't support Transitions, you can just skip them and the overall timing of the Sequence should still work.
 
 If the format your adapter supports allows arbitrary nesting, then you should traverse the composition in a general way, like this:
-```
+```python
 def export_otio_item(item):
     result = MyThing(item)
     if isinstance(item, otio.core.Composition):
@@ -227,7 +227,7 @@ def export_otio_item(item):
 ```
 
 If the format your adapter supports has strict expectations about the structure, then you should validate that the input has the expected structure and then traverse it based on those expectations, like this:
-```
+```python
 def export_timeline(timeline):
     result = MyTimeline(timeline.name, ...)
     for track in timeline.tracks:

--- a/src/py-opentimelineio/opentimelineio/adapters/otio_json.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/otio_json.py
@@ -64,7 +64,7 @@ def write_to_string(input_otio, indent=4):
 
     Args:
         input_otio (OpenTimeline): An OpenTimeline object
-        indent (int): number of spaces for each json indentation level. Use
+        indent (int): number of spaces for each json indentation level. Use\
             -1 for no indentation or newlines.
 
     Returns:
@@ -78,10 +78,11 @@ def write_to_file(input_otio, filepath, indent=4):
     Serializes an OpenTimelineIO object into a file
 
     Args:
+
         input_otio (OpenTimeline): An OpenTimeline object
         filepath (str): The name of an otio file to write to
-        indent (int): number of spaces for each json indentation level. Use
-            -1 for no indentation or newlines.
+        indent (int): number of spaces for each json indentation level.\
+            Use -1 for no indentation or newlines.
 
     Returns:
         bool: Write success


### PR DESCRIPTION
It turns out that we needed to add the "recommonmark" plugin to our plugins in sphinx to get the code blocks to get rendered correctly from markdown files.

- Also add code language annotations to code blocks in the documentation
- Fix the formatting on some of the examples

The bug this fixes is the table of contents looking like this:
![Screen Shot 2020-05-21 at 3 26 15 PM](https://user-images.githubusercontent.com/61017/82612324-7421b100-9b77-11ea-95e5-cbae3e8e3a64.png)

(note all the `{` in the table of contents)

For a preview of this, see:
https://opentimelineio-ssteinbach.readthedocs.io/en/documentation_busted_rtd/