### PR TITLE
FIxed invalid timecode frame number error message

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -119,7 +119,7 @@ RationalTime::from_timecode(std::string const& timecode, double rate, ErrorStatu
     if (frames >= nominal_fps) {
         *error_status = ErrorStatus(ErrorStatus::TIMECODE_RATE_MISMATCH,
                                     string_printf("Frame rate mismatch.  Timecode '%s' has "
-                                                  "frames beyond %f", timecode.c_str(),
+                                                  "frames beyond %d", timecode.c_str(),
                                                   nominal_fps - 1));
         return RationalTime::_invalid_time;
     }

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -114,6 +114,16 @@ class TestTime(unittest.TestCase):
         t = otio.opentime.from_timecode(timecode, 24)
         self.assertEqual(timecode, otio.opentime.to_timecode(t))
 
+    def test_time_timecode_convert_bad_rate(self):
+        with self.assertRaises(ValueError) as exception_manager:
+            otio.opentime.from_timecode('01:00:13:24', 24)
+
+        exc_message = str(exception_manager.exception)
+        self.assertEqual(
+            exc_message,
+            "Frame rate mismatch.  Timecode '01:00:13:24' has frames beyond 23",
+        )
+
     def test_timecode_24(self):
         timecode = "00:00:01:00"
         t = otio.opentime.RationalTime(value=24, rate=24)


### PR DESCRIPTION
**Summarize your change.**

Fixed issue where invalid timecode rate error message would always say `has frames beyond 0.000000` rather than the correct maximum frame number.

This error tends to come up a lot when an incorrect rate is specified when parsing a CMX edl.

**Reference associated tests.**

Added a unittest to both ensure the `ValueError` is raised in this case and the helpful message is correctly generated.
