### PR TITLE
Fix ImageSequenceReference implicit cast

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import opentimelineio as otio
 
 timeline = otio.adapters.read_from_file("foo.aaf")
 for clip in timeline.each_clip():
-  print clip.name, clip.duration()
+  print(clip.name, clip.duration())
 ```
 
 There are more code examples here: https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/master/examples

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -87,7 +87,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         std::string image_num_string = std::to_string(abs(file_image_num));
 
         std::string zero_pad = std::string();
-        if (image_num_string.length() <  _frame_zero_padding) {
+        if (static_cast<int>(image_num_string.length()) <  _frame_zero_padding) {
             zero_pad = std::string(_frame_zero_padding - image_num_string.length(), '0');
         }
 


### PR DESCRIPTION
Fixed an implicit cast that would happen between a `size_t` and an `int`.

Also addressed a line in the README.md that wasn't Python 3 safe.

closes #774

co-authored by @zebulon75018