### PR TITLE
Updated ErrorStatusHandler to escalate more exceptions and added detail to ImageSequenceReference exceptions

### DIFF
--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -69,7 +69,15 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
 
     std::string
     ImageSequenceReference::target_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
-        if (image_number >= this->number_of_images_in_sequence()) {
+        if (_rate == 0) {
+            *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX, "Zero rate sequence has no frames.");
+            return std::string();
+        }
+        else if (!this->available_range().has_value() || this->available_range().value().duration().value() == 0) {
+            *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX, "Zero duration sequences has no frames.");
+            return std::string();
+        }
+        else if (image_number >= this->number_of_images_in_sequence()) {
             *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX);
             return std::string();
         }

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_errorStatusHandler.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_errorStatusHandler.cpp
@@ -28,12 +28,12 @@ ErrorStatusHandler::~ErrorStatusHandler() noexcept(false) {
     if (!error_status) {
         return;
     }
-    
+
     switch(error_status.outcome) {
     case ErrorStatus::NOT_IMPLEMENTED:
-        throw py::not_implemented_error();
+        throw py::not_implemented_error(error_status.details);
     case ErrorStatus::ILLEGAL_INDEX:
-        throw py::index_error();
+        throw py::index_error(error_status.details);
     case ErrorStatus::KEY_NOT_FOUND:
         throw py::key_error(error_status.details);
     case ErrorStatus::INTERNAL_ERROR:


### PR DESCRIPTION
Updated the python errorStatusHandler to escalate details from IndexError and NotImplementedError and made ImageSequenceReference provide a more helpful exception message when trying to get a frame url from a zero rate or zero duration instance.

Split from #639, the docstring segment of that PR ended up handled elsewhere. This supersedes that PR.
