### PR TITLE
add a --version flag to otiopluginfo + otioconvert

### DIFF
--- a/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
+++ b/src/py-opentimelineio/opentimelineio/console/otiopluginfo.py
@@ -30,6 +30,11 @@ import fnmatch
 import textwrap
 import opentimelineio as otio
 
+# on some python interpreters, pkg_resources is not available
+try:
+    import pkg_resources
+except ImportError:
+    pkg_resources = None
 
 OTIO_PLUGIN_TYPES = ['all'] + otio.plugins.manifest.OTIO_PLUGIN_TYPES
 
@@ -77,6 +82,15 @@ def _parsed_args():
         default='*',
         nargs='?',
         help='Only print information about plugins that match this glob.'
+    )
+    parser.add_argument(
+        '--version',
+        default=False,
+        action="store_true",
+        help=(
+            "Print the otio and pkg_resource installed plugin version "
+            "information to the commandline."
+        ),
     )
 
     return parser.parse_args()
@@ -184,6 +198,21 @@ def main():
 
     # load all the otio plugins
     active_plugin_manifest = otio.plugins.ActiveManifest()
+
+    # print version information to the shell
+    if args.version:
+        print("OpenTimelineIO version: {}".format(otio.__version__))
+
+        if pkg_resources:
+            pkg_resource_plugins = list(
+                pkg_resources.iter_entry_points("opentimelineio.plugins")
+            )
+            if pkg_resource_plugins:
+                print("Plugins from pkg_resources:")
+                for plugin in pkg_resource_plugins:
+                    print("   {}".format(plugin.dist))
+            else:
+                print("No pkg_resource plugins installed.")
 
     # list the loaded manifests
     print("Manifests loaded:")


### PR DESCRIPTION
Adds a `--version` flag to `otiopluginfo` and `otioconvert`.  This:

- prints out the `__version__` string 
- searches for `pkg_resource` installed plugins, and prints out their dist info (which includes their version numbers)

Question for the community:  After seeing this I kind of wish there was a way to also burn the git commit hash into the repo some how.  Not sure if thats useful, but it something we could potentially do when we burn the version numbers in.

Output looks like this:

```
> otioconvert --version
OpenTimelineIO version: 0.14.0.dev1
No pkg_resource plugins installed.
```