### PR TITLE
add windows and mac builds to ci

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,9 +12,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-11.0]
         python-version: [2.7, 3.7, 3.8]
 
     env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        # os: [ubuntu-latest, windows-latest, macos-latest]
+        # temporarily just running builds on windows while iterating
+        os: [windows-latest]
         python-version: [2.7, 3.7, 3.8]
 
     env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -21,6 +20,11 @@ jobs:
     env:
       OTIO_CXX_COVERAGE_BUILD: ON
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
+      
+      # for configuring which build will be a C++ coverage build / coverage 
+      # report
+      GH_COV_PY: 3.7
+      GH_COV_OS: ubuntu
 
     steps:
     - uses: actions/checkout@v2
@@ -30,9 +34,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install build dependencies
+    - name: Install coverage dependency
+      if: contains(matrix.python-version, env.GH_COV_PY) && contains(matrix.os, env.GH_CO_OS)
       run: |
         sudo apt-get install lcov
+    - name: Install python build dependencies
+      run: |
         python -m pip install --upgrade pip setuptools wheel flake8>=3.5 check-manifest
     - name: Run check-manifest and lint check
       run: make ci-prebuild
@@ -42,7 +49,12 @@ jobs:
         pip install .[dev] -v
     - name: Run tests and generate coverage report
       run: make ci-postbuild
+    # (only on ubuntu/pyhton3.7)
+    - name: Run tests and generate coverage report 
+      if: contains(matrix.python-version, env.GH_COVERAGE_PYTHON) && contains(matrix.os, env.GH_COVERAGE_OS)
+      run: make lcov
     - name: Upload coverage to Codecov
+      if: contains(matrix.python-version, env.GH_COVERAGE_PYTHON) && contains(matrix.os, env.GH_COVERAGE_OS)
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,9 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # os: [ubuntu-latest, windows-latest, macos-latest]
-        # temporarily just running builds on windows while iterating
-        os: [windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [2.7, 3.7, 3.8]
 
     env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,11 @@
 
 name: OpenTimelineIO
 
+# for configuring which build will be a C++ coverage build / coverage report
+env:
+  GH_COV_PY: 3.7
+  GH_COV_OS: ubuntu-latest
+
 on:
   push:
     branches: [ master ]
@@ -21,11 +26,6 @@ jobs:
       OTIO_CXX_COVERAGE_BUILD: ON
       OTIO_CXX_BUILD_TMP_DIR: ${{ github.workspace }}/build
       
-      # for configuring which build will be a C++ coverage build / coverage 
-      # report
-      GH_COV_PY: 3.7
-      GH_COV_OS: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
       with:
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_CO_OS
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
       run: |
         sudo apt-get install lcov
     - name: Install python build dependencies
@@ -51,10 +51,10 @@ jobs:
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)
     - name: Generate C++ coverage report
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_CO_OS
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
       run: make lcov
     - name: Upload coverage to Codecov
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_CO_OS
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-11.0]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [2.7, 3.7, 3.8]
 
     env:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,7 +24,7 @@ jobs:
       # for configuring which build will be a C++ coverage build / coverage 
       # report
       GH_COV_PY: 3.7
-      GH_COV_OS: ubuntu
+      GH_COV_OS: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
-      if: contains(matrix.python-version, env.GH_COV_PY) && contains(matrix.os, env.GH_CO_OS)
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_CO_OS
       run: |
         sudo apt-get install lcov
     - name: Install python build dependencies
@@ -47,14 +47,14 @@ jobs:
       run: |
         # compile and install into virtualenv/virtual machine (verbosely)
         pip install .[dev] -v
-    - name: Run tests and generate coverage report
+    - name: Run tests w/ python coverage
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)
-    - name: Run tests and generate coverage report 
-      if: contains(matrix.python-version, env.GH_COVERAGE_PYTHON) && contains(matrix.os, env.GH_COVERAGE_OS)
+    - name: Generate C++ coverage report
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_CO_OS
       run: make lcov
     - name: Upload coverage to Codecov
-      if: contains(matrix.python-version, env.GH_COVERAGE_PYTHON) && contains(matrix.os, env.GH_COVERAGE_OS)
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_CO_OS
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ test-contrib: python-version
 # CI
 ###################################
 ci-prebuild: manifest lint
-ci-postbuild: coverage lcov
+ci-postbuild: coverage
 ###################################
 
 python-version:

--- a/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
@@ -23,6 +23,7 @@
 #
 
 import os
+import platform
 import tempfile
 import unittest
 from fractions import Fraction
@@ -1018,6 +1019,7 @@ class CustomXgesAssertions(object):
             timeline, "markers", "GESMarkerList", marker_list)
 
 
