### PR TITLE
Update pyaaf2 pin to 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -418,7 +418,7 @@ setup(
 
     install_requires=(
         [
-            'pyaaf2==1.2.0',
+            'pyaaf2==1.4.0',
         ]
     ),
     entry_points={


### PR DESCRIPTION
update pyaaf2 pin to use 1.4.0 (latest pyaaf2 release). This contains some important fixes
(like understanding the pulldown AAF object) required for some upcoming AAF Reader changes.