### PR TITLE
Expose OTIO version numbers as integers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -288,6 +288,9 @@ PROJECT_METADATA = {
 
 METADATA_TEMPLATE = """
 __version__ = "{version}"
+__min_version__ = {major_version}
+__maj_version__ = {minor_version}
+__patch_version__ = "{patch_version}"
 __author__ = "{author}"
 __author_email__ = "{author_email}"
 __license__ = "{license}"
@@ -296,6 +299,16 @@ __license__ = "{license}"
 
 def _append_version_info_to_init_scripts(build_lib):
     """Stamp PROJECT_METADATA into __init__ files."""
+
+    # expose the maj, min, patch versions programmatically
+    version_tokens = PROJECT_METADATA["version"].split(".")
+    major_ver, minor_ver = [
+        int(v) for v in version_tokens[:2]
+    ]
+    patch_version = ".".join(version_tokens[2:])
+    PROJECT_METADATA["major_version"] = major_ver
+    PROJECT_METADATA["minor_version"] = minor_ver
+    PROJECT_METADATA["patch_version"] = patch_version
 
     for module, parentdir in [
             ("opentimelineio", "src/py-opentimelineio"),


### PR DESCRIPTION
### Issue
Fixes #844 

### Description
Adds the major, minor and patch versions of OTIO as integers
and strings metadata so that they can be accessed on the `otio`
module, like this:

```
>>> import opentimelineio as otio
>>> otio.__maj_version__
0
>>> otio.__min_version__
14
>>> otio.__patch_version__
'0.dev1'
```

### Tests
I haven't added any tests since I wasn't sure if it was worth?
It's my understanding that right now the PROJECT_METADATA["version"] is set manually, so maybe it could be useful if we could avoid somebody potentially using a wrong formatting and messing up the `setup.py` ?