### PR TITLE
Implementation of post adapter write hook

### DIFF
--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -97,7 +97,7 @@ def hook_function(in_timeline,argument_map=None):
                 in_clip.media_reference.target_url = in_clip.media_reference.target_url.replace(r'/linux/media/path','S:')
 ```
 
-### Add an incremental copy of otio file in backup folder
+### Add an incremental copy of otio file to backup folder
 
 Example of a post adapter write hook
 

--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -99,7 +99,7 @@ def hook_function(in_timeline,argument_map=None):
 
 ### Add an incremental copy of otio file to backup folder
 
-Example of a post adapter write hook
+Example of a post adapter write hook that creates a timestamped copy of newly written file in a hidden "incremental" folder
 
 ```python
 import os
@@ -123,3 +123,6 @@ def hook_function(in_timeline, argument_map=None):
 
     return in_timeline    
 ```
+
+Please note that if your "post adapter write hook" changes `in_timeline` in any way, it's up to the user to persist those changes 
+as the hook is run _after_ the file is written to disk.

--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -124,5 +124,4 @@ def hook_function(in_timeline, argument_map=None):
     return in_timeline    
 ```
 
-Please note that if your "post adapter write hook" changes `in_timeline` in any way, it's up to the user to persist those changes 
-as the hook is run _after_ the file is written to disk.
+Please note that if a "post adapter write hook" changes `in_timeline` in any way, the api will not automatically update the already serialized file.  The changes will only exist in the in-memory object, because the hook runs _after_ the file is serialized to disk.

--- a/docs/tutorials/write-a-hookscript.md
+++ b/docs/tutorials/write-a-hookscript.md
@@ -39,6 +39,7 @@ To create a new OTIO hook script, you need to create a file myhooks.py. Then add
     "hooks" : {
         "pre_adapter_write" : ["example hook"],
         "post_adapter_read" : [],
+        "post_adapter_write" : [],
         "post_media_linker" : []
     }
 }
@@ -89,9 +90,36 @@ An example use-case would be to create a pre-write adapter hook that checks the 
 ```python
 def hook_function(in_timeline,argument_map=None):
     adapter_args = argument_map.get('adapter_arguments')
-    if if adapter_args and adapter_args.get('style') == 'nucoda':
+    if adapter_args and adapter_args.get('style') == 'nucoda':
         for in_clip in in_timeline.each_clip():
             ''' Change the Path to use windows drive letters ( Nucoda is not otherwise forward slash sensative ) '''
             if in_clip.media_reference:
                 in_clip.media_reference.target_url = in_clip.media_reference.target_url.replace(r'/linux/media/path','S:')
+```
+
+### Add an incremental copy of otio file in backup folder
+
+Example of a post adapter write hook
+
+```python
+import os
+import time
+import shutil
+
+def hook_function(in_timeline, argument_map=None):
+    # Adapter will add "_filepath" to argument_map
+    filepath = argument_map.get('_filepath')
+
+    backup_name = "{filename}.{time}".format(
+        filename=os.path.basename(filepath),
+        time=time.time()
+    )
+    incrpath = os.path.join(
+        os.path.dirname(filepath),
+        '.incremental',
+        backup_name
+    )   
+    shutil.copyfile(filepath, incrpath)
+
+    return in_timeline    
 ```

--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -172,11 +172,12 @@ class Adapter(plugins.PythonPlugin):
         a trivial file object wrapper.
         """
         hook_function_argument_map['adapter_arguments'] = adapter_argument_map
+
+        # Store file path for use in hooks
+        hook_function_argument_map['_filepath'] = filepath
+
         input_otio = hooks.run("pre_adapter_write", input_otio,
                                extra_args=hook_function_argument_map)
-
-        # Store filepath for use in post_adapter_write hooks
-        hook_function_argument_map['_filepath'] = filepath
 
         if (
             not self.has_feature("write_to_file") and

--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -30,6 +30,7 @@ For information on writing adapters, please consult:
 
 import inspect
 import collections
+import copy
 
 from .. import (
     core,
@@ -171,14 +172,15 @@ class Adapter(plugins.PythonPlugin):
         If write_to_string exists, but not write_to_file, execute that with
         a trivial file object wrapper.
         """
-        hook_function_argument_map['adapter_arguments'] = adapter_argument_map
+        hook_function_argument_map['adapter_arguments'] = copy.deepcopy(
+            adapter_argument_map
+        )
 
         # Store file path for use in hooks
         hook_function_argument_map['_filepath'] = filepath
 
         input_otio = hooks.run("pre_adapter_write", input_otio,
                                extra_args=hook_function_argument_map)
