### PR TITLE
Update doc string for otio.algorithms.track_with_expanded_transitions()

### DIFF
--- a/src/py-opentimelineio/opentimelineio/algorithms/track_algo.py
+++ b/src/py-opentimelineio/opentimelineio/algorithms/track_algo.py
@@ -96,10 +96,11 @@ def track_with_expanded_transitions(in_track):
         Clip1, T, Clip2
 
     will return:
-        Clip1', Clip1_t, T, Clip2_t, Clip2'
+        Clip1', (Clip1_t, T, Clip2_t), Clip2'
 
     Where Clip1' is the part of Clip1 not in the transition, Clip1_t is the
-    part inside the transition and so on.
+    part inside the transition and so on. Please note that the items used in
+    a transition are encapsulated in `tuple`s
     """
 
     result_track = []


### PR DESCRIPTION
Fixes #793

**Summarize your change.**

Updated doc string of `otio.algorithms.track_with_expanded_transitions()` to clarify that the returned list encapsulates the items in a transition in tuples
Please let me know if my wording is misleading or could be changed in any way.
 
**Reference associated tests.**

No tests need updating for this PR

<!--
For a step-by-step instructions on the pull request process, see
https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html
-->

