### PR TITLE
detect cycles

### DIFF
--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -36,7 +36,8 @@ struct ErrorStatus {
         CANNOT_COMPUTE_AVAILABLE_RANGE,
         INVALID_TIME_RANGE,
         OBJECT_WITHOUT_DURATION,
-        CANNOT_TRIM_TRANSITION
+        CANNOT_TRIM_TRANSITION,
+        OBJECT_CYCLE
     };
 
     ErrorStatus()

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_errorStatusHandler.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_errorStatusHandler.cpp
@@ -58,6 +58,8 @@ ErrorStatusHandler::~ErrorStatusHandler() noexcept(false) {
         throw _NotAChildException(full_details());
     case ErrorStatus::CANNOT_COMPUTE_AVAILABLE_RANGE:
         throw _CannotComputeAvailableRangeException(full_details());
+    case ErrorStatus::OBJECT_CYCLE:
+        throw py::value_error("Detected SerializableObject cycle while copying/serializing: " + details());
     default:
         throw py::value_error(full_details());
     }

--- a/tests/test_serializable_object.py
+++ b/tests/test_serializable_object.py
@@ -173,6 +173,29 @@ class SerializableObjTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         o = otio.core.SerializableObject()
         self.assertTrue(o)
 
+    def test_instancing_without_instancing_support(self):
+        o = otio.core.SerializableObjectWithMetadata()
+        c = otio.core.SerializableObjectWithMetadata()
+        o.metadata["child1"] = c
+        o.metadata["child2"] = c
+        self.assertTrue(o.metadata["child1"] is o.metadata["child2"])
+
+        oCopy = o.clone()
+        # Note: If we ever enable INSTANCING_SUPPORT in the C++ code,
+        # then this will (and should) fail
+        self.assertTrue(oCopy.metadata["child1"] is not oCopy.metadata["child2"])
+
+    def test_cycle_detection(self):
+        o = otio.core.SerializableObjectWithMetadata()
+        o.metadata["myself"] = o
+
+        # Note: If we ever enable INSTANCING_SUPPORT in the C++ code,
+        # then modify the code below to be:
+        #   oCopy = o.clone()
+        #   self.assertTrue(oCopy is oCopy.metadata["myself"])
+        with self.assertRaises(ValueError):
+            o.clone()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
```Fixes cycles in SerializableObjects cause crashes #847```

Modified the logic near #ifdef INSTANCING_SUPPORT to make use of the same table for checking for already encountered objects; however, because we only want to detect cycle and let mere instancing pass through (i.e. we don't demand things be a tree, we just demand they be acyclic) we remove an object from the table as we leave the function where we first encountered it.

In this way, we should be back to not being able to crash the system by writing bad Python code.

New tests (in tests.test_serializable_object.SerializableObjTest):
    test_instancing_without_instancing_support
    test_cycle_detection