-
         if (
             not self.has_feature("write_to_file") and
             self.has_feature("write_to_string")

--- a/src/py-opentimelineio/opentimelineio/adapters/builtin_adapters.plugin_manifest.json
+++ b/src/py-opentimelineio/opentimelineio/adapters/builtin_adapters.plugin_manifest.json
@@ -26,6 +26,7 @@
     "hooks": {
         "post_adapter_read" : [],
         "post_media_linker" : [],
-        "pre_adapter_write" : []
+        "pre_adapter_write" : [],
+        "post_adapter_write" : []
     }
 }

--- a/tests/baselines/adapter_plugin_manifest.plugin_manifest.json
+++ b/tests/baselines/adapter_plugin_manifest.plugin_manifest.json
@@ -1,6 +1,6 @@
 {
     "OTIO_SCHEMA" : "PluginManifest.1",
-    "adapters" : [ 
+    "adapters" : [
         {
             "FROM_TEST_FILE" : "adapter_example.json"
         }
@@ -13,11 +13,15 @@
     "hook_scripts" : [
         {
             "FROM_TEST_FILE" : "hookscript_example.json"
+        },
+        {
+            "FROM_TEST_FILE" : "post_write_hookscript_example.json"
         }
     ],
     "hooks" : {
         "pre_adapter_write" : ["example hook", "example hook"],
         "post_adapter_read" : [],
+        "post_adapter_write" : ["post write example hook"],
         "post_media_linker" : ["example hook"]
     }
 }

--- a/tests/baselines/post_write_example.py
+++ b/tests/baselines/post_write_example.py
@@ -1,0 +1,37 @@
+#
+# Copyright Contributors to the OpenTimelineIO project
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+import os
+
+"""This file is here to support the test_adapter_plugin unittest.
+If you want to learn how to write your own adapter plugin, please read:
+https://opentimelineio.readthedocs.io/en/latest/tutorials/write-an-adapter.html
+"""
+
+
+def hook_function(in_timeline, argument_map=None):
+    filename = argument_map.get('_filepath')
+    argument_map.update({'filesize': os.path.getsize(filename)})
+    in_timeline.metadata.update(argument_map)
+
+    return in_timeline

--- a/tests/baselines/post_write_example.py
+++ b/tests/baselines/post_write_example.py
@@ -30,8 +30,8 @@ https://opentimelineio.readthedocs.io/en/latest/tutorials/write-an-adapter.html
 
 
 def hook_function(in_timeline, argument_map=None):
-    filename = argument_map.get('_filepath')
-    argument_map.update({'filesize': os.path.getsize(filename)})
+    filepath = argument_map.get('_filepath')
+    argument_map.update({'filesize': os.path.getsize(filepath)})
     in_timeline.metadata.update(argument_map)
 
     return in_timeline

--- a/tests/baselines/post_write_hookscript_example.json
+++ b/tests/baselines/post_write_hookscript_example.json
@@ -1,0 +1,6 @@
+{
+    "OTIO_SCHEMA" : "HookScript.1",
+    "name" : "post write example hook",
+    "execution_scope" : "in process",
+    "filepath" : "post_write_example.py"
+}

--- a/tests/test_hooks_plugins.py
+++ b/tests/test_hooks_plugins.py
@@ -23,6 +23,7 @@
 #
 import unittest
 import os
+import tempfile
 # import pkg_resources
 # import sys
 
@@ -36,6 +37,7 @@ from tests import (
 )
 
 HOOKSCRIPT_PATH = "hookscript_example"
+POST_WRITE_HOOKSCRIPT_PATH = "post_write_hookscript_example"
 
 POST_RUN_NAME = "hook ran and did stuff"
 TEST_METADATA = {'extra_data': True}
@@ -78,7 +80,18 @@ class TestPluginHookSystem(unittest.TestCase):
             "baselines",
             HOOKSCRIPT_PATH
         )
-        self.man.hook_scripts = [self.hsf]
+        self.post_jsn = baseline_reader.json_baseline_as_string(
+            POST_WRITE_HOOKSCRIPT_PATH
+        )
+        self.post_hsf = otio.adapters.otio_json.read_from_string(
+            self.post_jsn
+        )
+        self.post_hsf._json_path = os.path.join(
+            baseline_reader.MODPATH,
+            "baselines",
+            POST_WRITE_HOOKSCRIPT_PATH
+        )
+        self.man.hook_scripts = [self.hsf, self.post_hsf]
 
         self.orig_manifest = otio.plugins.manifest._MANIFEST
         otio.plugins.manifest._MANIFEST = self.man
@@ -118,6 +131,27 @@ class TestPluginHookSystem(unittest.TestCase):
         self.assertEqual(result.name, POST_RUN_NAME)
         self.assertEqual(result.metadata.get("extra_data"), True)
 
+    def test_post_write_hook(self):
+        self.man.adapters.extend(self.orig_manifest.adapters)
+
+        tl = otio.schema.Timeline()
+
+        with tempfile.NamedTemporaryFile(
+                'wb', prefix='post_hook_', suffix='.otio') as f:
+            arg_map = dict()
+            otio.adapters.write_to_file(
+                tl,
+                f.name,
+                adapter_name='otio_json',
+                hook_function_argument_map=arg_map
+            )
+
+            self.assertTrue(os.path.exists(f.name))
+            self.assertEqual(
+                os.path.getsize(f.name),
+                tl.metadata.get('filesize')
+            )
+
     def test_serialize(self):
 
         self.assertEqual(
@@ -142,20 +176,30 @@ class TestPluginHookSystem(unittest.TestCase):
         )
 
     def test_available_hookscript_names(self):
+        # Need to disable maxdiff to compare lists
+        old_maxdiff = self.maxDiff
+        self.maxDiff = None
+
         # for not just assert that it returns a non-empty list
         self.assertEqual(
             list(otio.hooks.available_hookscripts()),
-            [self.hsf]
+            [self.hsf, self.post_hsf]
         )
         self.assertEqual(
             otio.hooks.available_hookscript_names(),
-            [self.hsf.name]
+            [self.hsf.name, self.post_hsf.name]
         )
+
+        # Restore maxdiff
+        self.maxDiff = old_maxdiff
 
     def test_manifest_hooks(self):
         self.assertEqual(
             sorted(list(otio.hooks.names())),
-            sorted(["post_adapter_read", "post_media_linker", "pre_adapter_write"])
+            sorted(
+                ["post_adapter_read", "post_media_linker",
+                 "pre_adapter_write", "post_adapter_write"]
+            )
         )
 
         self.assertEqual(
@@ -175,6 +219,13 @@ class TestPluginHookSystem(unittest.TestCase):
             list(otio.hooks.scripts_attached_to("post_media_linker")),
             [
                 self.hsf.name
+            ]
+        )
+
+        self.assertEqual(
+            list(otio.hooks.scripts_attached_to("post_adapter_write")),
+            [
+                self.post_hsf.name
             ]
         )
 

--- a/tests/test_hooks_plugins.py
+++ b/tests/test_hooks_plugins.py
@@ -182,10 +182,6 @@ class TestPluginHookSystem(unittest.TestCase):
         )
 
     def test_available_hookscript_names(self):
