### PR TITLE
Add point and box geometry primivites and use them to create MediaReference bounding boxes

### DIFF
--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -60,6 +60,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *metadata*
 - *name*
 
@@ -149,6 +150,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *metadata*
 - *name*
 - *target_url*
@@ -174,6 +176,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *generator_kind*
 - *metadata*
 - *name*
@@ -183,6 +186,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *frame_step*
 - *frame_zero_padding*
 - *metadata*
@@ -214,6 +218,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *metadata*
 - *name*
 

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -114,6 +114,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *metadata*: 
 - *name*: 
 
@@ -300,6 +301,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *metadata*: 
 - *name*: 
 - *target_url*: 
@@ -349,6 +351,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *generator_kind*: 
 - *metadata*: 
 - *name*: 
@@ -426,6 +429,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *frame_step*: Step between frame numbers in file names.
 - *frame_zero_padding*: Number of digits to pad zeros out to in frame numbers.
 - *metadata*: 
@@ -481,6 +485,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *metadata*: 
 - *name*: 
 

--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(OPENTIME_HEADER_FILES
+    box.h
     errorStatus.h
+    point.h
     rationalTime.h
     stringPrintf.h
     timeRange.h

--- a/src/opentime/box.h
+++ b/src/opentime/box.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "opentime/version.h"
+#include "opentime/point.h"
+
+namespace opentime {
+    namespace OPENTIME_VERSION {
+
+class Box {
+public:
+    Box() = default;
+
+    Box(double width, double height, Point const& center)
+    : _width(width), _height(height), _center(center) {}
+
+    double width() const {
+        return _width;
+    }
+
+    double height() const {
+        return _height;
+    }
+
+    Point const& center() const {
+        return _center;
+    }
+
+    double get_aspect_ratio() const {
+        return is_equal( _height, 0.0 ) ? 1.0 : _width / _height;
+    }
+
+    bool contains(Point const& p) const {
+       static constexpr auto epsilon = std::numeric_limits<double>::epsilon();
+
+       const double min_x = _center.x() - _width * 0.5 - epsilon;
+       const double max_x = _center.x() + _width * 0.5 + epsilon;
+
+       if (p.x() < min_x || p.x() > max_x) return false;
+
+       const double min_y = _center.y() - _height * 0.5 - epsilon;
+       const double max_y = _center.y() + _height * 0.5 + epsilon;
+
+       return p.y() >= min_y && p.y() <= max_y;
+    }
+
+    Box get_union(Box const& b) const {
+        const double min_x = std::min(_center.x() - _width * 0.5,
+                                      b._center.x() - b._width * 0.5);
+        const double max_x = std::max(_center.x() + _width * 0.5,
+                                      b._center.x() + b._width * 0.5);
+        const double min_y = std::min(_center.y() - _height * 0.5,
+                                      b._center.y() - b._height * 0.5);
+        const double max_y = std::max(_center.y() + _height * 0.5,
+                                      b._center.y() + b._height * 0.5);
+
+        return Box(max_x - min_x, max_y - min_y,
+                   Point((max_x + min_x) * 0.5, (max_y + min_y) * 0.5));
+    }
+
+    friend bool operator== (Box lhs, Box rhs) {
+        return is_equal( lhs._width, rhs._width ) &&
+               is_equal( lhs._height, rhs._height ) &&
+               lhs._center == rhs._center;
+    }
+
+    friend bool operator!= (Box lhs, Box rhs) {
+        return !(lhs == rhs);
+    }
+
+private:
+    double _width{ 0.0 };
+    double _height{ 0.0 };
+    Point _center;
+};
+
+} }

--- a/src/opentime/point.h
+++ b/src/opentime/point.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "opentime/version.h"
+
+#include <limits>
+#include <cmath>
+
+namespace opentime {
+    namespace OPENTIME_VERSION {
+
+template <class T>
+inline bool is_equal(T a, T b) {
+    return std::fabs(a - b) < std::numeric_limits<T>::epsilon();
+}
+
+class Point {
+public:
+    Point() = default;
+
+    Point(double x, double y)
+    : _x(x), _y(y) {}
+
+    double x() const {
+        return _x;
+    }
+
+    double y() const {
+        return _y;
+    }
+
+    friend bool operator== (Point lhs, Point rhs) {
+        return is_equal(lhs._x, rhs._x) && is_equal(lhs._y, rhs._y);
+    }
+
+    friend bool operator!= (Point lhs, Point rhs) {
+        return !(lhs == rhs);
+    }
+
+private:
+    double _x{ 0.0 };
+    double _y{ 0.0 };
+};
+
+} }

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -2,7 +2,7 @@
 #include "opentimelineio/missingReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 Clip::Clip(std::string const& name,
            MediaReference* media_reference,
            optional<TimeRange> const& source_range,
@@ -40,14 +40,30 @@ TimeRange Clip::available_range(ErrorStatus* error_status) const {
                                     "No media reference set on clip", this);
         return TimeRange();
     }
-    
+
     if (!_media_reference.value->available_range()) {
         *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_AVAILABLE_RANGE,
                                     "No available_range set on media reference on clip", this);
         return TimeRange();
     }
-    
+
     return *_media_reference.value->available_range();
+}
+
+Box Clip::bounds(ErrorStatus* error_status) const {
+    if (!_media_reference) {
+        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+                                    "No media reference set on clip", this);
+        return Box();
+    }
+
+    if (!_media_reference.value->bounds()) {
+        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+                                    "No bounds set on media reference on clip", this);
+        return Box();
+    }
+
+    return *_media_reference.value->bounds();
 }
 
 } }

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -5,7 +5,7 @@
 #include "opentimelineio/mediaReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class Clip : public Item {
 public:
     struct Schema {
@@ -23,8 +23,9 @@ public:
     void set_media_reference(MediaReference* media_reference);
 
     MediaReference* media_reference() const;
-    
+
     virtual TimeRange available_range(ErrorStatus* error_status) const;
+    virtual Box bounds(ErrorStatus* error_status) const;
 
 protected:
     virtual ~Clip();

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -2,7 +2,7 @@
 #include "opentimelineio/composition.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 Composable::Composable(std::string const& name,
                        AnyDictionary const& metadata)
     : Parent(name, metadata),
@@ -48,6 +48,11 @@ void Composable::write_to(Writer& writer) const {
 RationalTime Composable::duration(ErrorStatus* error_status) const {
     *error_status = ErrorStatus::NOT_IMPLEMENTED;
     return RationalTime();
+}
+
+Box Composable::bounds(ErrorStatus* error_status) const {
+    *error_status = ErrorStatus::NOT_IMPLEMENTED;
+    return Box();
 }
 
 } }

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -4,7 +4,7 @@
 #include "opentimelineio/serializableObjectWithMetadata.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class Composition;
 
 class Composable : public SerializableObjectWithMetadata {
@@ -25,8 +25,9 @@ public:
     Composition* parent() const {
         return _parent;
     }
-    
+
     virtual RationalTime duration(ErrorStatus* error_status) const;
+    virtual Box bounds(ErrorStatus* error_status) const;
 
 protected:
     bool _set_parent(Composition*);

--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -1,5 +1,6 @@
 #include "opentimelineio/composition.h"
 #include "opentimelineio/vectorIndexing.h"
+#include "opentimelineio/clip.h"
 
 #include <assert.h>
 #include <set>
@@ -333,6 +334,18 @@ optional<TimeRange> Composition::trim_child_range(TimeRange child_range) const {
 
 bool Composition::has_child(Composable* child) const {
     return _child_set.find(child) != _child_set.end();
+}
+
+bool Composition::has_clips() const {
+    for (auto child: children()) {
+        if (dynamic_cast<Clip*>(child.value)) {
+            return true;
+        }
+        else if (auto child_comp = dynamic_cast<Composition*>(child.value)) {
+            return child_comp->has_clips();
+        }
+    }
+    return false;
 }
 
 } }

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -56,6 +56,8 @@ public:
     optional<TimeRange> trim_child_range(TimeRange child_range) const;
 
     bool has_child(Composable* child) const;
+
+    bool has_clips() const;
     
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 