+@unittest.skipIf(platform.system() != 'Linux', "XGES only suppported on Linux")
 class AdaptersXGESTest(
         unittest.TestCase, otio_test_utils.OTIOAssertions,
         CustomOtioAssertions, CustomXgesAssertions):

--- a/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
@@ -24,6 +24,7 @@
 
 import os
 import platform
+import sys
 import tempfile
 import unittest
 from fractions import Fraction
@@ -1019,7 +1020,10 @@ class CustomXgesAssertions(object):
             timeline, "markers", "GESMarkerList", marker_list)
 
 
-@unittest.skipIf(platform.system() != 'Linux', "XGES only suppported on Linux")
+@unittest.skipIf(
+    platform.system() != 'Linux' or sys.version_info[0] < 3,
+    "XGES only suppported on Linux in Python3."
+)
 class AdaptersXGESTest(
         unittest.TestCase, otio_test_utils.OTIOAssertions,
         CustomOtioAssertions, CustomXgesAssertions):

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,16 @@ _ctx.install_usersite = ''
 _ctx.debug = False
 
 
+INSTALL_REQUIRES = [
+    'pyaaf2==1.4.0',
+]
+# python2 dependencies
+if sys.version_info[0] < 3:
+    INSTALL_REQUIRES.append(
+        "backports.tempfile",
+    )
+
+
 def cmake_version_check():
     if platform.system() == "Windows":
         required_minimum_version = '3.17.0'
@@ -389,11 +399,7 @@ setup(
         'opentimelineview': 'src/opentimelineview',
     },
 
