### PR TITLE
Remove .dev1 suffix for release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,7 @@ if (
 
 # Metadata that gets stamped into the __init__ files during the build phase.
 PROJECT_METADATA = {
-    "version": "0.13.0.dev1",
+    "version": "0.13.0",
     "author": 'Contributors to the OpenTimelineIO project',
     "author_email": 'opentimelineio@pixar.com',
     "license": 'Modified Apache 2.0 License',


### PR DESCRIPTION
Releasing OTIO beta 13, stripping the .dev1 suffix off the version in setup.py for release to pypi.