--- a/src/opentimelineio/errorStatus.cpp
+++ b/src/opentimelineio/errorStatus.cpp
@@ -1,7 +1,7 @@
 #include "opentimelineio/errorStatus.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 std::string ErrorStatus::outcome_to_string(Outcome o) {
     switch(o) {
     case OK:
@@ -52,6 +52,8 @@ std::string ErrorStatus::outcome_to_string(Outcome o) {
         return "cannot compute duration on this type of object";
     case CANNOT_TRIM_TRANSITION:
         return "cannot trim transition";
+    case CANNOT_COMPUTE_BOUNDS:
+        return "cannot compute bounds";
     default:
         return "unknown/illegal ErrorStatus::Outcome code";
     };

--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -4,14 +4,14 @@
 #include <string>
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class SerializableObject;
 
 struct ErrorStatus {
     operator bool () {
         return outcome != Outcome::OK;
     }
-    
+
     enum Outcome {
         OK = 0,
         NOT_IMPLEMENTED,
@@ -36,21 +36,22 @@ struct ErrorStatus {
         CANNOT_COMPUTE_AVAILABLE_RANGE,
         INVALID_TIME_RANGE,
         OBJECT_WITHOUT_DURATION,
-        CANNOT_TRIM_TRANSITION
+        CANNOT_TRIM_TRANSITION,
+        CANNOT_COMPUTE_BOUNDS
     };
 
     ErrorStatus()
         : outcome(OK),
           object_details(nullptr) {
     }
-    
+
     ErrorStatus(Outcome in_outcome)
         : outcome(in_outcome),
           details(outcome_to_string(in_outcome)),
           full_description(details),
           object_details(nullptr) {
     }
-    
+
     ErrorStatus(Outcome in_outcome, std::string const& in_details,
                 SerializableObject const* object = nullptr)
         : outcome(in_outcome),
@@ -58,7 +59,7 @@ struct ErrorStatus {
           full_description(outcome_to_string(in_outcome) + ": " + in_details),
           object_details(object) {
     }
-    
+
     ErrorStatus& operator=(Outcome in_outcome) {
         *this = ErrorStatus(in_outcome);
         return *this;

--- a/src/opentimelineio/externalReference.cpp
+++ b/src/opentimelineio/externalReference.cpp
@@ -1,11 +1,12 @@
 #include "opentimelineio/externalReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 ExternalReference::ExternalReference(std::string const& target_url,
                                      optional<TimeRange> const& available_range,
-                                     AnyDictionary const& metadata)
-    : Parent(std::string(), available_range, metadata),
+                                     AnyDictionary const& metadata,
+                                     optional<Box> const& bounds)
+    : Parent(std::string(), available_range, metadata, bounds),
       _target_url(target_url) {
 }
 

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -4,7 +4,7 @@
 #include "opentimelineio/mediaReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class ExternalReference final : public MediaReference {
 public:
     struct Schema {
@@ -16,12 +16,13 @@ public:
 
     ExternalReference(std::string const& target_url = std::string(),
                       optional<TimeRange> const& available_range = nullopt,
-                      AnyDictionary const& metadata = AnyDictionary());
-        
+                      AnyDictionary const& metadata = AnyDictionary(),
+                      optional<Box> const& bounds = nullopt);
+
     std::string const& target_url() const {
         return _target_url;
     }
-    
+
     void set_target_url(std::string const& target_url) {
         _target_url = target_url;
     }

--- a/src/opentimelineio/generatorReference.cpp
+++ b/src/opentimelineio/generatorReference.cpp
@@ -1,13 +1,14 @@
 #include "opentimelineio/generatorReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 GeneratorReference::GeneratorReference(std::string const& name,
                                        std::string const& generator_kind,
                                        optional<TimeRange> const& available_range,
                                        AnyDictionary const& parameters,
-                                       AnyDictionary const& metadata)
-    : Parent(name, available_range, metadata),
+                                       AnyDictionary const& metadata,
+                                       optional<Box> const& bounds)
+    : Parent(name, available_range, metadata, bounds),
       _generator_kind(generator_kind),
       _parameters(parameters) {
 }

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -4,7 +4,7 @@
 #include "opentimelineio/mediaReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class GeneratorReference final : public MediaReference {
 public:
     struct Schema {
@@ -18,12 +18,13 @@ public:
                        std::string const& generator_kind = std::string(),
                        optional<TimeRange> const& available_range = nullopt,
                        AnyDictionary const& parameters = AnyDictionary(),
-                       AnyDictionary const& metadata = AnyDictionary());
-        
+                       AnyDictionary const& metadata = AnyDictionary(),
+                       optional<Box> const& bounds = nullopt);
+
     std::string const& generator_kind() const {
         return _generator_kind;
     }
-    
+
     void set_generator_kind(std::string const& generator_kind) {
         _generator_kind = generator_kind;
     }

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -11,8 +11,9 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
                       int frame_zero_padding,
                       MissingFramePolicy const missing_frame_policy,
                       optional<TimeRange> const& available_range,
-                      AnyDictionary const& metadata)
-    : Parent(std::string(), available_range, metadata),
+                      AnyDictionary const& metadata,
+                      optional<Box> const& bounds)
+    : Parent(std::string(), available_range, metadata, bounds),
     _target_url_base(target_url_base),
     _name_prefix(name_prefix),
     _name_suffix(name_suffix),

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -4,7 +4,7 @@
 #include "opentimelineio/mediaReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class ImageSequenceReference final : public MediaReference {
 public:
     enum MissingFramePolicy {
@@ -29,20 +29,21 @@ public:
                       int frame_zero_padding = 0,
                       MissingFramePolicy const missing_frame_policy = MissingFramePolicy::error,
                       optional<TimeRange> const& available_range = nullopt,
-                      AnyDictionary const& metadata = AnyDictionary());
-        
+                      AnyDictionary const& metadata = AnyDictionary(),
+                      optional<Box> const& bounds = nullopt);
+
     std::string const& target_url_base() const {
         return _target_url_base;
     }
-    
+
     void set_target_url_base(std::string const& target_url_base) {
         _target_url_base = target_url_base;
     }
-        
+
     std::string const& name_prefix() const {
         return _name_prefix;
     }
-    
+
     void set_name_prefix(std::string const& target_url_base) {
         _name_prefix = target_url_base;
     }
@@ -50,7 +51,7 @@ public:
     std::string const& name_suffix() const {
         return _name_suffix;
     }
-    
+
     void set_name_suffix(std::string const& target_url_base) {
         _name_suffix = target_url_base;
     }
@@ -107,7 +108,7 @@ public:
 
 protected:
     virtual ~ImageSequenceReference();
- 
+
     virtual bool read_from(Reader&);
     virtual void write_to(Writer&) const;
 
@@ -120,7 +121,7 @@ private:
     double _rate;
     int _frame_zero_padding;
     MissingFramePolicy _missing_frame_policy;
-    
+
     RationalTime frame_duration() const;
 };
 

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -7,7 +7,7 @@
 #include "opentimelineio/errorStatus.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class Effect;
 class Marker;
 
@@ -64,13 +64,13 @@ public:
     TimeRange visible_range(ErrorStatus* error_status) const;
 
     optional<TimeRange> trimmed_range_in_parent(ErrorStatus* error_status) const;
-    
+
     TimeRange range_in_parent(ErrorStatus* error_status) const;
-    
+
     RationalTime transformed_time(RationalTime time, Item const* to_item, ErrorStatus* error_status) const;
-    
+
     TimeRange transformed_time_range(TimeRange time_range, Item const* to_item, ErrorStatus* error_status) const;
-    
+
 protected:
     virtual ~Item();
 

--- a/src/opentimelineio/mediaReference.cpp
+++ b/src/opentimelineio/mediaReference.cpp
@@ -1,12 +1,14 @@
 #include "opentimelineio/mediaReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 MediaReference::MediaReference(std::string const& name,
                                optional<TimeRange> const& available_range,
-                               AnyDictionary const& metadata)
+                               AnyDictionary const& metadata,
+                               optional<Box> const& bounds)
     : Parent(name, metadata),
