### PR TITLE
Update flatten_video_tracks.py to use deepcopy.

### DIFF
--- a/examples/flatten_video_tracks.py
+++ b/examples/flatten_video_tracks.py
@@ -25,6 +25,7 @@
 
 import opentimelineio as otio
 import sys
+import copy
 
 inputpath, outputpath = sys.argv[1:]
 
@@ -49,7 +50,7 @@ newtimeline = otio.schema.Timeline(name="{} Flattened".format(timeline.name))
 newtimeline.tracks[:] = [onetrack]
 
 # keep the audio track(s) as-is
-newtimeline.tracks.extend(audio_tracks)
+newtimeline.tracks.extend(copy.deepcopy(audio_tracks))
 
 # ...and save it to disk.
 print("Saving {} video tracks and {} audio tracks.".format(


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

```Fixes #811 ```

**Summarize your change.**

Now the example uses deepcopy when splicing the audio tracks into the output timeline.

**Reference associated tests.**

There are no tests for the code in the `examples/` folder.
