### PR TITLE
Support --prefix correctly in new cmake system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if(OTIO_PYTHON_INSTALL)
             # In order to not require setting $PYTHONPATH to point at the .so,
             # the shared libraries are installed into the python library 
             # location.
-            set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
+            set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
             message(INFO, "OTIO Defaulting Python install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
             message(INFO, "Note: C++ linkable-shared libraries can be found: ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,13 +45,13 @@ if(OTIO_PYTHON_INSTALL)
     #
     # if nothing has been set, 
     #   Python: ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio
-    #   C++:    ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-libs
+    #   C++:    ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk
     # if only CMAKE_INSTALL_PREFIX has been set,
     #   Python: ${CMAKE_INSTALL_PREFIX}/opentimelineio/python
     #   C++:    ${CMAKE_INSTALL_PREFIX}/opentimelineio
     # if only OTIO_PYTHON_INSTALL_DIR has been set,
     #   Python: ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio
-    #   C++:    ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio/cxx-libs
+    #   C++:    ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk
     #
     # In a python install, the dylibs/dlls need to be installed where __init.py
     # can find them, rather as part of the C++ sdk package; so the variable 
@@ -61,7 +61,7 @@ if(OTIO_PYTHON_INSTALL)
         # neither install directory supplied from the command line
         find_package(Python REQUIRED COMPONENTS Interpreter Development)
         set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
-        set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-libs")
+        set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk")
         set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
         message(INFO, "OTIO Defaulting both Python and C++ install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
     else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ if(OTIO_PYTHON_INSTALL)
     # that default behaviors match a reasonable expectation, as follows:
     #
     # if nothing has been set, 
-    #   Python: ${Python_SITEARCH}/opentimelineio
-    #   C++:    ${Python_SITEARCH}/opentimelineio/cxx-libs
+    #   Python: ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio
+    #   C++:    ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-libs
     # if only CMAKE_INSTALL_PREFIX has been set,
     #   Python: ${CMAKE_INSTALL_PREFIX}/opentimelineio/python
     #   C++:    ${CMAKE_INSTALL_PREFIX}/opentimelineio
@@ -60,19 +60,13 @@ if(OTIO_PYTHON_INSTALL)
     if(OTIO_PYTHON_INSTALL_DIR STREQUAL "" AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
         # neither install directory supplied from the command line
         find_package(Python REQUIRED COMPONENTS Interpreter Development)
-        set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${Python_SITEARCH}")
-        set(OTIO_RESOLVED_CXX_INSTALL_DIR "${Python_SITEARCH}/opentimelineio/cxx-libs")
-        set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${Python_SITEARCH}/opentimelineio")
+        set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
+        set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-libs")
+        set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
         message(INFO, "OTIO Defaulting both Python and C++ install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
     else()
         # either python_install or install_prefix have been set
-        if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-            # OTIO_PYTHON_INSTALL_DIR was set, so install everything into the python package
-            set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}")
-            set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio/lib")
-            set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
-            message(INFO, "OTIO Defaulting C++ install to ${OTIO_RESOLVED_CXX_INSTALL_DIR}")
-        else()
+        if(OTIO_PYTHON_INSTALL_DIR_INITIALIZED_TO_DEFAULT)
             # CMAKE_INSTALL_PREFIX was set, so install the python components there
             set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/python")
             set(OTIO_RESOLVED_CXX_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}")
@@ -82,7 +76,13 @@ if(OTIO_PYTHON_INSTALL)
             # location.
             set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
             message(INFO, "OTIO Defaulting Python install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
-            message(INFO, "Note: C++ linkable-shared libraries can be found: ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
+            message(INFO, "Note: C++ linkable-shared libraries can be found: ${CMAKE_INSTALL_PREFIX}/opentimelineio")
+        else()
+            # OTIO_PYTHON_INSTALL_DIR was set, so install everything into the python package
+            set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}")
+            set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk")
+            set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
+            message(INFO, "OTIO Defaulting C++ install to ${OTIO_PYTHON_INSTALL_DIR}")
         endif()
     endif()
 else()

--- a/setup.py
+++ b/setup.py
@@ -85,33 +85,30 @@ def cmake_generate():
         '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release')
     ]
 
+    python_inst_dir = get_python_lib()
+
     if PREFIX:
+        # XXX: is there a better way to find this?  This is the suffix from
+        # where it would have been installed pasted onto the PREFIX as passed
+        # in by --prefix.
         python_inst_dir = (
             distutils.sysconfig.get_python_lib().replace(sys.prefix, PREFIX)
         )
-        cmake_args += [
-            '-DOTIO_PYTHON_INSTALL_DIR=' + python_inst_dir,
-            (
-
-                '-DCMAKE_INSTALL_PREFIX='
-                + os.path.join(python_inst_dir, "opentimelineio", "cxx-sdk")
-            ),
-        ]
     elif "--user" in sys.argv:
-        cmake_args += [
-            '-DOTIO_PYTHON_INSTALL_DIR=' + _ctx.install_usersite,
-            '-DCMAKE_INSTALL_PREFIX=' + os.path.join(_ctx.install_usersite,
-                                                     "opentimelineio", "cxx-libs"),
-            '-DOTIO_PYTHON_PACKAGE_DIR=' + os.path.join(_ctx.install_usersite,
-                                                        "opentimelineio")
-        ]
-    else:
-        cmake_args += [
-            '-DOTIO_PYTHON_INSTALL_DIR=' + get_python_lib(),
-            '-DCMAKE_INSTALL_PREFIX=' + os.path.join(get_python_lib(),
-                                                     "opentimelineio", "cxx-libs"),
-            '-DOTIO_PYTHON_PACKAGE_DIR=' + get_python_lib()
-        ]
+        python_inst_dir = _ctx.install_usersite
+
+    # install the C++ into the opentimelineio/cxx-sdk directory under the
+    # python installation
+    cmake_install_prefix = os.path.join(
+        python_inst_dir,
+        "opentimelineio",
+        "cxx-sdk"
+    )
+
+    cmake_args += [
+        '-DOTIO_PYTHON_INSTALL_DIR=' + python_inst_dir,
+        '-DCMAKE_INSTALL_PREFIX=' + cmake_install_prefix,
+    ]
 
     if platform.system() == "Windows":
         if sys.maxsize > 2**32:

--- a/setup.py
+++ b/setup.py
@@ -86,17 +86,16 @@ def cmake_generate():
     ]
 
     if PREFIX:
+        python_inst_dir = (
+            distutils.sysconfig.get_python_lib().replace(sys.prefix, PREFIX)
+        )
         cmake_args += [
-            '-DOTIO_PYTHON_INSTALL_DIR=' + PREFIX,
+            '-DOTIO_PYTHON_INSTALL_DIR=' + python_inst_dir,
             (
 
                 '-DCMAKE_INSTALL_PREFIX='
-                + os.path.join(PREFIX, "opentimelineio", "cxx-libs")
+                + os.path.join(python_inst_dir, "opentimelineio", "cxx-sdk")
             ),
-            (
-                '-DOTIO_PYTHON_PACKAGE_DIR='
-                + os.path.join(PREFIX, "opentimelineio")
-            )
         ]
     elif "--user" in sys.argv:
         cmake_args += [
@@ -390,7 +389,7 @@ setup(
         ],
         'opentimelineio_contrib': [
             'adapters/contrib_adapters.plugin_manifest.json',
-        ]
+        ],
     },
 
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,14 @@ from distutils.version import LooseVersion
 import distutils
 
 
+# XXX: If there is a better way to find the value of --prefix, please notify
+#      the maintainers of OpenTimelineIO.
+_dist = distutils.dist.Distribution()
+_dist.parse_config_files()
+_dist.parse_command_line()
+PREFIX = _dist.get_option_dict('install').get('prefix', [None, None])[1]
+
+
 class _Ctx(object):
     pass
 
@@ -77,7 +85,20 @@ def cmake_generate():
         '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release')
     ]
 
-    if "--user" in sys.argv:
+    if PREFIX:
+        cmake_args += [
+            '-DOTIO_PYTHON_INSTALL_DIR=' + PREFIX,
+            (
+
+                '-DCMAKE_INSTALL_PREFIX='
+                + os.path.join(PREFIX, "opentimelineio", "cxx-libs")
+            ),
+            (
+                '-DOTIO_PYTHON_PACKAGE_DIR='
+                + os.path.join(PREFIX, "opentimelineio")
+            )
+        ]
+    elif "--user" in sys.argv:
         cmake_args += [
             '-DOTIO_PYTHON_INSTALL_DIR=' + _ctx.install_usersite,
             '-DCMAKE_INSTALL_PREFIX=' + os.path.join(_ctx.install_usersite,


### PR DESCRIPTION
Closes #885 

Refactors how the setup.py communicates target locations to the cmake so that `--prefix` and `--user` arguments are correctly handled.

*POTENTIALLY BREAKING CHANGE*: Now if installing via `pip`/`setup.py`, the C++ libraries are installed under the python install in a `cxx-sdk` instead of `cxx-libs` directory.

I'd like to note that the way of finding the _value_ of the `--prefix` argument is pretty gross. If there is a better/cleaner way, please let me know!