-      _available_range(available_range) {
+      _available_range(available_range),
+      _bounds(bounds) {
 }
 
 MediaReference::~MediaReference() {
@@ -19,12 +21,14 @@ bool MediaReference::is_missing_reference() const {
 
 bool MediaReference::read_from(Reader& reader) {
     return reader.read_if_present("available_range", &_available_range) &&
+           reader.read_if_present("bounds", &_bounds) &&
         Parent::read_from(reader);
 }
 
 void MediaReference::write_to(Writer& writer) const {
     Parent::write_to(writer);
     writer.write("available_range", _available_range);
+    writer.write("bounds", _bounds);
 }
 
 } }

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -2,11 +2,12 @@
 
 #include "opentimelineio/version.h"
 #include "opentimelineio/serializableObjectWithMetadata.h"
+#include "opentime/box.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 
     using namespace opentime;
-    
+
 class MediaReference : public SerializableObjectWithMetadata {
 public:
     struct Schema {
@@ -18,7 +19,8 @@ public:
 
     MediaReference(std::string const& name = std::string(),
                    optional<TimeRange> const& available_range = nullopt,
-                   AnyDictionary const& metadata = AnyDictionary());
+                   AnyDictionary const& metadata = AnyDictionary(),
+                   optional<Box> const& bounds = nullopt);
 
     optional<TimeRange> const& available_range () const {
         return _available_range;
@@ -28,8 +30,16 @@ public:
         _available_range = available_range;
     }
 
+    optional<Box> const& bounds() const {
+        return _bounds;
+    }
+
+    void set_bounds(optional<Box> const& bounds) {
+        _bounds = bounds;
+    }
+
     virtual bool is_missing_reference() const;
-    
+
 protected:
     virtual ~MediaReference();
 
@@ -38,6 +48,7 @@ protected:
 
 private:
     optional<TimeRange> _available_range;
+    optional<Box> _bounds;
 };
 
 } }

--- a/src/opentimelineio/missingReference.cpp
+++ b/src/opentimelineio/missingReference.cpp
@@ -1,11 +1,12 @@
 #include "opentimelineio/missingReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 MissingReference::MissingReference(std::string const& name,
                                    optional<TimeRange> const& available_range,
-                                   AnyDictionary const& metadata)
-    : Parent(name, available_range, metadata) {
+                                   AnyDictionary const& metadata,
+                                   optional<Box> const& bounds)
+    : Parent(name, available_range, metadata, bounds) {
 }
 
 MissingReference::~MissingReference() {

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -4,7 +4,7 @@
 #include "opentimelineio/mediaReference.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class MissingReference final : public MediaReference {
 public:
     struct Schema {
@@ -16,7 +16,8 @@ public:
 
     MissingReference(std::string const& name = std::string(),
                      optional<TimeRange> const& available_range = nullopt,
-                     AnyDictionary const& metadata = AnyDictionary());
+                     AnyDictionary const& metadata = AnyDictionary(),
+                     optional<Box> const& bounds = nullopt);
 
     virtual bool is_missing_reference() const;
 

--- a/src/opentimelineio/safely_typed_any.cpp
+++ b/src/opentimelineio/safely_typed_any.cpp
@@ -1,7 +1,7 @@
 #include "opentimelineio/safely_typed_any.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 any create_safely_typed_any(bool&& value) {
     return any(value);
 }
