### PR TITLE
Hotfix/python cxx libs correct place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -135,8 +135,14 @@ class Install(install):
         self.cxx_install_root = ""
         install.initialize_options(self)
 
-    def move_cxx_to_root(self):
-        print("cxx_install_root `{}`".format(_ctx.cxx_install_root))
+    def cxx_to_root(self):
+        """
+        Moving content of `cxx-libs` to correct destination.
+
+        By default the CMake lib and bin dir are stored in
+        `opentimelineio/cxx-libs` but to be able to correctly import
+        all content should be living in root folder of `opentimelineio`.
+        """
         subdirs = ["lib", "bin"]
         dst_dir = os.path.dirname(_ctx.cxx_install_root)
         for subd in subdirs:
@@ -152,7 +158,9 @@ class Install(install):
         _ctx.install_usersite = self.install_usersite
         possibly_install(rerun_cmake=True)
         install.run(self)
-        self.move_cxx_to_root()
+
+        # move cxx files to opentimelineio root
+        self.cxx_to_root()
 
 
 class CMakeExtension(Extension):

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ For more information:
 import os
 import re
 import sys
+import shutil
 import platform
 import subprocess
 import unittest
@@ -97,6 +98,7 @@ def compute_cmake_args():
                 )
             cmake_args += ['-DCMAKE_INSTALL_PREFIX=' + cxxLibDir,
                            '-DOTIO_CXX_NOINSTALL:BOOL=ON']
+            _ctx.cxx_install_root = cxxLibDir
 
     cfg = 'Debug' if _ctx.debug else 'Release'
 
@@ -133,11 +135,24 @@ class Install(install):
         self.cxx_install_root = ""
         install.initialize_options(self)
 
+    def move_cxx_to_root(self):
+        print("cxx_install_root `{}`".format(self.cxx_install_root))
+        subdirs = ["lib", "bin"]
+        dst_dir = os.path.dirname(self.cxx_install_root)
+        for subd in subdirs:
+            src_dir = os.path.join(self.cxx_install_root, subd)
+            for file in os.listdir(src_dir):
+                src_path = os.path.join(src_dir, file)
+                dst_path = os.path.join(dst_dir, file)
+                print("Copy {} to {} ...".format(src_path, dst_path))
+                shutil.copy(src_path, dst_path)
+
     def run(self):
         _ctx.cxx_install_root = self.cxx_install_root
         _ctx.install_usersite = self.install_usersite
         possibly_install(rerun_cmake=True)
         install.run(self)
+        self.move_cxx_to_root()
 
 
 class CMakeExtension(Extension):

--- a/setup.py
+++ b/setup.py
@@ -136,11 +136,11 @@ class Install(install):
         install.initialize_options(self)
 
     def move_cxx_to_root(self):
-        print("cxx_install_root `{}`".format(self.cxx_install_root))
+        print("cxx_install_root `{}`".format(_ctx.cxx_install_root))
         subdirs = ["lib", "bin"]
-        dst_dir = os.path.dirname(self.cxx_install_root)
+        dst_dir = os.path.dirname(_ctx.cxx_install_root)
         for subd in subdirs:
-            src_dir = os.path.join(self.cxx_install_root, subd)
+            src_dir = os.path.join(_ctx.cxx_install_root, subd)
             for file in os.listdir(src_dir):
                 src_path = os.path.join(src_dir, file)
                 dst_path = os.path.join(dst_dir, file)


### PR DESCRIPTION
Fixes #667

**Summarize your change.**

There was not successful pip installation on windows platform (only one I was testing). The error mentioned in the above issue was persisting. Solution for us was to move all nested files from `cxx-libs` to root folder of `opentimelineio` in site-packages. The proposed solution is rather work-around as I realize this could be fixed in many more ways. Lets discourse I will be more then happy for any of your suggestion. 

- in `setup.py:Install` class was created function for `cxx_to_root` which is moving all content to module root
