### PR TITLE
Python 3 deprecation fixes (including Python 3.9 support)

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -32,7 +32,11 @@ import os
 import sys
 import numbers
 import copy
-import collections
+try:
+    # Python 3.3+
+    import collections.abc as abc
+except ImportError:
+    import collections as abc
 import fractions
 import opentimelineio as otio
 
@@ -552,7 +556,7 @@ def _transcribe(item, parents, edit_rate, indent=0):
     #     elif isinstance(item, pyaaf.AxProperty):
     #         self.properties['Value'] = str(item.GetValue())
 
-    elif isinstance(item, collections.Iterable):
+    elif isinstance(item, abc.Iterable):
         msg = "Creating SerializableCollection for Iterable for {}".format(
             _encoded_name(item))
         _transcribe_log(msg, indent)

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_utils.h
@@ -124,7 +124,8 @@ struct MutableSequencePyAPI : public V {
 
         pybind11::class_<This::Iterator>(m, (name + "Iterator").c_str())
             .def("__iter__", &This::Iterator::iter)
-            .def("next", &This::Iterator::next);
+            .def("next", &This::Iterator::next)
+            .def("__next__", &This::Iterator::next);
 
         pybind11::class_<This>(m, name.c_str())
             .def(pybind11::init<>())

--- a/src/py-opentimelineio/opentimelineio/adapters/adapter.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/adapter.py
@@ -40,6 +40,13 @@ from .. import (
 )
 
 
+try:
+    # Python 3.0+
+    getargspec = inspect.getfullargspec
+except AttributeError:
+    getargspec = inspect.getargspec
+
+
 @core.register_type
 class Adapter(plugins.PythonPlugin):
     """Adapters convert between OTIO and other formats.
@@ -307,7 +314,7 @@ class Adapter(plugins.PythonPlugin):
                 for fn_name in _FEATURE_MAP[feature]:
                     if hasattr(self.module(), fn_name):
                         fn = getattr(self.module(), fn_name)
-                        args = inspect.getargspec(fn)
+                        args = getargspec(fn)
                         docs = inspect.getdoc(fn)
                         break
 

--- a/src/py-opentimelineio/opentimelineio/core/_core_utils.py
+++ b/src/py-opentimelineio/opentimelineio/core/_core_utils.py
@@ -1,5 +1,9 @@
 import types
-import collections
+try:
+    # Python 3.3+
+    import collections.abc as abc
+except ImportError:
+    import collections as abc
 import copy
 import sys
 
@@ -46,7 +50,7 @@ else:
 
 
 def _is_nonstring_sequence(v):
-    return isinstance(v, collections.Sequence) and not _is_str(v)
+    return isinstance(v, abc.Sequence) and not _is_str(v)
 
 
 def _value_to_any(value, ids=None):
@@ -55,7 +59,7 @@ def _value_to_any(value, ids=None):
 
     if isinstance(value, SerializableObject):
         return PyAny(value)
-    if isinstance(value, collections.Mapping):
+    if isinstance(value, abc.Mapping):
         if ids is None:
             ids = set()
         d = AnyDictionary()
@@ -88,7 +92,7 @@ def _value_to_any(value, ids=None):
 
 
 def _value_to_so_vector(value, ids=None):
-    if not isinstance(value, collections.Sequence) or _is_str(value):
+    if not isinstance(value, abc.Sequence) or _is_str(value):
         raise TypeError(
             "Expected list/sequence of SerializableObjects;"
             " found type '{}'".format(type(value))
@@ -150,13 +154,13 @@ def _add_mutable_mapping_methods(mapClass):
         )
         return m
 
-    collections.MutableMapping.register(mapClass)
+    abc.MutableMapping.register(mapClass)
     mapClass.__setitem__ = __setitem__
     mapClass.__str__ = __str__
     mapClass.__repr__ = __repr__
 
     seen = set()
-    for klass in (collections.MutableMapping, collections.Mapping):
+    for klass in (abc.MutableMapping, abc.Mapping):
         for name in klass.__dict__.keys():
             if name in seen:
                 continue
@@ -217,7 +221,7 @@ def _add_mutable_sequence_methods(
         if not isinstance(index, slice):
             self.__internal_setitem__(index, conversion_func(item))
         else:
-            if not isinstance(item, collections.Iterable):
+            if not isinstance(item, abc.Iterable):
                 raise TypeError("can only assign an iterable")
 
             indices = range(*index.indices(len(self)))
@@ -225,7 +229,7 @@ def _add_mutable_sequence_methods(
             if index.step in (1, None):
                 if (
                         not side_effecting_insertions
-                        and isinstance(item, collections.MutableSequence)
+                        and isinstance(item, abc.MutableSequence)
                         and len(item) == len(indices)
                 ):
                     for i0, i in enumerate(indices):
@@ -254,7 +258,7 @@ def _add_mutable_sequence_methods(
                             self.extend(cached_items)
                             raise e
             else:
-                if not isinstance(item, collections.Sequence):
+                if not isinstance(item, abc.Sequence):
                     raise TypeError("can only assign a sequence")
                 if len(item) != len(indices):
                     raise ValueError(
@@ -292,7 +296,7 @@ def _add_mutable_sequence_methods(
             if conversion_func else item
         )
 
-    collections.MutableSequence.register(sequenceClass)
+    abc.MutableSequence.register(sequenceClass)
     sequenceClass.__radd__ = __radd__
     sequenceClass.__add__ = __add__
     sequenceClass.__getitem__ = __getitem__
@@ -303,7 +307,7 @@ def _add_mutable_sequence_methods(
     sequenceClass.__repr__ = __repr__
 
     seen = set()
-    for klass in (collections.MutableSequence, collections.Sequence):
+    for klass in (abc.MutableSequence, abc.Sequence):
         for name in klass.__dict__.keys():
             if name not in seen:
                 seen.add(name)


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

Addressed deprecation warning:
```
opentimelineio/core/_core_utils.py:220: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  if not isinstance(item, collections.Iterable):
```
We do this by importing `abc` from collections where available (Python 3.3+), otherwise we alias `collections` as `abc`.

This fixes OTIO in Python 3.9.

Also addressed:
- Add `__next__` (favored instead of `next` in Python 3.0+) - [PEP 3114](https://www.python.org/dev/peps/pep-3114/)
- Where available (Python 3.0+) use `inspect.getfullargspec` rather than `inspect.getargspec`

**Reference associated tests.**

Existing tests covered the use cases already, under Python 3.9 they were failing. I successfully ran the test suite in Python 3.9 locally and verified the deprecation warnings are no longer dropping to the shell in other versions.