@@ -16,7 +16,7 @@ any create_safely_typed_any(int64_t&& value) {
 
 any create_safely_typed_any(double&& value) {
     return any(value);
-}    
+}
 
 any create_safely_typed_any(std::string&& value) {
     return any(value);
@@ -31,6 +31,14 @@ any create_safely_typed_any(TimeRange&& value) {
 }
 
 any create_safely_typed_any(TimeTransform&& value) {
+    return any(value);
+}
+
+any create_safely_typed_any(Point&& value) {
+    return any(value);
+}
+
+any create_safely_typed_any(Box&& value) {
     return any(value);
 }
 
@@ -77,6 +85,14 @@ TimeRange safely_cast_time_range_any(any const& a) {
 
 TimeTransform safely_cast_time_transform_any(any const& a) {
     return any_cast<TimeTransform>(a);
+}
+
+Point safely_cast_point_any(any const& a) {
+    return any_cast<Point>(a);
+}
+
+Box safely_cast_box_any(any const& a) {
+    return any_cast<Box>(a);
 }
 
 AnyDictionary safely_cast_any_dictionary_any(any const& a) {

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -20,10 +20,12 @@
 #include "opentime/rationalTime.h"
 #include "opentime/timeRange.h"
 #include "opentime/timeTransform.h"
+#include "opentime/box.h"
+#include "opentime/point.h"
 #include "opentimelineio/serializableObject.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 any create_safely_typed_any(bool&&);
 any create_safely_typed_any(int&&);
 any create_safely_typed_any(int64_t&&);
@@ -32,6 +34,8 @@ any create_safely_typed_any(std::string&&);
 any create_safely_typed_any(RationalTime&&);
 any create_safely_typed_any(TimeRange&&);
 any create_safely_typed_any(TimeTransform&&);
+any create_safely_typed_any(Point&&);
+any create_safely_typed_any(Box&&);
 any create_safely_typed_any(AnyVector&&);
 any create_safely_typed_any(AnyDictionary&&);
 any create_safely_typed_any(SerializableObject*);
@@ -44,6 +48,8 @@ std::string safely_cast_string_any(any const& a);
 RationalTime safely_cast_rational_time_any(any const& a);
 TimeRange safely_cast_time_range_any(any const& a);
 TimeTransform safely_cast_time_transform_any(any const& a);
+Point safely_cast_point_any(any const& a);
+Box safely_cast_box_any(any const& a);
 SerializableObject* safely_cast_retainer_any(any const& a);
 
 AnyDictionary safely_cast_any_dictionary_any(any const& a);

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -4,7 +4,7 @@
 #include "opentimelineio/composition.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class Stack : public Composition {
 public:
     struct Schema {
@@ -24,6 +24,7 @@ public:
     virtual TimeRange range_of_child_at_index(int index, ErrorStatus* error_status) const;
     virtual TimeRange trimmed_range_of_child_at_index(int index, ErrorStatus* error_status) const;
     virtual TimeRange available_range(ErrorStatus* error_status) const;
+    virtual Box bounds(ErrorStatus* error_status) const;
 
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -6,7 +6,7 @@
 #include "opentimelineio/stack.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+
 class Timeline : public SerializableObjectWithMetadata {
 public:
     struct Schema {
@@ -28,16 +28,16 @@ public:
     Stack* tracks() {
         return _tracks;
     }*/
-    
+
 
     void set_tracks(Stack* stack) {
         _tracks = stack;
     }
-    
+
     optional<RationalTime> const& global_start_time() const {
         return _global_start_time;
     }
-    
+
     void set_global_start_time(optional<RationalTime> const& global_start_time) {
         _global_start_time = global_start_time;
     }
@@ -45,14 +45,18 @@ public:
     RationalTime duration(ErrorStatus* error_status) const {
         return _tracks.value->duration(error_status);
     }
-    
+
     TimeRange range_of_child(Composable const* child, ErrorStatus* error_status) const {
         return _tracks.value->range_of_child(child, error_status);
     }
 
+    Box bounds(ErrorStatus* error_status) const {
+        return _tracks.value->bounds(error_status);
+    }
+
     std::vector<Track*> audio_tracks() const;
     std::vector<Track*> video_tracks() const;
-    
+
 protected:
     virtual ~Timeline();
 

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -40,6 +40,7 @@ public:
     virtual TimeRange range_of_child_at_index(int index, ErrorStatus* error_status) const;
     virtual TimeRange trimmed_range_of_child_at_index(int index, ErrorStatus* error_status) const;
     virtual TimeRange available_range(ErrorStatus* error_status) const;
+    virtual Box bounds(ErrorStatus* error_status) const;
 
     virtual std::pair<optional<RationalTime>, optional<RationalTime>>
     handles_of_child(Composable const* child, ErrorStatus* error_status) const;

--- a/src/opentimelineio/version.h
+++ b/src/opentimelineio/version.h
@@ -6,12 +6,16 @@
 #include "opentime/rationalTime.h"
 #include "opentime/timeRange.h"
 #include "opentime/timeTransform.h"
+#include "opentime/point.h"
+#include "opentime/box.h"
 
 namespace opentimelineio {
     namespace OPENTIMELINEIO_VERSION {
         using opentime::RationalTime;
         using opentime::TimeRange;
         using opentime::TimeTransform;
+        using opentime::Point;
+        using opentime::Box;
     }
 }
 

--- a/src/py-opentimelineio/opentime-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentime-bindings/CMakeLists.txt
@@ -1,5 +1,7 @@
 pybind11_add_module(_opentime
                     opentime_bindings.cpp
+                    opentime_box.cpp
+                    opentime_point.cpp
                     opentime_rationalTime.cpp
                     opentime_timeRange.cpp
                     opentime_timeTransform.cpp

--- a/src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp
@@ -6,4 +6,6 @@ PYBIND11_MODULE(_opentime, m) {
     opentime_rationalTime_bindings(m);
     opentime_timeRange_bindings(m);
     opentime_timeTransform_bindings(m);
+    opentime_point_bindings(m);
+    opentime_box_bindings(m);
 }

--- a/src/py-opentimelineio/opentime-bindings/opentime_bindings.h
+++ b/src/py-opentimelineio/opentime-bindings/opentime_bindings.h
@@ -4,12 +4,18 @@
 #include <pybind11/pybind11.h>
 #include <string>
 #include "opentime/rationalTime.h"
+#include "opentime/box.h"
 
 void opentime_rationalTime_bindings(pybind11::module);
 void opentime_timeRange_bindings(pybind11::module);
 void opentime_timeTransform_bindings(pybind11::module);
+void opentime_point_bindings(pybind11::module);
+void opentime_box_bindings(pybind11::module);
 
 std::string opentime_python_str(opentime::RationalTime rt);
 std::string opentime_python_repr(opentime::RationalTime rt);
+
+std::string opentime_python_str(opentime::Point p);
+std::string opentime_python_repr(opentime::Point p);
 
 #endif

--- a/src/py-opentimelineio/opentime-bindings/opentime_box.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_box.cpp
@@ -1,0 +1,41 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "opentime_bindings.h"
+#include "opentime/point.h"
+#include "opentime/stringPrintf.h"
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+using namespace opentime;
+
+void opentime_box_bindings(py::module m) {
+    py::class_<Box>(m, "Box")
+        .def(py::init<double, double, Point>(), "width"_a= 0, "height"_a = 0, "center"_a = Point())
+        .def_property_readonly("width", &Box::width)
+        .def_property_readonly("height", &Box::height)
+        .def_property_readonly("center", &Box::center)
+        .def("get_aspect_ratio", &Box::get_aspect_ratio)
+        .def("contains", &Box::contains)
+        .def("get_union", &Box::get_union)
+        .def("__copy__", [](Box p) {
+                return p;
+            })
+        .def("__deepcopy__", [](Box p, py::object memo) {
+                return p;
+            })
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__str__", [](Box b) {
+                return string_printf("Box(%g, %g, %s)",
+                                     b.width(), b.height(),
+                                     opentime_python_str(b.center()).c_str());
+            })
+        .def("__repr__", [](Box b) {
+                return string_printf("otio.opentime.Box(width=%g, height=%g, center=%s)",
+                                     b.width(), b.height(),
+                                     opentime_python_repr(b.center()).c_str());
+            })
+        ;
+}
+

--- a/src/py-opentimelineio/opentime-bindings/opentime_point.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_point.cpp
@@ -1,0 +1,42 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "opentime_bindings.h"
+#include "opentime/point.h"
+#include "opentime/stringPrintf.h"
+
+namespace py = pybind11;
+using namespace pybind11::literals;
+using namespace opentime;
+
+std::string opentime_python_str(Point p) {
+    return string_printf("Point(%g, %g)", p.x(), p.y());
+}
+
+std::string opentime_python_repr(Point p) {
+    return string_printf("otio.opentime.Point(x=%g, y=%g)", p.x(), p.y());
+}
+
+void opentime_point_bindings(py::module m) {
+    py::class_<Point>(m, "Point")
+        .def(py::init<double, double>(), "x"_a= 0, "y"_a = 0)
+        .def_property_readonly("x", &Point::x)
+        .def_property_readonly("y", &Point::y)
+        .def("__copy__", [](Point p) {
+                return p;
+            })
+        .def("__deepcopy__", [](Point p, py::object memo) {
+                return p;
+            })
+        .def(py::self == py::self)
+        .def(py::self != py::self)
+        .def("__str__", [](Point p ) {
+            return opentime_python_str( p );
+        } )
+        .def("__repr__", [](Point p ) {
+            return opentime_python_repr( p );
+        } )
+        ;
+}
+
+

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -290,7 +290,11 @@ static void define_items_and_compositions(py::module m) {
             }, "time"_a, "to_item"_a)
         .def("transformed_time_range", [](Item* item, TimeRange time_range, Item* to_item) {
             return item->transformed_time_range(time_range, to_item, ErrorStatusHandler());
-            }, "time_range"_a, "to_item"_a);
+            }, "time_range"_a, "to_item"_a)
+        .def("bounds", [](Item* item) {
+            return item->bounds(ErrorStatusHandler());
+            });
+
 
     auto transition_class =
         py::class_<Transition, Composable, managing_ptr<Transition>>(m, "Transition", py::dynamic_attr())
@@ -406,6 +410,7 @@ static void define_items_and_compositions(py::module m) {
                 auto result = c->handles_of_child(child, ErrorStatusHandler());
                 return py::make_tuple(py::cast(result.first), py::cast(result.second));
             }, "child_a")
+        .def("has_clips", &Composition::has_clips)
         .def("__internal_getitem__", [](Composition* c, int index) {
                 index = adjusted_vector_index(index, c->children());
                 if (index < 0 || index >= int(c->children().size())) {
@@ -524,7 +529,10 @@ static void define_items_and_compositions(py::module m) {
                 return t->range_of_child(child, ErrorStatusHandler());
             })
         .def("video_tracks", &Timeline::video_tracks)
-        .def("audio_tracks", &Timeline::audio_tracks);
+        .def("audio_tracks", &Timeline::audio_tracks)
+        .def("bounds", [](Timeline* timeline) {
+            return timeline->bounds(ErrorStatusHandler());
+            });
 }
 
 static void define_effects(py::module m) {
@@ -570,28 +578,34 @@ static void define_media_references(py::module m) {
                managing_ptr<MediaReference>>(m, "MediaReference", py::dynamic_attr())
         .def(py::init([](std::string name,
                          optional<TimeRange> available_range,
-                         py::object metadata) {
-                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata)); }),
+                         py::object metadata,
+                         optional<Box> bounds) {
+                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata), bounds); }),
              name_arg,
              "available_range"_a = nullopt,
-             metadata_arg)
+             metadata_arg,
+             "bounds"_a = nullopt)
         .def_property("available_range", &MediaReference::available_range, &MediaReference::set_available_range)
+        .def_property("bounds", &MediaReference::bounds, &MediaReference::set_bounds)
         .def_property_readonly("is_missing_reference", &MediaReference::is_missing_reference);
 
     py::class_<GeneratorReference, MediaReference,
                managing_ptr<GeneratorReference>>(m, "GeneratorReference", py::dynamic_attr())
         .def(py::init([](std::string name, std::string generator_kind,
                          optional<TimeRange> const& available_range,
-                         py::object parameters, py::object metadata) {
+                         py::object parameters, py::object metadata,
+                         optional<Box> bounds) {
                           return new GeneratorReference(name, generator_kind,
                                                         available_range,
                                                         py_to_any_dictionary(parameters),
-                                                        py_to_any_dictionary(metadata)); }),
+                                                        py_to_any_dictionary(metadata),
+                                                        bounds); }),
              name_arg,
              "generator_kind"_a = std::string(),
              "available_range"_a = nullopt,
              "parameters"_a = py::none(),
