### PR TITLE
Implement subtitles schema [WIP]

### DIFF
--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -27,6 +27,9 @@ set(OPENTIMELINEIO_HEADER_FILES
     stack.h
     stackAlgorithm.h
     stringUtils.h
+    subtitles.h
+    timedText.h
+    timedTextStyle.h
     timeEffect.h
     timeline.h
     track.h
@@ -62,6 +65,9 @@ add_library(opentimelineio SHARED
             stack.cpp
             stackAlgorithm.cpp
             stringUtils.cpp
+            subtitles.cpp
+            timedText.cpp
+            timedTextStyle.cpp
             timeEffect.cpp
             timeline.cpp
             track.cpp

--- a/src/opentimelineio/subtitles.cpp
+++ b/src/opentimelineio/subtitles.cpp
@@ -1,0 +1,97 @@
+#include "opentimelineio/subtitles.h"
+
+namespace opentimelineio {
+    namespace OPENTIMELINEIO_VERSION {
+
+        Subtitles::Subtitles(float extent_x,
+                             float extent_y,
+                             float padding_x,
+                             float padding_y,
+                             std::string background_color,
+                             float background_opacity,
+                             DisplayAlignment display_alignment,
+                             std::vector<TimedText *> timed_texts)
+                : Parent(),
+                  _extent_x(extent_x),
+                  _extent_y(extent_y),
+                  _padding_x(padding_x),
+                  _padding_y(padding_y),
+                  _background_color(background_color),
+                  _background_opacity(background_opacity),
+                  _display_alignment(display_alignment),
+                  _timed_texts(timed_texts.begin(), timed_texts.end()) {
+        }
+
+        Subtitles::~Subtitles() noexcept {}
+
+        TimeRange Subtitles::available_range(ErrorStatus *) const {
+            TimeRange timeRange;
+            for (auto timed_text : _timed_texts) {
+                timeRange = timeRange.extended_by(timed_text.value->marked_range());
+            }
+            return timeRange;
+        }
+
+        bool Subtitles::read_from(Reader &reader) {
+            auto result = reader.read("extent_x", &_extent_x) &&
+                          reader.read("extent_y", &_extent_y) &&
+                          reader.read("padding_x", &_padding_x) &&
+                          reader.read("padding_y", &_padding_y) &&
+                          reader.read("background_color", &_background_color) &&
+                          reader.read("background_opacity", &_background_opacity) &&
+                          reader.read("timed_texts", &_timed_texts);
+            std::string display_alignment_value;
+            result = result && reader.read("display_alignment", &display_alignment_value);
+            if (!result) {
+                return result;
+            }
+
+            if (display_alignment_value == "before") {
+                _display_alignment = DisplayAlignment::before;
+            } else if (display_alignment_value == "after") {
+                _display_alignment = DisplayAlignment::after;
+            } else if (display_alignment_value == "center") {
+                _display_alignment = DisplayAlignment::justify;
+            } else if (display_alignment_value == "justify") {
+                _display_alignment = DisplayAlignment::justify;
+            } else {
+                // Unrecognized value
+                ErrorStatus error_status = ErrorStatus(ErrorStatus::JSON_PARSE_ERROR,
+                                                       "Unknown display_alignment: " + display_alignment_value);
+                reader.error(error_status);
+                return false;
+            }
+
+            return Parent::read_from(reader);
+        }
+
+        void Subtitles::write_to(Writer &writer) const {
+            Parent::write_to(writer);
+            writer.write("extent_x", _extent_x);
+            writer.write("extent_y", _extent_y);
+            writer.write("padding_x", _padding_x);
+            writer.write("padding_y", _padding_y);
+            writer.write("background_color", _background_color);
+            writer.write("background_opacity", _background_opacity);
+            writer.write("timed_texts", _timed_texts);
+
+            std::string display_alignment_value;
+            switch (_display_alignment) {
+                case DisplayAlignment::before:
+                    display_alignment_value = "before";
+                    break;
+                case DisplayAlignment::after:
+                    display_alignment_value = "after";
+                    break;
+                case DisplayAlignment::center:
+                    display_alignment_value = "center";
+                    break;
+                case DisplayAlignment::justify:
+                    display_alignment_value = "justify";
+                    break;
+            }
+            writer.write("display_alignment", display_alignment_value);
+        }
+
+    }
+}

--- a/src/opentimelineio/subtitles.h
+++ b/src/opentimelineio/subtitles.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "opentimelineio/version.h"
+#include "opentimelineio/item.h"
+#include "opentimelineio/timedText.h"
+
+namespace opentimelineio {
+    namespace OPENTIMELINEIO_VERSION {
+        class Subtitles : public Item {
+        public:
+            enum DisplayAlignment {
+                before = 0,
+                after = 1,
+                center = 2,
+                justify = 3
+            };
+
+            struct Schema {
+                static auto constexpr name = "Subtitles";
+                static int constexpr version = 1;
+            };
+
+            using Parent = Item;
+
+            Subtitles(float extent_x = 0.f,
+                      float extent_y = 0.f,
+                      float padding_x = 0.f,
+                      float padding_y = 0.f,
+                      std::string background_color = std::string(),
+                      float background_opacity = 0.f,
+                      DisplayAlignment display_alignment = DisplayAlignment::after,
+                      std::vector<TimedText *> timed_texts = std::vector<TimedText *>());
+
+            virtual TimeRange available_range(ErrorStatus *error_status) const;
+
+            float const extent_x() const {
+                return _extent_x;
+            }
+
+            void set_extent_x(float const extent_x) {
+                _extent_x = extent_x;
+            }
+
+            float const extent_y() const {
+                return _extent_y;
+            }
+
+            void set_extent_y(float const extent_y) {
+                _extent_y = extent_y;
+            }
+
+            float const padding_x() const {
+                return _padding_x;
+            }
+
+            void set_padding_x(float const padding_x) {
+                _padding_x = padding_x;
+            }
+
+            float const padding_y() const {
+                return _padding_y;
+            }
+
+            void set_padding_y(float const padding_y) {
+                _padding_y = padding_y;
+            }
+
+            std::string const &background_color() const {
+                return _background_color;
+            }
+
+            void set_background_color(std::string const &background_color) {
+                _background_color = background_color;
+            }
+
+            float const background_opacity() const {
+                return _background_opacity;
+            }
+
+            void set_background_opacity(float const background_opacity) {
+                _background_opacity = background_opacity;
+            }
+
+            DisplayAlignment const display_alignment() const {
+                return _display_alignment;
+            }
+
+            void set_display_alignment(DisplayAlignment const display_alignment) {
+                _display_alignment = display_alignment;
+            }
+
+        protected:
+            ~Subtitles();
+
+            virtual bool read_from(Reader &);
+
+            virtual void write_to(Writer &) const;
+
+        private:
+            float _extent_x;
+            float _extent_y;
+            float _padding_x;
+            float _padding_y;
+            std::string _background_color;
+            float _background_opacity;
+            DisplayAlignment _display_alignment;
+            std::vector<Retainer < TimedText>> _timed_texts;
+        };
+
+    }
+}

--- a/src/opentimelineio/timedText.cpp
+++ b/src/opentimelineio/timedText.cpp
@@ -1,0 +1,31 @@
+#include "opentimelineio/timedText.h"
+
+namespace opentimelineio {
+    namespace OPENTIMELINEIO_VERSION {
+
+        TimedText::TimedText(std::string const &text,
+                             RationalTime const &in_time,
+                             RationalTime const &out_time,
+                             TimedTextStyle *style)
+                : Parent(),
+                  _text(text),
+                  _style(style) {
+            set_marked_range(TimeRange::range_from_start_end_time(in_time, out_time));
+        }
+
+        TimedText::~TimedText() {}
+
+        bool TimedText::read_from(Reader &reader) {
+            return reader.read("text", &_text) &&
+                   reader.read("style", &_style) &&
+                   Parent::read_from(reader);
+        }
+
+        void TimedText::write_to(Writer &writer) const {
+            Parent::write_to(writer);
+            writer.write("text", _text);
+            writer.write("style", _style);
+        }
+
+    }
+}

--- a/src/opentimelineio/timedText.h
+++ b/src/opentimelineio/timedText.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "opentimelineio/version.h"
+#include "opentimelineio/marker.h"
+#include "opentimelineio/timedTextStyle.h"
+
+namespace opentimelineio {
+    namespace OPENTIMELINEIO_VERSION {
+
+        class TimedText : public Marker {
+        public:
+            struct Schema {
+                static auto constexpr name = "TimedText";
+                static int constexpr version = 1;
+            };
+
+            using Parent = Marker;
+
+            TimedText(std::string const &text = std::string(),
+                      RationalTime const &in_time = RationalTime(),
+                      RationalTime const &out_time = RationalTime(),
+                      TimedTextStyle *style = new TimedTextStyle());
+
+            std::string const &text() const {
+                return _text;
+            }
+
+            void set_text(std::string const &text) {
+                _text = text;
+            }
+
+            Retainer <TimedTextStyle> const style() const {
+                return _style;
+            }
+
+            void set_style(TimedTextStyle *style) {
+                _style = style;
+            }
+
+            RationalTime const in_time() const {
+                return marked_range().start_time();
+            }
+
+            RationalTime out_time() const {
+                return marked_range().end_time_inclusive();
+            }
+
+        protected:
+            ~TimedText();
+
+            virtual bool read_from(Reader &);
+
+            virtual void write_to(Writer &) const;
+
+        private:
+            std::string _text;
+            Retainer <TimedTextStyle> _style;
+        };
+
+    }
+}

--- a/src/opentimelineio/timedTextStyle.cpp
+++ b/src/opentimelineio/timedTextStyle.cpp
@@ -1,0 +1,52 @@
+#include "opentimelineio/timedTextStyle.h"
+
+namespace opentimelineio {
+    namespace OPENTIMELINEIO_VERSION {
+
+        TimedTextStyle::TimedTextStyle(const std::string &style_id,
+                                       std::string text_alignment,
+                                       std::string text_color,
+                                       float text_size,
+                                       bool text_bold,
+                                       bool text_italics,
+                                       bool text_underline,
+                                       std::string font_family)
+                : Parent(),
+                  _style_id(style_id),
+                  _text_alignment(text_alignment),
+                  _text_color(text_color),
+                  _text_size(text_size),
+                  _text_bold(text_bold),
+                  _text_italics(text_italics),
+                  _text_underline(text_underline),
+                  _font_family(font_family) {
+        }
+
+        TimedTextStyle::~TimedTextStyle() {}
+
+        bool TimedTextStyle::read_from(Reader &reader) {
+            return reader.read("style_id", &_style_id) &&
+                   reader.read("text_alignment", &_text_alignment) &&
+                   reader.read("text_color", &_text_color) &&
+                   reader.read("text_size", &_text_size) &&
+                   reader.read("text_bold", &_text_bold) &&
+                   reader.read("text_italics", &_text_italics) &&
+                   reader.read("text_underline", &_text_underline) &&
+                   reader.read("font_family", &_font_family) &&
+                   Parent::read_from(reader);
+        }
+
+        void TimedTextStyle::write_to(Writer &writer) const {
+            Parent::write_to(writer);
+            writer.write("style_id", _style_id);
+            writer.write("text_alignment", _text_alignment);
+            writer.write("text_color", _text_color);
+            writer.write("text_size", _text_size);
+            writer.write("text_bold", _text_bold);
+            writer.write("text_italics", _text_italics);
+            writer.write("text_underline", _text_underline);
+            writer.write("font_family", _font_family);
+        }
+
+    }
+}

--- a/src/opentimelineio/timedTextStyle.h
+++ b/src/opentimelineio/timedTextStyle.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "opentimelineio/version.h"
+#include "opentimelineio/serializableObjectWithMetadata.h"
+#include "opentimelineio/marker.h"
+
+namespace opentimelineio {
+    namespace OPENTIMELINEIO_VERSION {
+
+        class TimedTextStyle : public SerializableObject {
+        public:
+            struct TextAlignment {
+                static auto constexpr left = "LEFT";
+                static auto constexpr top = "TOP";
+                static auto constexpr right = "RIGHT";
+                static auto constexpr bottom = "BOTTOM";
+                static auto constexpr center = "CENTER";
+            };
+
+            struct Schema {
+                static auto constexpr name = "TimedTextStyle";
+                static int constexpr version = 1;
+            };
+
+            using Parent = SerializableObject;
+
+            TimedTextStyle(std::string const &style_id = std::string(),
+                           std::string text_alignment = TextAlignment::bottom,
+                           std::string text_color = Marker::Color::black,
+                           float text_size = 10,
+                           bool text_bold = false,
+                           bool text_italics = false,
+                           bool text_underline = false,
+                           std::string font_family = std::string());
+
+            std::string const &style_id() const {
+                return _style_id;
+            }
+
+            void set_style_id(std::string const &style_id) {
+                _style_id = style_id;
+            }
+
+            std::string const &text_alignment() const {
+                return _text_alignment;
+            }
+
+            void set_text_alignment(std::string const &text_alignment) {
+                _text_alignment = text_alignment;
+            }
+
+            std::string const &text_color() const {
+                return _text_color;
+            }
+
+            void set_text_color(std::string const &text_color) {
+                _text_color = text_color;
+            }
+
+            float const text_size() const {
+                return _text_size;
+            }
+
+            void set_text_size(float const text_size) {
+                _text_size = text_size;
+            }
+
+            bool const is_text_bold() const {
+                return _text_bold;
+            }
+
+            void set_text_bold(bool const text_bold) {
+                _text_bold = text_bold;
+            }
+
+            bool const is_text_italicized() const {
+                return _text_italics;
+            }
+
+            void set_text_italicized(bool const text_italics) {
+                _text_italics = text_italics;
+            }
+
+            bool const is_text_underlined() const {
+                return _text_underline;
+            }
+
+            void set_text_underlined(bool const text_underline) {
+                _text_underline = text_underline;
+            }
+
+            std::string const &font_family() const {
+                return _font_family;
+            }
+
+            void set_font_family(std::string const &font_family) {
+                _font_family = font_family;
+            }
+
+        protected:
+            ~TimedTextStyle();
+
+            virtual bool read_from(Reader &);
+
+            virtual void write_to(Writer &) const;
+
+        private:
+            std::string _text_color;
+            std::string _style_id;
+            std::string _text_alignment;
+            float _text_size;
+            bool _text_bold;
+            bool _text_italics;
+            bool _text_underline;
+            std::string _font_family;
+        };
+
+    }
+}


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Closes #62 

**Summarize your change.**

This PR adds basic support for Subtitles. I've based it on what I understood from TTML2 and from my experience with Premiere Pro. I've summarized the changes in the issue (#62). Here's an image summarizing the changes (Note change: `SerializableObject` instead of `SerializableObjectWithMetadata`):

![image](https://user-images.githubusercontent.com/35020024/94196501-11984300-fed2-11ea-9fdd-f14a277690df.png)

Some concerns:

- I think storing a `Style` object with each `TimedText` is wasteful, but decided to have this approach because we don't have id system in otio yet. In TTML2 there's a section to specify all styles and then refer then in each TimedText. With the current approach conversion from otio to say TTML2 won't be so direct because we don't have a single set of styles. One other thing I thought of was to have a list of styles inside `Subtitle` and then have a string id in each `TimedText`. But then each `TimedText` object will have no style meaning independently/outside the Subtitle. Thoughts?

- What are `Markers` used for? Each marker has a markedRange. When we trim an `Item` or change the sourceRange shouldn't the markedRange of the markers at the start or end of the `Item` also change? I couldn't find anything that does something like this. Or is this handled in another way? Why I'm asking is if we trim the `Subtitle` or change its sourceRange, the ranges of `TimedTexts` at the start or end might change. 

**Reference associated tests.**

Will be added later.

<!--
For a step-by-step instructions on the pull request process, see
https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html
-->