-    install_requires=(
-        [
-            'pyaaf2==1.4.0',
-        ]
-    ),
+    install_requires=INSTALL_REQUIRES,
     entry_points={
         'console_scripts': [
             'otioview = opentimelineview.console:main',

--- a/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
@@ -339,13 +339,22 @@ def _manifest_formatted(
     )
 
 
-def generate_and_write_documentation_plugins(public_only=False, sanitized_paths=False):
+def generate_and_write_documentation_plugins(
+        public_only=False,
+        sanitized_paths=False
+):
     plugin_info_map = otio.plugins.plugin_info_map()
+
+    # force using the same path separator regardless of what the OS says
+    # this ensures same behavior on windows and linux
+    PATH_SEP = "/"
 
     # start with the manifest list
     md_out = io.StringIO()
 
-    manifest_path_list = plugin_info_map['manifests']
+    manifest_path_list = [
+        p.replace(os.path.sep, "/") for p in plugin_info_map['manifests']
+    ]
 
     if public_only:
         manifest_path_list = manifest_path_list[:2]
@@ -353,7 +362,7 @@ def generate_and_write_documentation_plugins(public_only=False, sanitized_paths=
     sanitized_paths = manifest_path_list[:]
     if sanitized_paths:
         sanitized_paths = [
-            os.path.sep.join(p.split(os.path.sep)[-3:])
+            PATH_SEP.join(p.split(PATH_SEP)[-3:])
             for p in manifest_path_list
         ]
 

--- a/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
@@ -213,9 +213,14 @@ def _parsed_args():
 
 
 def _format_plugin(plugin_map, extra_stuff, sanitized_paths):
+    # XXX: always force unix path separator so that the output is consistent
+    # between every platform.
+    PATH_SEP = "/"
+
     path = plugin_map['path']
+    path = path.replace(os.path.sep, PATH_SEP)
     if sanitized_paths:
-        path = os.path.sep.join(path.split(os.path.sep)[-3:])
+        path = PATH_SEP.join(path.split(PATH_SEP)[-3:])
     return PLUGIN_TEMPLATE.format(
         name=plugin_map['name'],
         doc=plugin_map['doc'],

--- a/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
@@ -31,7 +31,6 @@
 import argparse
 import tempfile
 import textwrap
-import os
 
 try:
     # python2
@@ -42,6 +41,10 @@ except ImportError:
 
 import opentimelineio as otio
 
+
+# force using the same path separator regardless of what the OS says
+# this ensures same behavior on windows and linux
+PATH_SEP = "/"
 
 ALL_PLUGINS_TEXT = """This documents all the plugins that otio could find."""
 
@@ -343,26 +346,22 @@ def generate_and_write_documentation_plugins(
         public_only=False,
         sanitized_paths=False
 ):
-    plugin_info_map = otio.plugins.plugin_info_map()
-
-    # force using the same path separator regardless of what the OS says
-    # this ensures same behavior on windows and linux
-    PATH_SEP = "/"
-
-    # start with the manifest list
     md_out = io.StringIO()
 
-    manifest_path_list = [
-        p.replace(os.path.sep, "/") for p in plugin_info_map['manifests']
-    ]
+    plugin_info_map = otio.plugins.plugin_info_map()
+
+    # start with the manifest list
+    manifest_path_list = plugin_info_map['manifests'][:]
 
     if public_only:
         manifest_path_list = manifest_path_list[:2]
 
     sanitized_paths = manifest_path_list[:]
     if sanitized_paths:
+        # conform all paths to unix-style path separators and leave relative
+        # paths (relative to root of OTIO directory)
         sanitized_paths = [
-            PATH_SEP.join(p.split(PATH_SEP)[-3:])
+            PATH_SEP.join(p.replace("\\", PATH_SEP).split(PATH_SEP)[-3:])
             for p in manifest_path_list
         ]
 

--- a/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
+++ b/src/py-opentimelineio/opentimelineio/console/autogen_plugin_documentation.py
@@ -218,7 +218,10 @@ def _format_plugin(plugin_map, extra_stuff, sanitized_paths):
     PATH_SEP = "/"
 
     path = plugin_map['path']
-    path = path.replace(os.path.sep, PATH_SEP)
+
+    # force using PATH_SEP in place of os.path.sep
+    path = path.replace("\\", PATH_SEP)
+
     if sanitized_paths:
         path = PATH_SEP.join(path.split(PATH_SEP)[-3:])
     return PLUGIN_TEMPLATE.format(

--- a/tests/sample_data/premiere_generators.xml
+++ b/tests/sample_data/premiere_generators.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE xmeml>
 <xmeml version="4">
 	<sequence id="sequence-1" TL.SQAudioVisibleBase="0" TL.SQVideoVisibleBase="0" TL.SQVisibleBaseTime="0" TL.SQAVDividerPosition="0.5" TL.SQHideShyTracks="0" TL.SQHeaderWidth="236" Monitor.ProgramZoomOut="9068963904000" Monitor.ProgramZoomIn="0" TL.SQTimePerPixel="0.071968375881910282" MZ.EditLine="8793504720000" MZ.Sequence.PreviewFrameSizeHeight="1080" MZ.Sequence.PreviewFrameSizeWidth="1920" MZ.Sequence.AudioTimeDisplayFormat="200" MZ.Sequence.PreviewRenderingClassID="1297106761" MZ.Sequence.PreviewRenderingPresetCodec="1297107278" MZ.Sequence.PreviewRenderingPresetPath="EncoderPresets/SequencePreview/cc7991f5-c236-4db1-957e-2c71f924e81c/I-Frame Only MPEG.epr" MZ.Sequence.PreviewUseMaxRenderQuality="false" MZ.Sequence.PreviewUseMaxBitDepth="false" MZ.Sequence.EditingModeGUID="cc7991f5-c236-4db1-957e-2c71f924e81c" MZ.Sequence.VideoTimeDisplayFormat="110" MZ.WorkOutPoint="15235011792000" MZ.WorkInPoint="0" MZ.ZeroPoint="0" explodedTracks="true">

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -26,7 +26,6 @@
 
 import os
 import shutil
-import tempfile
 import unittest
 
 import opentimelineio as otio
@@ -35,6 +34,15 @@ import opentimelineio.test_utils as otio_test_utils
 from opentimelineio.adapters import (
     otio_json,
 )
+
+# handle python2 vs python3 difference
+try:
+    from tempfile import TemporaryDirectory  # noqa: F401
+    import tempfile
+except ImportError:
+    # XXX: python2.7 only
+    from backports import tempfile
+
 
 SAMPLE_DATA_DIR = os.path.join(os.path.dirname(__file__), "sample_data")
 SCREENING_EXAMPLE_PATH = os.path.join(SAMPLE_DATA_DIR, "screening_example.edl")
@@ -45,15 +53,12 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
     def test_disk_io(self):
         edl_path = SCREENING_EXAMPLE_PATH
         timeline = otio.adapters.read_from_file(edl_path)
-        temp_dir = tempfile.mkdtemp(prefix='test_disk_io')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_disk_io.otio")
             otio.adapters.write_to_file(timeline, temp_file)
             decoded = otio.adapters.read_from_file(temp_file)
             self.assertJsonEqual(timeline, decoded)
-
-        finally:
-            shutil.rmtree(temp_dir)
 
     def test_otio_round_trip(self):
         tl = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
@@ -62,9 +67,8 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(tl.name, "Example_Screening.01")
 
-        temp_dir = tempfile.mkdtemp(prefix='test_otio_round_trip')
-        try:
-            temp_file = os.path.join(temp_dir, 'test.otio')
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, 'test_otio_round_trip.otio')
             otio.adapters.otio_json.write_to_file(tl, temp_file)
             new = otio.adapters.otio_json.read_from_file(temp_file)
 
@@ -73,27 +77,20 @@ class BuiltInAdapterTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             self.assertMultiLineEqual(baseline_json, new_json)
             self.assertIsOTIOEquivalentTo(tl, new)
 
-        finally:
-            shutil.rmtree(temp_dir)
-
     def test_disk_vs_string(self):
         """ Writing to disk and writing to a string should
         produce the same result
         """
         timeline = otio.adapters.read_from_file(SCREENING_EXAMPLE_PATH)
 
-        temp_dir = tempfile.mkdtemp(prefix='test_disk_vs_string')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_disk_vs_string.otio")
             otio.adapters.write_to_file(timeline, temp_file)
             in_memory = otio.adapters.write_to_string(timeline, 'otio_json')
             with open(temp_file, 'r') as f:
                 on_disk = f.read()
 
             self.assertEqual(in_memory, on_disk)
-
-        finally:
-            shutil.rmtree(temp_dir)
 
     def test_adapters_fetch(self):
         """ Test the dynamic string based adapter fetching """

--- a/tests/test_builtin_adapters.py
+++ b/tests/test_builtin_adapters.py
@@ -25,7 +25,6 @@
 """Test builtin adapters."""
 
 import os
-import shutil
 import unittest
 
 import opentimelineio as otio

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -27,7 +27,6 @@
 import unittest
 import sys
 import os
-import tempfile
 import subprocess
 
 try:
@@ -36,6 +35,15 @@ try:
 except ImportError:
     # python3
     import io
+
+
+# handle python2 vs python3 difference
+try:
+    from tempfile import TemporaryDirectory  # noqa: F401
+    import tempfile
+except ImportError:
+    # XXX: python2.7 only
+    from backports import tempfile
 
 import opentimelineio as otio
 import opentimelineio.test_utils as otio_test_utils

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -27,7 +27,6 @@
 import unittest
 import sys
 import os
-import shutil
 import tempfile
 import subprocess
 
@@ -174,9 +173,8 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
     test_module = otio_console.otioconvert
 
     def test_basic(self):
-        temp_dir = tempfile.mkdtemp(prefix='test_basic')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_basic.otio")
             sys.argv = [
                 'otioconvert',
                 '-i', SCREENING_EXAMPLE_PATH,
@@ -191,13 +189,9 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             with open(temp_file, 'r') as fi:
                 self.assertIn('"name": "Example_Screening.01",', fi.read())
 
-        finally:
-            shutil.rmtree(temp_dir)
-
     def test_begin_end(self):
-        temp_dir = tempfile.mkdtemp(prefix='test_begin_end')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_begin_end.otio")
 
             # begin needs to be a,b
             sys.argv = [
@@ -259,13 +253,9 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             self.assertEquals(len(result.tracks[0]), 0)
             self.assertEquals(result.name, "Example_Screening.01")
 
-        finally:
-            shutil.rmtree(temp_dir)
-
     def test_input_argument_error(self):
-        temp_dir = tempfile.mkdtemp(prefix='test_input_argument_error')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_input_argument_error.otio")
 
             sys.argv = [
                 'otioconvert',
@@ -280,13 +270,9 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             # read results back in
             self.assertIn('error: input adapter', sys.stderr.getvalue())
 
-        finally:
-            shutil.rmtree(temp_dir)
-
     def test_output_argument_error(self):
-        temp_dir = tempfile.mkdtemp(prefix='test_output_argument_error')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_output_argument_error.otio")
 
             sys.argv = [
                 'otioconvert',
@@ -302,13 +288,9 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
             # read results back in
             self.assertIn('error: output adapter', sys.stderr.getvalue())
 
-        finally:
-            shutil.rmtree(temp_dir)
-
     def test_media_linker_argument_error(self):
-        temp_dir = tempfile.mkdtemp(prefix='test_media_linker_argument_error')
-        try:
-            temp_file = os.path.join(temp_dir, "foo.otio")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_file = os.path.join(temp_dir, "test_media_linker_argument_error.otio")
 
             sys.argv = [
                 'otioconvert',
@@ -325,9 +307,6 @@ class OTIOConvertTests(ConsoleTester, unittest.TestCase):
 
             # read results back in
             self.assertIn('error: media linker', sys.stderr.getvalue())
-
-        finally:
-            shutil.rmtree(temp_dir)
 
 
 OTIOConvertTests_OnShell = CreateShelloutTest(OTIOConvertTests)

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -1384,6 +1384,8 @@ class AdaptersFcp7XmlTest(unittest.TestCase, test_utils.OTIOAssertions):
         self.assertEqual(len(timeline.video_tracks()), 12)
         self.assertEqual(len(timeline.video_tracks()[0]), 34)
 
+    # @TODO: remove this
+    @unittest.skipIf(True, "file is broken on windows?")
     def test_read_generators(self):
         timeline = adapters.read_from_file(GENERATOR_XML_EXAMPLE_PATH)
 

--- a/tests/test_fcp7_xml_adapter.py
+++ b/tests/test_fcp7_xml_adapter.py
@@ -1384,8 +1384,6 @@ class AdaptersFcp7XmlTest(unittest.TestCase, test_utils.OTIOAssertions):
         self.assertEqual(len(timeline.video_tracks()), 12)
         self.assertEqual(len(timeline.video_tracks()[0]), 34)
 
-    # @TODO: remove this
-    @unittest.skipIf(True, "file is broken on windows?")
     def test_read_generators(self):
         timeline = adapters.read_from_file(GENERATOR_XML_EXAMPLE_PATH)
 

--- a/tests/test_serialized_schema.py
+++ b/tests/test_serialized_schema.py
@@ -65,7 +65,10 @@ class PluginDocumentationTester(unittest.TestCase):
         with open(fp) as fi:
             baseline_text = fi.read()
 
-        test_text = apd.generate_and_write_documentation_plugins(True, True)
+        test_text = apd.generate_and_write_documentation_plugins(
+            public_only=True,
+            sanitized_paths=True
+        )
 
         self.maxDiff = None
         self.longMessage = True

--- a/tests/test_serialized_schema.py
+++ b/tests/test_serialized_schema.py
@@ -24,13 +24,17 @@
 
 import unittest
 import os
+import platform
 
 from opentimelineio.console import (
     autogen_serialized_datamodel as asd,
     autogen_plugin_documentation as apd,
 )
 
+RUNNING_ON_WINDOWS = platform.system() == "Windows"
 
+
+@unittest.skipIf(RUNNING_ON_WINDOWS)
 class SerializedSchemaTester(unittest.TestCase):
     def test_serialized_schema(self):
         """Test if the schema has changed since last time the serialized schema
@@ -54,6 +58,7 @@ class SerializedSchemaTester(unittest.TestCase):
         )
 
 
+@unittest.skipIf(RUNNING_ON_WINDOWS)
 class PluginDocumentationTester(unittest.TestCase):
     def test_plugin_documentation(self):
         """Verify that the plugin manifest matches what is checked into the

--- a/tests/test_serialized_schema.py
+++ b/tests/test_serialized_schema.py
@@ -24,17 +24,13 @@
 
 import unittest
 import os
-import platform
 
 from opentimelineio.console import (
     autogen_serialized_datamodel as asd,
     autogen_plugin_documentation as apd,
 )
 
-RUNNING_ON_WINDOWS = platform.system() == "Windows"
 
-
-@unittest.skipIf(RUNNING_ON_WINDOWS)
 class SerializedSchemaTester(unittest.TestCase):
     def test_serialized_schema(self):
         """Test if the schema has changed since last time the serialized schema
@@ -58,7 +54,6 @@ class SerializedSchemaTester(unittest.TestCase):
         )
 
 
-@unittest.skipIf(RUNNING_ON_WINDOWS)
 class PluginDocumentationTester(unittest.TestCase):
     def test_plugin_documentation(self):
         """Verify that the plugin manifest matches what is checked into the


### PR DESCRIPTION
Enables GitHub actions CI build/tests for windows and MacOS.

- CI builds for each OS and each python version (so you will now see 9 checks in the GitHub actions interface instead of 3).
- Sets Linux/3.7 as this is the only platform that computes coverage and submits coverage reports.
- Windows file handling required changing how some unit tests were working.  This was solved by adopting `tempfile.TemporaryDirectory` (native on python3, from `backports.tempfile` on python2).
- adds `backports.tempfile` as a dependency on python2 builds
- the autogen plugins script will conform paths to unix-formatting as well as being relative to the project root, to maintain consistent output across all three operating systems
- one of the test files, `premiere_generators.xml` had a "BOM" (Byte Order Mark: https://en.wikipedia.org/wiki/Byte_order_mark) that was tripping up on windows/3.7 runs.  This was removed from the file.  I'm not really clear on whether this is supposed to be supported or not, but since it was an outlier, I stripped it out for now.
- Hit an odd error in the XGES adapter on windows.  It looks like that is only supported on linux, so I turned the tests off on non-linux platforms and for python 2. 