-             metadata_arg)
+             metadata_arg,
+             "bounds"_a = nullopt)
         .def_property("generator_kind", &GeneratorReference::generator_kind, &GeneratorReference::set_generator_kind)
         .def_property_readonly("parameters", [](GeneratorReference* g) {
                 auto ptr = g->parameters().get_or_create_mutation_stamp();
@@ -603,28 +617,34 @@ static void define_media_references(py::module m) {
         .def(py::init([](
                         py::object name,
                         optional<TimeRange> available_range,
-                        py::object metadata) {
+                        py::object metadata,
+                        optional<Box> bounds) {
                     return new MissingReference(
                                   string_or_none_converter(name),
                                   available_range,
-                                  py_to_any_dictionary(metadata)); 
+                                  py_to_any_dictionary(metadata),
+                                  bounds);
                     }),
              name_arg,
              "available_range"_a = nullopt,
-             metadata_arg);
+             metadata_arg,
+             "bounds"_a = nullopt);
 
 
     py::class_<ExternalReference, MediaReference,
                managing_ptr<ExternalReference>>(m, "ExternalReference", py::dynamic_attr())
         .def(py::init([](std::string target_url,
                          optional<TimeRange> const& available_range,
-                         py::object metadata) {
+                         py::object metadata,
+                         optional<Box> const& bounds) {
                           return new ExternalReference(target_url,
                                                         available_range,
-                                                        py_to_any_dictionary(metadata)); }),
+                                                        py_to_any_dictionary(metadata),
+                                                        bounds); }),
              "target_url"_a = std::string(),
              "available_range"_a = nullopt,
-             metadata_arg)
+             metadata_arg,
+             "bounds"_a = nullopt)
         .def_property("target_url", &ExternalReference::target_url, &ExternalReference::set_target_url);
 
     auto imagesequencereference_class = py:: class_<ImageSequenceReference, MediaReference,
@@ -705,7 +725,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                          int frame_zero_padding,
                          ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
-                         py::object metadata) {
+                         py::object metadata,
+                         optional<Box> const& bounds) {
                           return new ImageSequenceReference(target_url_base,
                                                             name_prefix,
                                                             name_suffix,
@@ -715,7 +736,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                                                             frame_zero_padding,
                                                             missing_frame_policy,
                                                             available_range,
-                                                            py_to_any_dictionary(metadata)); }),
+                                                            py_to_any_dictionary(metadata),
+                                                            bounds); }),
                         "target_url_base"_a = std::string(),
                         "name_prefix"_a = std::string(),
                         "name_suffix"_a = std::string(),
@@ -725,7 +747,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                         "frame_zero_padding"_a = 0,
                         "missing_frame_policy"_a = ImageSequenceReference::MissingFramePolicy::error,
                         "available_range"_a = nullopt,
-                        metadata_arg)
+                        metadata_arg,
+                        "bounds"_a = nullopt)
         .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base, "Everything leading up to the file name in the ``target_url``.")
         .def_property("name_prefix", &ImageSequenceReference::name_prefix, &ImageSequenceReference::set_name_prefix, "Everything in the file name leading up to the frame number.")
         .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix, "Everything after the frame number in the file name.")

--- a/src/py-opentimelineio/opentimelineio/core/mediaReference.py
+++ b/src/py-opentimelineio/opentimelineio/core/mediaReference.py
@@ -4,10 +4,11 @@ from .. import _otio
 
 @add_method(_otio.MediaReference)
 def __str__(self):
-    return "{}({}, {}, {})".format(
+    return "{}({}, {}, {}, {})".format(
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
+        repr(self.bounds),
         repr(self.metadata)
     )
 
@@ -18,6 +19,7 @@ def __repr__(self):
         "otio.{}.{}("
         "name={},"
         " available_range={},"
+        " bounds={},"
         " metadata={}"
         ")"
     ).format(
@@ -25,5 +27,6 @@ def __repr__(self):
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
+        repr(self.bounds),
         repr(self.metadata)
     )

--- a/src/py-opentimelineio/opentimelineio/opentime.py
+++ b/src/py-opentimelineio/opentimelineio/opentime.py
@@ -2,6 +2,8 @@ from . _opentime import ( # noqa
     RationalTime,
     TimeRange,
     TimeTransform,
+    Point,
+    Box,
 )
 
 from_frames = RationalTime.from_frames

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -6,7 +6,7 @@ from .. import _otio
 def __str__(self):
     return (
         'ImageSequenceReference('
-        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {})' .format(
+        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {}, {})' .format(
             self.target_url_base,
             self.name_prefix,
             self.name_suffix,
@@ -16,6 +16,7 @@ def __str__(self):
             self.frame_zero_padding,
             self.missing_frame_policy,
             self.available_range,
+            self.bounds,
             self.metadata,
         )
     )
@@ -34,6 +35,7 @@ def __repr__(self):
         'frame_zero_padding={}, '
         'missing_frame_policy={}, '
         'available_range={}, '
+        'bounds={}, '
         'metadata={}'
         ')' .format(
             repr(self.target_url_base),
@@ -45,6 +47,7 @@ def __repr__(self):
             repr(self.frame_zero_padding),
             repr(self.missing_frame_policy),
             repr(self.available_range),
+            repr(self.bounds),
             repr(self.metadata),
         )
     )

--- a/tests/baselines/empty_external_reference.json
+++ b/tests/baselines/empty_external_reference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "ExternalReference.1",
     "available_range" : null,
+    "bounds" : null,
     "metadata" : {},
     "name" : "",
     "target_url" : "foo.bar"

--- a/tests/baselines/empty_generator_reference.json
+++ b/tests/baselines/empty_generator_reference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "GeneratorReference.1",
     "available_range" : null,
+    "bounds" : null,
     "generator_kind" : "",
     "metadata" : {},
     "parameters" : {},

--- a/tests/baselines/empty_missingreference.json
+++ b/tests/baselines/empty_missingreference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "MissingReference.1",
     "available_range" : null,
+    "bounds" : null,
     "metadata" : {},
     "name" : ""
 }

--- a/tests/sample_data/clip_example.otio
+++ b/tests/sample_data/clip_example.otio
@@ -48,6 +48,16 @@
                 }
               },
               "metadata": {},
+              "bounds": {
+                "OTIO_SCHEMA": "Box.1",
+                "center": {
+                  "OTIO_SCHEMA": "Point.1",
+                  "x":0,
+                  "y":0
+                },
+                "width":16,
+                "height":9
+              },
               "name": null
             },
             "metadata": {},

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -66,7 +66,7 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", MissingReference(\'\', None, {}), None, {})'
+            'Clip("test_clip", MissingReference(\'\', None, None, {}), None, {})'
         )
         self.assertMultiLineEqual(
             repr(cl),
@@ -138,6 +138,35 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(cl.trimmed_range(), cl.source_range)
         self.assertIsNot(cl.trimmed_range(), cl.source_range)
+
+    def test_bounds(self):
+        bounding_box = otio.opentime.Box(
+            width=16.0,
+            height=9.0,
+            center=otio.opentime.Point(0, 0)
+        )
+
+        cl = otio.schema.Clip(
+            name="test_bounds",
+            media_reference=otio.schema.ExternalReference(
+                "/var/tmp/foo.mov",
+                bounds=bounding_box
+            )
+        )
+
+        self.assertEqual(0, cl.bounds().center.x)
+        self.assertEqual(0, cl.bounds().center.y)
+        self.assertTrue(cl.bounds().contains(cl.bounds().center))
+
+        self.assertTrue(cl.bounds().contains(otio.opentime.Point(-8, -4.5)))
+        self.assertTrue(cl.bounds().contains(otio.opentime.Point(8, -4.5)))
+        self.assertTrue(cl.bounds().contains(otio.opentime.Point(8, 4.5)))
+        self.assertTrue(cl.bounds().contains(otio.opentime.Point(-8, 4.5)))
+
+        self.assertFalse(cl.bounds().contains(otio.opentime.Point(-8.01, -4.5)))
+        self.assertFalse(cl.bounds().contains(otio.opentime.Point(8, -4.501)))
+        self.assertFalse(cl.bounds().contains(otio.opentime.Point(8.01, 4.5)))
+        self.assertFalse(cl.bounds().contains(otio.opentime.Point(-8, 4.501)))
 
     def test_ref_default(self):
         cl = otio.schema.Clip()

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -75,6 +75,14 @@ class DocTester(unittest.TestCase):
             track.trimmed_range_of_child(clip)
         )
         self.assertEqual(
+            otio.opentime.Box(
+                width=16,
+                height=9,
+                center=otio.opentime.Point(0, 0)
+            ),
+            track.bounds()
+        )
+        self.assertEqual(
             (
                 None,
                 otio.opentime.RationalTime(1, 24)
@@ -146,6 +154,23 @@ class DocTester(unittest.TestCase):
                 duration=otio.opentime.RationalTime(8, 24)
             ),
             clip.media_reference.available_range
+        )
+
+        self.assertEqual(
+            otio.opentime.Box(
+                width=16,
+                height=9,
+                center=otio.opentime.Point(0, 0)
+            ),
+            clip.bounds()
+        )
+        self.assertEqual(
+            otio.opentime.Box(
+                width=16,
+                height=9,
+                center=otio.opentime.Point(0, 0)
+            ),
+            clip.media_reference.bounds
         )
 
         self.assertEqual(

--- a/tests/test_generator_reference.py
+++ b/tests/test_generator_reference.py
@@ -24,7 +24,8 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             },
             metadata={
                 "foo": "bar"
-            }
+            },
+            bounds=otio.opentime.Box(16, 9, otio.opentime.Point(0, 0))
         )
 
     def test_constructor(self):
