### PR TITLE
Change hls_md_blacklist -> hls_md_rejectlist

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/hls_playlist.py
+++ b/contrib/opentimelineio_contrib/adapters/hls_playlist.py
@@ -1092,8 +1092,8 @@ def master_playlist_to_string(master_timeline):
 
     # Filter out any values from the HLS metadata that aren't meant to become
     # tags, such as the directive to force an HLS master playlist
-    hls_md_blacklist = ['master_playlist']
-    for key in hls_md_blacklist:
+    hls_md_rejectlist = ['master_playlist']
+    for key in hls_md_rejectlist:
         try:
             del(header_tags[key])
         except KeyError:


### PR DESCRIPTION
Looking to move away from terms that could be viewed as racially charged - hopefully this suggestion is ok.

Signed-off-by: John Mertic <jmertic@linuxfoundation.org>