### PR TITLE
Prune the .github folder with the issue templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ recursive-include examples *
 recursive-include contrib *
 recursive-include src *
 
+prune .github
 prune docs
 exclude .gitmodules
 recursive-exclude src *.git


### PR DESCRIPTION
Excludes the GitHub templates from the `MANIFEST.in` file.

This was causing `check-manifest` to fail, which in turn causes tox (And ci) to fail.

