### PR TITLE
Remove redundant comparison in clip tests

### DIFF
--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -52,7 +52,6 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(cl.name, name)
         self.assertEqual(cl.source_range, tr)
         self.assertIsOTIOEquivalentTo(cl.media_reference, mr)
-        self.assertEqual(cl.source_range, tr)
 
         encoded = otio.adapters.otio_json.write_to_string(cl)
         decoded = otio.adapters.otio_json.read_from_string(encoded)

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -92,15 +92,11 @@ class MediaReferenceTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         bl = otio.schema.MissingReference()
         self.assertNotEqual(filepath, bl)
 
-        filepath = otio.schema.ExternalReference(target_url="/var/tmp/foo.mov")
         filepath2 = otio.schema.ExternalReference(
             target_url="/var/tmp/foo2.mov"
         )
         self.assertNotEqual(filepath, filepath2)
         self.assertEqual(filepath == filepath2, False)
-
-        bl = otio.schema.MissingReference()
-        self.assertNotEqual(filepath, bl)
 
     def test_is_missing(self):
         mr = otio.schema.ExternalReference(target_url="/var/tmp/foo.mov")


### PR DESCRIPTION
I think instead of the line I removed, it might be `self.assertIsNot(cl.source_range, tr)`.