@@ -38,6 +39,10 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(100, 24),
             )
+        )
+        self.assertEqual(
+            self.gen.bounds,
+            otio.opentime.Box(16, 9, otio.opentime.Point(0, 0))
         )
 
     def test_serialize(self):

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -27,6 +27,7 @@ class ImageSequenceReferenceTests(
             missing_frame_policy=frame_policy,
             rate=30,
             metadata={"custom": {"foo": "bar"}},
+            bounds=otio.opentime.Box(16, 9, otio.opentime.Point(0, 0))
         )
 
         # Check Values
@@ -40,6 +41,10 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
             )
+        )
+        self.assertEqual(
+            ref.bounds,
+            otio.opentime.Box(16, 9, otio.opentime.Point(0, 0))
         )
         self.assertEqual(ref.frame_step, 3)
         self.assertEqual(ref.rate, 30)
@@ -64,6 +69,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             metadata={"custom": {"foo": "bar"}},
+            bounds=otio.opentime.Box(16, 9, otio.opentime.Point(0, 0)),
         )
         self.assertEqual(
             str(ref),
@@ -77,6 +83,7 @@ class ImageSequenceReferenceTests(
             '5, '
             'MissingFramePolicy.error, '
             'TimeRange(RationalTime(0, 30), RationalTime(60, 30)), '
+            'Box(16, 9, Point(0, 0)), '
             "{'custom': {'foo': 'bar'}}"
             ')'
         )
@@ -96,6 +103,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             metadata={"custom": {"foo": "bar"}},
+            bounds=otio.opentime.Box(16, 9, otio.opentime.Point(0, 0)),
         )
         ref_value = (
             'ImageSequenceReference('
@@ -108,8 +116,9 @@ class ImageSequenceReferenceTests(
             'frame_zero_padding=5, '
             'missing_frame_policy=MissingFramePolicy.error, '
             'available_range={}, '
+            'bounds={}, '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
-            ')'.format(repr(ref.available_range))
+            ')'.format(repr(ref.available_range), repr(ref.bounds))
         )
         self.assertEqual(repr(ref), ref_value)
 
@@ -128,6 +137,7 @@ class ImageSequenceReferenceTests(
             rate=30,
             missing_frame_policy=frame_policy,
             metadata={"custom": {"foo": "bar"}},
+            bounds=otio.opentime.Box(16, 9, otio.opentime.Point(0, 0)),
         )
 
         encoded = otio.adapters.otio_json.write_to_string(ref)
@@ -157,6 +167,10 @@ class ImageSequenceReferenceTests(
             decoded.missing_frame_policy,
             otio.schema.ImageSequenceReference.MissingFramePolicy.hold
         )
+        self.assertEqual(
+            decoded.bounds,
+            otio.opentime.Box(16, 9, otio.opentime.Point(0, 0))
+        )
         self.assertEqual(decoded.metadata, {"custom": {"foo": "bar"}})
 
     def test_deserialize_invalid_enum_value(self):
@@ -180,6 +194,16 @@ class ImageSequenceReferenceTests(
                     "rate": 30.0,
                     "value": 0.0
                 }
+            },
+            "bounds": {
+                "OTIO_SCHEMA": "Box.1"
+                "center": {
+                    "OTIO_SCHEMA": "Point.1",
+                    "x": 0,
+                    "y": 0
+                },
+                "width": 16,
+                "height": 9
             },
             "target_url_base": "file:///show/seq/shot/rndr/",
             "name_prefix": "show_shot.",

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -37,26 +37,30 @@ class MediaReferenceTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.opentime.RationalTime(5, 24),
             otio.opentime.RationalTime(10, 24.0)
         )
+        bounds = otio.opentime.Box(16, 9, otio.opentime.Point(0, 0))
         mr = otio.schema.MissingReference(
             available_range=tr,
-            metadata={'show': 'OTIOTheMovie'}
+            metadata={'show': 'OTIOTheMovie'},
+            bounds=bounds
         )
 
         self.assertEqual(mr.available_range, tr)
+        self.assertEqual(mr.bounds, bounds)
 
         mr = otio.schema.MissingReference()
         self.assertIsNone(mr.available_range)
+        self.assertIsNone(mr.bounds)
 
     def test_str_missing(self):
         missing = otio.schema.MissingReference()
         self.assertMultiLineEqual(
             str(missing),
-            "MissingReference(\'\', None, {})"
+            "MissingReference(\'\', None, None, {})"
         )
         self.assertMultiLineEqual(
             repr(missing),
             "otio.schema.MissingReference("
-            "name='', available_range=None, metadata={}"
+            "name='', available_range=None, bounds=None, metadata={}"
             ")"
         )
 

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -1159,5 +1159,207 @@ class TestTimeRange(unittest.TestCase):
         self.assertNotEqual(frame, otio.opentime.to_frames(t, 12))
 
 