-        # Need to disable maxdiff to compare lists
-        old_maxdiff = self.maxDiff
-        self.maxDiff = None
-
         # for not just assert that it returns a non-empty list
         self.assertEqual(
             list(otio.hooks.available_hookscripts()),
@@ -195,9 +191,6 @@ class TestPluginHookSystem(unittest.TestCase):
             otio.hooks.available_hookscript_names(),
             [self.hsf.name, self.post_hsf.name]
         )
-
-        # Restore maxdiff
-        self.maxDiff = old_maxdiff
 
     def test_manifest_hooks(self):
         self.assertEqual(

--- a/tests/test_hooks_plugins.py
+++ b/tests/test_hooks_plugins.py
@@ -24,6 +24,7 @@
 import unittest
 import os
 import tempfile
+from copy import deepcopy
 # import pkg_resources
 # import sys
 
@@ -135,6 +136,7 @@ class TestPluginHookSystem(unittest.TestCase):
         self.man.adapters.extend(self.orig_manifest.adapters)
 
         tl = otio.schema.Timeline()
+        tl_copy = deepcopy(tl)
 
         with tempfile.NamedTemporaryFile(
                 'wb', prefix='post_hook_', suffix='.otio') as f:
@@ -151,6 +153,10 @@ class TestPluginHookSystem(unittest.TestCase):
                 os.path.getsize(f.name),
                 tl.metadata.get('filesize')
             )
+
+            # In this case the post hook actually changed the metadata.
+            # Users must take care to catch changes they do in their hooks.
+            self.assertNotEqual(tl, tl_copy)
 
     def test_serialize(self):
 


### PR DESCRIPTION
Added support for "post_adapter_write" hooks.
Post hooks are run _after_ the file is written to disk by an adapter and passes the file path to the hooks through `_filepath` key in the `argument_map`.

Updated unit tests and added example in the hooks docs.