### PR TITLE
Add description for faulty formatted timecode test

### DIFF
--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -360,6 +360,18 @@ class TestTime(unittest.TestCase):
             self.assertEqual(t2, t)
 
     def test_faulty_formatted_timecode_24(self):
+        """
+        01:00:13;23 is drop-frame timecode, which only applies for
+        NTSC rates (24000/1001, 30000/1001, etc). Such timecodes
+        drop frames to compensate for the NTSC rates being slightly
+        slower than whole frame rates (eg: 24 fps).
+        It does not make sense to use drop-frame timecodes for
+        non-NTSC rates.
+
+        This is what we're testing here. When using 24 fps for the
+        drop-frame timecode 01:00:13;23 we should get a ValueError
+        mapping internally to the ErrorStatus 'NON_DROPFRAME_RATE'.
+        """
         with self.assertRaises(ValueError):
             otio.opentime.from_timecode('01:00:13;23', 24)
 


### PR DESCRIPTION
As per discussion here: #753

> My rule of thumb is that if a line of code requires a lot of careful explanation when someone new comes across it, it deserves formal documentation at the call site. So @KarthikRIyer I think a couple of sentences that explain to the next person what the test is for are in order.