+class TestPoint(unittest.TestCase):
+
+    def test_create(self):
+        p1 = otio.opentime.Point()
+        self.assertEqual(p1.x, 0)
+        self.assertEqual(p1.y, 0)
+
+        p2 = otio.opentime.Point(1)
+        self.assertEqual(p2.x, 1)
+        self.assertEqual(p2.y, 0)
+
+        p3 = otio.opentime.Point(2, 3)
+        self.assertEqual(p3.x, 2)
+        self.assertEqual(p3.y, 3)
+
+    def test_equality(self):
+        p1 = otio.opentime.Point()
+        self.assertEqual(p1, p1)
+
+        p2 = otio.opentime.Point()
+        self.assertTrue(p1 is not p2)
+        self.assertEqual(p1, p2)
+
+        p3 = otio.opentime.Point(9, 5)
+        p4 = otio.opentime.Point(9, 5)
+        self.assertTrue(p3 is not p4)
+        self.assertEqual(p3, p4)
+        self.assertTrue(p3 == p4)
+
+    def test_inequality(self):
+        p1 = otio.opentime.Point(5, 9)
+        self.assertEqual(p1, p1)
+
+        p2 = otio.opentime.Point(9, 5)
+        self.assertTrue(p1 is not p2)
+        self.assertNotEqual(p1, p2)
+
+        p3 = otio.opentime.Point()
+        self.assertTrue(p1 is not p3)
+        self.assertTrue(p1 != p3)
+
+    def test_copy(self):
+        p1 = otio.opentime.Point(42, 24)
+        p2 = copy.copy(p1)
+        self.assertEqual(p2, otio.opentime.Point(42, 24))
+
+    def test_deepcopy(self):
+        p1 = otio.opentime.Point(42, 24)
+        p2 = copy.deepcopy(p1)
+        self.assertEqual(p2, otio.opentime.Point(42, 24))
+
+    def test_point_to_string(self):
+        p = otio.opentime.Point(1.0, 2.0)
+        self.assertEqual(str(p), "Point(1, 2)")
+        self.assertEqual(
+            repr(p),
+            "otio.opentime.Point(x=1, y=2)"
+        )
+
+
+class TestBox(unittest.TestCase):
+
+    def test_create(self):
+        b1 = otio.opentime.Box()
+        self.assertEqual(b1.width, 0)
+        self.assertEqual(b1.height, 0)
+        self.assertEqual(b1.center.x, 0)
+        self.assertEqual(b1.center.y, 0)
+
+        b2 = otio.opentime.Box(1)
+        self.assertEqual(b2.width, 1)
+        self.assertEqual(b2.height, 0)
+        self.assertEqual(b2.center.x, 0)
+        self.assertEqual(b2.center.y, 0)
+
+        b3 = otio.opentime.Box(2, 3)
+        self.assertEqual(b3.width, 2)
+        self.assertEqual(b3.height, 3)
+        self.assertEqual(b3.center.x, 0)
+        self.assertEqual(b3.center.y, 0)
+
+        b4 = otio.opentime.Box(4, 5, otio.opentime.Point(6, 7))
+        self.assertEqual(b4.width, 4)
+        self.assertEqual(b4.height, 5)
+        self.assertEqual(b4.center.x, 6)
+        self.assertEqual(b4.center.y, 7)
+
+    def test_equality(self):
+        b1 = otio.opentime.Box()
+        self.assertEqual(b1, b1)
+
+        b2 = otio.opentime.Box()
+        self.assertTrue(b1 is not b2)
+        self.assertEqual(b1, b2)
+
+        b3 = otio.opentime.Box(4, 3, otio.opentime.Point(2, 1))
+        b4 = otio.opentime.Box(4, 3, otio.opentime.Point(2, 1))
+        self.assertTrue(b3 is not b4)
+        self.assertEqual(b3, b4)
+        self.assertTrue(b3 == b4)
+
+    def test_inequality(self):
+        b1 = otio.opentime.Box(5, 9, otio.opentime.Point(-1, -2))
+        self.assertEqual(b1, b1)
+
+        b2 = otio.opentime.Box(5, 9, otio.opentime.Point(-2, -1))
+        self.assertTrue(b1 is not b2)
+        self.assertNotEqual(b1, b2)
+
+        b3 = otio.opentime.Box()
+        self.assertTrue(b1 is not b3)
+        self.assertTrue(b1 != b3)
+
+    def test_copy(self):
+        b1 = otio.opentime.Box(42, 24, otio.opentime.Point(-10, 10))
+        b2 = copy.copy(b1)
+        self.assertEqual(b2, otio.opentime.Box(42, 24, otio.opentime.Point(-10, 10)))
+
+    def test_deepcopy(self):
+        b1 = otio.opentime.Box(42, 24, otio.opentime.Point(-10, 10))
+        b2 = copy.deepcopy(b1)
+        self.assertEqual(b2, otio.opentime.Box(42, 24, otio.opentime.Point(-10, 10)))
+
+    def test_box_to_string(self):
+        b = otio.opentime.Box(1.0, 2.0, otio.opentime.Point(-1.0, -2.0))
+        self.assertEqual(str(b), "Box(1, 2, Point(-1, -2))")
+        self.assertEqual(
+            repr(b),
+            "otio.opentime.Box(width=1, height=2, "
+            "center=otio.opentime.Point(x=-1, y=-2))"
+        )
+
+    def test_aspect_ratio(self):
+        b1 = otio.opentime.Box()
+        self.assertEqual(1, b1.get_aspect_ratio())
+
+        b2 = otio.opentime.Box(1, 0)
+        self.assertEqual(1, b2.get_aspect_ratio())
+
+        b3 = otio.opentime.Box(4, 2)
+        self.assertEqual(2, b3.get_aspect_ratio())
+
+        b4 = otio.opentime.Box(2, 4)
+        self.assertEqual(0.5, b4.get_aspect_ratio())
+
+    def test_contains_symetrical(self):
+        b1 = otio.opentime.Box(16, 9)
+
+        # test center
+        self.assertTrue(b1.contains(otio.opentime.Point(0, 0)))
+
+        # test exact borders
+        self.assertTrue(b1.contains(otio.opentime.Point(-8, -4.5)))
+        self.assertTrue(b1.contains(otio.opentime.Point(8, -4.5)))
+        self.assertTrue(b1.contains(otio.opentime.Point(8, 4.5)))
+        self.assertTrue(b1.contains(otio.opentime.Point(-8, 4.5)))
+
+        # test just outside borders
+        self.assertFalse(b1.contains(otio.opentime.Point(-8.01, -4.5)))
+        self.assertFalse(b1.contains(otio.opentime.Point(8, -4.501)))
+        self.assertFalse(b1.contains(otio.opentime.Point(8.01, 4.5)))
+        self.assertFalse(b1.contains(otio.opentime.Point(-8, 4.501)))
+
+    def test_contains_asymetrical(self):
+        b1 = otio.opentime.Box(16, 9, otio.opentime.Point(16, 9))
+
+        # test center
+        self.assertTrue(b1.contains(otio.opentime.Point(16, 9)))
+
+        # test exact borders
+        self.assertTrue(b1.contains(otio.opentime.Point(8, 4.5)))
+        self.assertTrue(b1.contains(otio.opentime.Point(24, 4.5)))
+        self.assertTrue(b1.contains(otio.opentime.Point(24, 13.5)))
+        self.assertTrue(b1.contains(otio.opentime.Point(8, 13.5)))
+
+        # test just outside borders
+        self.assertFalse(b1.contains(otio.opentime.Point(7.99, 4.5)))
+        self.assertFalse(b1.contains(otio.opentime.Point(24, 4.449)))
+        self.assertFalse(b1.contains(otio.opentime.Point(24.01, 13.5)))
+        self.assertFalse(b1.contains(otio.opentime.Point(8, 13.501)))
+
+    def test_union(self):
+        # complete overlap
+        b1 = otio.opentime.Box(2, 2)
+        union1 = b1.get_union(otio.opentime.Box(1, 1))
+        self.assertEqual(b1, union1)
+
+        # partial overlap
+        b2 = otio.opentime.Box(2, 2, otio.opentime.Point(1, 1))
+        union2 = b2.get_union(otio.opentime.Box(2, 2, otio.opentime.Point(2, 2)))
+        self.assertEqual(3, union2.width)
+        self.assertEqual(3, union2.height)
+        self.assertEqual(otio.opentime.Point(1.5, 1.5), union2.center)
+
+        # no overlap
+        b3 = otio.opentime.Box(2, 2, otio.opentime.Point(1, 1))
+        union3 = b3.get_union(otio.opentime.Box(2, 2, otio.opentime.Point(3, 3)))
+        self.assertEqual(4, union3.width)
+        self.assertEqual(4, union3.height)
+        self.assertEqual(otio.opentime.Point(2, 2), union3.center)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #771
MediaReference: spatial bounding box

**Summary**

This change addresses the need to have spatial bounds expressed in the MediaReference.  These are used to define a measurement-agnostic coordinate system representing the viewing area of the clip(s), which can be used by media players to determine how to display or scale/resize/center (if necessary) the media referenced by the Clips.  

For a more in-depth explanation of the idea and motivations please see the issue linked here:
https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/771

I have flagged as many potential discussion points that I think might arise with **Note** below.  

**Note**
- I have my editor set to remove all trailing whitespace on save (since this is required by a lot of the Autodesk github linters which will block the PR if its not done).  This resulted in some whitespace changes in the c++ code, Python was unaffected.  If you'd like me to undo those, let me know. As an aside, a clang-format file in the repo root could be very useful so that coding style is enforced in c++ as well as Python. 

**Files changed**
- *.md files
Lists the additions to the schemas (automatically generated by Makefiles).

- src/opentime/CMakeLists.txt
Adds new Point and Box files to the compilation

