### PR TITLE
Fixed broken repr and str magic methods for Marker

### DIFF
--- a/src/py-opentimelineio/opentimelineio/schema/marker.py
+++ b/src/py-opentimelineio/opentimelineio/schema/marker.py
@@ -4,26 +4,23 @@ from .. import _otio
 
 @add_method(_otio.Marker)
 def __str__(self):
-    return 'Marker("{}", {}, {}, {})'.format(
-        self.name,
-        self.media_reference,
-        self.source_range,
-        self.metadata
+    return "Marker({}, {}, {})".format(
+        str(self.name),
+        str(self.marked_range),
+        str(self.metadata),
     )
 
 
 @add_method(_otio.Marker)
 def __repr__(self):
     return (
-        'otio.schema.Marker('
-        'name={}, '
-        'media_reference={}, '
-        'source_range={}, '
-        'metadata={}'
-        ')'.format(
+        "otio.schema.Marker("
+        "name={}, "
+        "marked_range={}, "
+        "metadata={}"
+        ")".format(
             repr(self.name),
-            repr(self.media_reference),
-            repr(self.source_range),
+            repr(self.marked_range),
             repr(self.metadata),
         )
     )

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -103,7 +103,7 @@ class MarkerTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         expected = (
             "otio.schema.Marker(name='marker_1', "
             "marked_range={}, metadata={})".format(
-                repr(tr), repr({'foo': 'bar'})
+                repr(tr), repr(m.metadata)
             )
         )
 
@@ -122,7 +122,7 @@ class MarkerTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         )
 
         expected = 'Marker(marker_1, {}, {})'.format(
-            str(tr), str({'foo': 'bar'})
+            str(tr), str(m.metadata)
         )
 
         self.assertEqual(str(m), expected)

--- a/tests/test_marker.py
+++ b/tests/test_marker.py
@@ -88,6 +88,45 @@ class MarkerTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertNotEqual(m, bo)
         self.assertNotEqual(bo, m)
 
+    def test_repr(self):
+        tr = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(5, 24),
+            otio.opentime.RationalTime(10, 24)
+        )
+        m = otio.schema.Marker(
+            name="marker_1",
+            marked_range=tr,
+            color=otio.schema.MarkerColor.GREEN,
+            metadata={'foo': 'bar'}
+        )
+
+        expected = (
+            "otio.schema.Marker(name='marker_1', "
+            "marked_range={}, metadata={})".format(
+                repr(tr), repr({'foo': 'bar'})
+            )
+        )
+
+        self.assertEqual(repr(m), expected)
+
+    def test_str(self):
+        tr = otio.opentime.TimeRange(
+            otio.opentime.RationalTime(5, 24),
+            otio.opentime.RationalTime(10, 24)
+        )
+        m = otio.schema.Marker(
+            name="marker_1",
+            marked_range=tr,
+            color=otio.schema.MarkerColor.GREEN,
+            metadata={'foo': 'bar'}
+        )
+
+        expected = 'Marker(marker_1, {}, {})'.format(
+            str(tr), str({'foo': 'bar'})
+        )
+
+        self.assertEqual(str(m), expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It appears the `__str__` and `__repr__` methods may have been copy/pasted from Clip by accident in the C++ port, printing in the python REPL would result in a traceback like:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/ereinecke/.venv/lib/python3.8/site-packages/opentimelineio/schema/marker.py", line 25, in __repr__
    repr(self.media_reference),
AttributeError: 'opentimelineio._otio.Marker' object has no attribute 'media_reference'
```

Restored implementations from the pre-C++ port version and added unitests to prevent this kind of error in the future.