### PR TITLE
ImageSequenceReference: Added handling for empty target_url_base

### DIFF
--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -98,7 +98,8 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
 
         // If the base does not include a trailing slash, add it
         std::string path_sep = std::string();
-        if (_target_url_base.compare(_target_url_base.length() - 1, 1, "/") != 0) {
+        const auto target_url_base_len = _target_url_base.length();
+        if (target_url_base_len > 0 && _target_url_base.compare(target_url_base_len - 1, 1, "/") != 0) {
             path_sep = "/";
         }
 

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -675,4 +675,6 @@ class ImageSequenceReferenceTests(
             ),
         )
 
-        assert ref.target_url_for_image_number(0) == 'myfilename.0101.exr'
+        self.assertEqual(
+            ref.target_url_for_image_number(0), "myfilename.0101.exr"
+        )

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -661,3 +661,18 @@ class ImageSequenceReferenceTests(
             str(exception_manager.exception),
             "Zero rate sequence has no frames.",
         )
+
+    def test_target_url_for_image_number_with_blank_target_url_base(self):
+        ref = otio.schema.ImageSequenceReference(
+            name_prefix="myfilename.",
+            name_suffix=".exr",
+            start_frame=101,
+            rate=24,
+            frame_zero_padding=4,
+            available_range=otio.opentime.TimeRange(
+                otio.opentime.from_timecode("01:25:30:04", rate=24),
+                duration=otio.opentime.from_frames(48, 24)
+            ),
+        )
+
+        assert ref.target_url_for_image_number(0) == 'myfilename.0101.exr'


### PR DESCRIPTION
Fixes #890 


**Summarize your change.**

There was a check to see if `target_url_base` ended in a `/` to avoid having double-/ in constructed urls. This assumed `target_url_was of at lease length 1. Added a check to not attempt the check if the length is zero.

**Reference associated tests.**

Added test checking generation of bare filenames using `target_url_for_image_number`.
