### PR TITLE
Fix Issue #881

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,12 +132,6 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-if(MSVC)
-	set(PYBIND11_CPP_STANDARD /std:c++11)
-else()
-	set(PYBIND11_CPP_STANDARD -std=c++11)
-endif()
-
 if(OTIO_CXX_COVERAGE AND NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
     # this causes cmake to produce file.gcno instead of file.cpp.gcno


### PR DESCRIPTION
not necessary to set C++11 flags for pybind11, that's already
handled by cmake's C++ standard settings.

Signed-off-by: Nick Porcino <nporcino@pixar.com>

**Link the Issue(s) this Pull Request is related to.**

Each PR should link at least one issue, in the form:

https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/881

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

**Summarize your change.**

Describe the reason for the change.

Add a list of changes, and note any that might need special attention during review.

**Reference associated tests.**

If no new tests are introduced as part of this PR, note the tests that are providing coverage.

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html
-->
