### PR TITLE
Added docstrings to python bindings for interval algebra methods in TimeRange

### DIFF
--- a/src/py-opentimelineio/opentime-bindings/opentime_timeRange.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_timeRange.cpp
@@ -42,18 +42,88 @@ void opentime_timeRange_bindings(py::module m) {
         .def("extended_by", &TimeRange::extended_by, "other"_a)
         .def("clamped", (RationalTime (TimeRange::*)(RationalTime) const) &TimeRange::clamped, "other"_a)
         .def("clamped", (TimeRange (TimeRange::*)(TimeRange) const) &TimeRange::clamped, "other"_a)
-        .def("contains", (bool (TimeRange::*)(RationalTime) const) &TimeRange::contains, "other"_a)
-        .def("contains", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::contains, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("overlaps", (bool (TimeRange::*)(RationalTime) const) &TimeRange::overlaps, "other"_a)
-        .def("overlaps", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::overlaps, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("before", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::before, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("before", (bool (TimeRange::*)(RationalTime, double ) const) &TimeRange::before, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("meets", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::meets, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("begins", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::begins, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("begins", (bool (TimeRange::*)(RationalTime, double) const) &TimeRange::begins, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("finishes", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::finishes, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("finishes", (bool (TimeRange::*)(RationalTime, double) const) &TimeRange::finishes, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
-        .def("intersects", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::intersects, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s)
+        .def("contains", (bool (TimeRange::*)(RationalTime) const) &TimeRange::contains, "other"_a, R"docstring(
+The start of :para:`this` precedes :param:`other`.
+:param:`other` precedes the end of this.
+                    other
+                      ↓
+                      *
+              [      this      ]
+)docstring")
+        .def("contains", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::contains, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The start of :param:`this` precedes start of :param:`other`.
+The end of :param:`this` antecedes end of :param:`other`.
+                  [ other ]
+             [      this      ]
+The converse would be ``other.contains(this)``
+)docstring")
+        .def("overlaps", (bool (TimeRange::*)(RationalTime) const) &TimeRange::overlaps, "other"_a, R"docstring(
+:param:`this` contains :param:`other`.
+                  other
+                   ↓
+                   *
+             [    this    ]
+)docstring")
+        .def("overlaps", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::overlaps, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The start of :param:`this` strictly precedes end of :param:`other` by a value >= :param:`epsilon_s`.
+The end of :param:`this` strictly antecedes start of :param:`other` by a value >= :param:`epsilon_s`.
+             [ this ]
+                 [ other ]
+The converse would be ``other.overlaps(this)``
+)docstring")
+        .def("before", (bool (TimeRange::*)(RationalTime, double ) const) &TimeRange::before, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The end of :param:`this` strictly precedes :param:`other` by a value >= :param:`epsilon_s`.
+                       other
+                         ↓
+             [ this ]    *
+)docstring")
+        .def("before", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::before, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The end of :param:`this` strictly equals the start of :param:`other` and
+the start of :param:`this` strictly equals the end of :param:`other`.
+             [this][other]
+The converse would be ``other.meets(this)``
+)docstring")
+        .def("meets", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::meets, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The end of :param:`this` strictly equals the start of :param:`other` and
+the start of :param:`this` strictly equals the end of :param:`other`.
+             [this][other]
+The converse would be ``other.meets(this)``
+)docstring")
+        .def("begins", (bool (TimeRange::*)(RationalTime, double) const) &TimeRange::begins, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The start of :param:`this` strictly equals :param:`other`.
+           other
+             ↓
+             *
+             [ this ]
+)docstring")
+        .def("begins", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::begins, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The start of :param:`this` strictly equals the start of :param:`other`.
+The end of :param:`this` strictly precedes the end of :param:`other` by a value >= :param:`epsilon_s`.
+             [ this ]
+             [    other    ]
+The converse would be ``other.begins(this)``
+)docstring")
+        .def("finishes", (bool (TimeRange::*)(RationalTime, double) const) &TimeRange::finishes, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The end of :param:`this` strictly equals :param:`other`.
+                  other
+                    ↓
+                    *
+             [ this ]
+)docstring")
+        .def("finishes", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::finishes, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The start of :param:`this` strictly antecedes the start of :param:`other` by a value >= :param:`epsilon_s`.
+The end of :param:`this` strictly equals the end of :param:`other`.
+                     [ this ]
+             [     other    ]
+The converse would be ``other.finishes(this)``
+)docstring")
+        .def("intersects", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::intersects, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
+The start of :param:`this` precedes or equals the end of :param:`other` by a value >= :param:`epsilon_s`.
+The end of :param:`this` antecedes or equals the start of :param:`other` by a value >= :param:`epsilon_s`.
+        [    this    ]           OR      [    other    ]
+             [     other    ]                    [     this    ]
+The converse would be ``other.finishes(this)``
+)docstring")
         .def("__copy__", [](TimeRange tr) {
                 return tr;
             })
@@ -77,5 +147,3 @@ void opentime_timeRange_bindings(py::module m) {
             })
         ;
 }
-
-        

--- a/src/py-opentimelineio/opentime-bindings/opentime_timeRange.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_timeRange.cpp
@@ -43,83 +43,98 @@ void opentime_timeRange_bindings(py::module m) {
         .def("clamped", (RationalTime (TimeRange::*)(RationalTime) const) &TimeRange::clamped, "other"_a)
         .def("clamped", (TimeRange (TimeRange::*)(TimeRange) const) &TimeRange::clamped, "other"_a)
         .def("contains", (bool (TimeRange::*)(RationalTime) const) &TimeRange::contains, "other"_a, R"docstring(
-The start of :para:`this` precedes :param:`other`.
-:param:`other` precedes the end of this.
+The start of `this` precedes `other`.
+`other` precedes the end of `this`.
+::
                     other
                       ↓
                       *
               [      this      ]
+
 )docstring")
         .def("contains", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::contains, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The start of :param:`this` precedes start of :param:`other`.
-The end of :param:`this` antecedes end of :param:`other`.
+The start of `this` precedes start of `other`.
+The end of `this` antecedes end of `other`.
+::
+
                   [ other ]
              [      this      ]
+
 The converse would be ``other.contains(this)``
 )docstring")
         .def("overlaps", (bool (TimeRange::*)(RationalTime) const) &TimeRange::overlaps, "other"_a, R"docstring(
-:param:`this` contains :param:`other`.
+`this` contains `other`.
+::
                   other
                    ↓
                    *
              [    this    ]
 )docstring")
         .def("overlaps", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::overlaps, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The start of :param:`this` strictly precedes end of :param:`other` by a value >= :param:`epsilon_s`.
-The end of :param:`this` strictly antecedes start of :param:`other` by a value >= :param:`epsilon_s`.
+The start of `this` strictly precedes end of `other` by a value >= `epsilon_s`.
+The end of `this` strictly antecedes start of `other` by a value >= `epsilon_s`.
+::
              [ this ]
                  [ other ]
 The converse would be ``other.overlaps(this)``
 )docstring")
         .def("before", (bool (TimeRange::*)(RationalTime, double ) const) &TimeRange::before, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The end of :param:`this` strictly precedes :param:`other` by a value >= :param:`epsilon_s`.
+The end of `this` strictly precedes `other` by a value >= `epsilon_s`.
+::
                        other
                          ↓
              [ this ]    *
 )docstring")
         .def("before", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::before, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The end of :param:`this` strictly equals the start of :param:`other` and
-the start of :param:`this` strictly equals the end of :param:`other`.
+The end of `this` strictly equals the start of `other` and
+the start of `this` strictly equals the end of `other`.
+::
              [this][other]
 The converse would be ``other.meets(this)``
 )docstring")
         .def("meets", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::meets, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The end of :param:`this` strictly equals the start of :param:`other` and
-the start of :param:`this` strictly equals the end of :param:`other`.
+The end of `this` strictly equals the start of `other` and
+the start of `this` strictly equals the end of `other`.
+::
              [this][other]
 The converse would be ``other.meets(this)``
 )docstring")
         .def("begins", (bool (TimeRange::*)(RationalTime, double) const) &TimeRange::begins, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The start of :param:`this` strictly equals :param:`other`.
+The start of `this` strictly equals `other`.
+::
            other
              ↓
              *
              [ this ]
 )docstring")
         .def("begins", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::begins, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The start of :param:`this` strictly equals the start of :param:`other`.
-The end of :param:`this` strictly precedes the end of :param:`other` by a value >= :param:`epsilon_s`.
+The start of `this` strictly equals the start of `other`.
+The end of `this` strictly precedes the end of `other` by a value >= `epsilon_s`.
+::
              [ this ]
              [    other    ]
 The converse would be ``other.begins(this)``
 )docstring")
         .def("finishes", (bool (TimeRange::*)(RationalTime, double) const) &TimeRange::finishes, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The end of :param:`this` strictly equals :param:`other`.
+The end of `this` strictly equals `other`.
+::
                   other
                     ↓
                     *
              [ this ]
 )docstring")
         .def("finishes", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::finishes, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The start of :param:`this` strictly antecedes the start of :param:`other` by a value >= :param:`epsilon_s`.
-The end of :param:`this` strictly equals the end of :param:`other`.
+The start of `this` strictly antecedes the start of `other` by a value >= `epsilon_s`.
+The end of `this` strictly equals the end of `other`.
+::
                      [ this ]
              [     other    ]
 The converse would be ``other.finishes(this)``
 )docstring")
         .def("intersects", (bool (TimeRange::*)(TimeRange, double) const) &TimeRange::intersects, "other"_a, "epsilon_s"_a=opentime::DEFAULT_EPSILON_s, R"docstring(
-The start of :param:`this` precedes or equals the end of :param:`other` by a value >= :param:`epsilon_s`.
-The end of :param:`this` antecedes or equals the start of :param:`other` by a value >= :param:`epsilon_s`.
+The start of `this` precedes or equals the end of `other` by a value >= `epsilon_s`.
+The end of `this` antecedes or equals the start of `other` by a value >= `epsilon_s`.
+::
         [    this    ]           OR      [    other    ]
              [     other    ]                    [     this    ]
 The converse would be ``other.finishes(this)``


### PR DESCRIPTION
Also re-arranged the overloaded definitions so the TimeRange/RationalTime variants would have consistent ordering.

Here is a summary of what the docstrings in python look like now:
```
 |  before(...)
 |      before(*args, **kwargs)
 |      Overloaded function.
 |
 |      1. before(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.RationalTime, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The end of :param:`this` strictly precedes :param:`other` by a value >= :param:`epsilon_s`.
 |                             other
 |                               ↓
 |                   [ this ]    *
 |
 |
 |      2. before(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The end of :param:`this` strictly equals the start of :param:`other` and
 |      the start of :param:`this` strictly equals the end of :param:`other`.
 |                   [this][other]
 |      The converse would be ``other.meets(this)``
 |
 |  begins(...)
 |      begins(*args, **kwargs)
 |      Overloaded function.
 |
 |      1. begins(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.RationalTime, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The start of :param:`this` strictly equals :param:`other`.
 |                 other
 |                   ↓
 |                   *
 |                   [ this ]
 |
 |
 |      2. begins(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The start of :param:`this` strictly equals the start of :param:`other`.
 |      The end of :param:`this` strictly precedes the end of :param:`other` by a value >= :param:`epsilon_s`.
 |                   [ this ]
 |                   [    other    ]
 |      The converse would be ``other.begins(this)``
 |
 |  contains(...)
 |      contains(*args, **kwargs)
 |      Overloaded function.
 |
 |      1. contains(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.RationalTime) -> bool
 |
 |
 |      The start of :para:`this` precedes :param:`other`.
 |      :param:`other` precedes the end of this.
 |                          other
 |                            ↓
 |                            *
 |                    [      this      ]
 |
 |
 |      2. contains(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The start of :param:`this` precedes start of :param:`other`.
 |      The end of :param:`this` antecedes end of :param:`other`.
 |                        [ other ]
 |                   [      this      ]
 |      The converse would be ``other.contains(this)``
 |
 |  finishes(...)
 |      finishes(*args, **kwargs)
 |      Overloaded function.
 |
 |      1. finishes(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.RationalTime, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The end of :param:`this` strictly equals :param:`other`.
 |                        other
 |                          ↓
 |                          *
 |                   [ this ]
 |
 |
 |      2. finishes(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The start of :param:`this` strictly antecedes the start of :param:`other` by a value >= :param:`epsilon_s`.
 |      The end of :param:`this` strictly equals the end of :param:`other`.
 |                           [ this ]
 |                   [     other    ]
 |      The converse would be ``other.finishes(this)``
 |
 |  intersects(...)
 |      intersects(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The start of :param:`this` precedes or equals the end of :param:`other` by a value >= :param:`epsilon_s`.
 |      The end of :param:`this` antecedes or equals the start of :param:`other` by a value >= :param:`epsilon_s`.
 |              [    this    ]           OR      [    other    ]
 |                   [     other    ]                    [     this    ]
 |      The converse would be ``other.finishes(this)``
 |
 |  meets(...)
 |      meets(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The end of :param:`this` strictly equals the start of :param:`other` and
 |      the start of :param:`this` strictly equals the end of :param:`other`.
 |                   [this][other]
 |      The converse would be ``other.meets(this)``
 |
 |  overlaps(...)
 |      overlaps(*args, **kwargs)
 |      Overloaded function.
 |
 |      1. overlaps(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.RationalTime) -> bool
 |
 |
 |      :param:`this` contains :param:`other`.
 |                        other
 |                         ↓
 |                         *
 |                   [    this    ]
 |
 |
 |      2. overlaps(self: opentimelineio._opentime.TimeRange, other: opentimelineio._opentime.TimeRange, epsilon_s: float = 2.6041666666666666e-06) -> bool
 |
 |
 |      The start of :param:`this` strictly precedes end of :param:`other` by a value >= :param:`epsilon_s`.
 |      The end of :param:`this` strictly antecedes start of :param:`other` by a value >= :param:`epsilon_s`.
 |                   [ this ]
 |                       [ other ]
 |      The converse would be ``other.overlaps(this)``
```