- src/opentime/box.h
Adds a new Box primitive with members width, height and center, including accessor and mutators for each.  The default constructor, operator== and operator!= required by the serialization code is also added.  Lastly, some common convenience methods are added: get_aspect_ratio, contains and get_union.
The get_aspect_ratio method returns simply the ratio of width over height, commonly used by media applications.  The contains method returns true if Point argument is contained within the Box.  Lastly, the get_union method take a Box and returns the minimum sized box required to contain both Boxes.  This is used by Composition/Timeline to calculate the union of all the Clips contained within them.
**Note**: The contains and get_aspect_ratio methods are really only used by the unit tests, but I thought they were useful.  I can remove it if you prefer not to have it.
**Note**: To prevent a divide by 0, get_aspect_ratio returns 1 if the width is 0.  If you'd prefer another default value, let me know.
**Python Bindings**: Also added for all public functions.

- src/opentime/point.h
Adds a new Point primitive with members x and y, including accessor and mutators for each. The default constructor, operator== and operator!= required by the serialization code is also added.
The class is mainly used by Box to define it's center.
**Note**: I added a convenience templated is_equal method for floating point values here, that is also used by Box.  If you'd prefer it to go somewhere else (like a utility file), let me know.
**Python Bindings**: Also added for all public functions.

- src/opentimelineio/clip.cpp
Implement the bounds method.  Simply returns the bounding box if it has been set on the clip or an error otherwise (conforming to the standard of the available_range method).

- src/opentimelineio/clip.h
Adds the bounds method to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/composable.cpp
Implements the bounds method to return an error so that any dervied classes that do not explicitly override the virtual method return the error (it is overriden by Clip, Stack and Track).  

- src/opentimelineio/composable.h
Adds the bounds method to the public interface
**Python Bindings**: Also added

- src/opentimelineio/composition.cpp
Implements the has_clips method for composition, which returns true if the Composition contains at least one clip.  This function is used by bounds method of the derived Stack class to exclude any tracks that do not contain any clips when it calculates the union of the bounds.  Since the bounds default to width, height and center of {0, 0, (0, 0)} we want to prevent the default values from affecting the result and thus use the has_clips method to skip over any tracks that do not contain clips. 

- src/opentimelineio/composition.h
Adds the has_clips method to the public interface. 
**Python Bindings**: Also added
**Note**: Even though this method is only needed by Stack, I thought it could be useful elsewhere so I made it public.  If you would prefer I could make it protected so only Stack could access it.  Or if you do not want it in the interface at all, I can also implement it as a lambda function (or in the anonymous namespace) inside of Stack::bounds.

- src/opentimelineio/deserialization.cpp
Implements the de/serialization of Point, Box and optional<Box> primitives.  The code follows the existing standard provided by Time and TimeRange.

- src/opentimelineio/errorStatus.cpp
Adds a new error value for when the bounds cannot be determined.  This occurs when the user asks for bounds on a Clip that does not contain bounds or asks for bounds on a Composition that has a Clip that does not contain bounds.

- src/opentimelineio/externalReference.cpp, src/opentimelineio/generatorReference.cpp, src/opentimelineio/imageSequenceReference.cpp, src/opentimelineio/missingReference.h
Pass bounds constructor argument to MediaReference parent constructor 

- src/opentimelineio/externalReference.h, src/opentimelineio/generatorReference.h, src/opentimelineio/imageSequenceReference.h, src/opentimelineio/missingReference.h
Adds optional constructor argument for bounds.

- src/opentimelineio/mediaReference.cpp
Initializes bounds member and add it to the read/write method for serialization.

- src/opentimelineio/mediaReference.h
Add bounds member and constructor argument as well as a mutator and accessor method.
**Python Bindings**: Also added (includes derived classes)

- src/opentimelineio/safely_typed_any.cpp
Adds casting support for Box  and Point (required by serialization code).

- src/opentimelineio/safely_typed_any.h
Adds casting methods for Box and Point to public interface.

- src/opentimelineio/serializableObject.h
Adds de/serialization support for Box and Point found within the MediaReference schema.

- src/opentimelineio/serialization.cpp
Adds de/serialization code for Box and Point.

- src/opentimelineio/stack.cpp
Implements bounds method for a stack.  We begin by finding the first bounding box, defined as the Box of the first Clip or of the first Composition that contains at least one Clip. After this is found, we then calculate the union of this with each subsequent Clip or Composition containing at least one Clip.  If no Clips are found, we returning the default Box.  If an error is found, we return the error (as a parameter) and the default Box. This follows the standard defined by the available_range method.

- src/opentimelineio/stack.h
Adds bounds method to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/timeline.h
Adds bounds to the public interface and implements it by redirecting the call to it's Stack.
**Python Bindings**: Also added

- src/opentimelineio/track.cpp
Implements bounds method for a track.  Similarly to Stack, we begin by finding the first bounding box, however in this case we don't need to consider Compositions, only Clips.  Once we have the bounding Box of the first clip, we get the union of it with the Box of each subsequent Clip.  If no Clips are found, we returning the default Box.  If an error is found, we return the error (as a parameter) and the default Box. This follows the standard defined by the available_range method.

- src/opentimelineio/track.h
Adds bounds method to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/version.h
Adds Point and Box to the versioned opentimelineio namespace.

- src/py-opentimelineio/opentime-bindings/CMakeLists.txt
Adds compilation of Python bindings for Box and Point.

- src/py-opentimelineio/opentime-bindings/opentime_bindings.cpp
Call Point and Box Python bindings. 

- src/py-opentimelineio/opentime-bindings/opentime_bindings.h
Adds prototypes for Point and Box bindings as well as prototypes for the Python __str__ and __repr__ functions for Points (since this is reused by Box __str__ and __repr__ methods).

- src/py-opentimelineio/opentime-bindings/opentime_box.cpp
Adds implementation of Python bindings for the Box class
**Note**: These are denoted by **Python Bindings** in Box.h description above.

- src/py-opentimelineio/opentime-bindings/opentime_point.cpp
Adds implementation of Python bindings for the Point class
**Note**: These are denoted by **Python Bindings** in Point.h description above.

- src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
Adds all added opentimelineio public c++ interface methods to the Python bindings
**Note**: These are denoted by **Python Bindings** in descriptions above.

- src/py-opentimelineio/opentimelineio/core/mediaReference.py
Adds bounds to the __repr__ and __str__ method for MediaReference.

- src/py-opentimelineio/opentimelineio/opentime.py
Adds Point and Box to the opentime module.

- src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
Adds bounds to the __repr__ and __str__ method for ImageSequence.

**Tests**

- tests/baselines/*.json
Adds empty bounds to the json representations
**Note**: This is necessary even if the bounds don't exist in the metadata since the serialization code will add a null bounds member in this case.  If you'd prefer I could make it exclude the bounds member entirely if it is not defined.

- tests/sample_data/clip_example.otio
Added bounds to the example clip and associated test (test_documentation.py).

- tests/test_clip.py
Updated the str test to include the bounds.  Also adds a bounding box to a clip and tests that they were set correctly using the contains methods to find the edges of the Box.

- tests/test_composition.py
Tests the added has_clips method on empty stacks and tracks and ones containing no Clips (only Gaps).  Also tests that the bounds are correctly applied to empty Stacks, single clip Stacks, multi-clip Stacks, Stacks with gaps, and Stacks containing Tracks containing Clips. Tracks are also tested for empty Tracks, gap-only Tracks, single Clip Tracks and multi-Clip Tracks.

- tests/test_documentation.py
Deserializes the updated clip_example.otio file and make sure it contains the bounds.

- tests/test_generator_reference.py, tests/test_image_sequence_reference.py, tests/test_media_reference.py
Ensures the bounds can be passed to the constructor and the same bounds are returned from the accessor.
ImageSequenceReference and MediaRefererence also test the __str__ and __repr__ methods return the expected string.

- tests/test_opentime.py
Adds Point and Box tests to test all the publicly available basic methods: equality, inequality, accessor, and mutators, and well as the Python __copy__, __deepcopy__, __str__ and __repr__.  The Box test also adds tests for aspect_ratio and aspect_ratio with 0 width.  The contains method tests Boxes centered at the the default (0,0) and a non-default value. The union method is tests in three situation: completely overlapping boxes, partially overlapping boxes and non-overlapping boxes.

- tests/test_timeline.py
Timeline bounds are tested to ensure a single track timeline has equal bounds between the Track and the Timeline.  
