### PR TITLE
Enable xges unit tests on all platform/python versions

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/tests_xges_adapter.py
@@ -23,13 +23,12 @@
 #
 
 import os
-import platform
-import sys
 import tempfile
 import unittest
 from fractions import Fraction
 from xml.etree import ElementTree
 
+from builtins import int
 import opentimelineio as otio
 import opentimelineio.test_utils as otio_test_utils
 from opentimelineio.schema import (
@@ -352,7 +351,7 @@ class CustomOtioAssertions(object):
         attr_str = ""
         val = otio_obj
         for attr_name in attr_path:
-            if type(attr_name) is int:
+            if isinstance(attr_name, int):
                 if not hasattr(val, "__getitem__"):
                     raise AssertionError(
                         "{}{} is not a list".format(
@@ -1020,10 +1019,6 @@ class CustomXgesAssertions(object):
             timeline, "markers", "GESMarkerList", marker_list)
 
 
-@unittest.skipIf(
-    platform.system() != 'Linux' or sys.version_info[0] < 3,
-    "XGES only suppported on Linux in Python3."
-)
 class AdaptersXGESTest(
         unittest.TestCase, otio_test_utils.OTIOAssertions,
         CustomOtioAssertions, CustomXgesAssertions):

--- a/contrib/opentimelineio_contrib/adapters/xges.py
+++ b/contrib/opentimelineio_contrib/adapters/xges.py
@@ -38,6 +38,7 @@ except ImportError:  # python2
     from urlparse import urlparse
     from urlparse import parse_qs
 
+from builtins import int
 from fractions import Fraction
 from xml.etree import ElementTree
 from xml.dom import minidom
@@ -3526,7 +3527,7 @@ class GESMarker(otio.core.SerializableObject):
 
     def set_color_from_argb(self, argb):
         """Set the color of the marker using the AARRGGBB hex value"""
-        if type(argb) is not int:
+        if not isinstance(argb, int):
             _wrong_type_for_arg(argb, "int", "argb")
         if argb < 0 or argb > 0xffffffff:
             raise InvalidValueError(
@@ -3669,15 +3670,8 @@ class GESMarkerList(otio.core.SerializableObject):
 
     def markers_at_position(self, position):
         """Return a list of markers with the given position"""
-        if type(position) is not int:
-            # TODO: remove below once python2 has ended
-            # currently in python2, can receive either an int or
-            # a long
-            if isinstance(position, numbers.Integral):
-                position = int(position)
-                # may still be an int if the position is too big
-            if type(position) is not int:
-                _wrong_type_for_arg(position, "int", "position")
+        if not isinstance(position, int):
+            _wrong_type_for_arg(position, "int", "position")
         return [mrk for mrk in self.markers if mrk.position == position]
 
     def __getitem__(self, index):
@@ -3731,7 +3725,7 @@ class XgesTrack(otio.core.SerializableObject):
             caps = GstCaps()
         if not isinstance(caps, GstCaps):
             _wrong_type_for_arg(caps, "GstCaps", "caps")
-        if type(track_type) is not int:
+        if not isinstance(track_type, int):
             _wrong_type_for_arg(track_type, "int", "track_type")
         if track_type not in GESTrackType.ALL_TYPES:
             raise InvalidValueError(

--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,11 @@ INSTALL_REQUIRES = [
 ]
 # python2 dependencies
 if sys.version_info[0] < 3:
-    INSTALL_REQUIRES.append(
-        "backports.tempfile",
+    INSTALL_REQUIRES.extend(
+        [
+            "backports.tempfile",
+            'future',  # enables the builtins module
+        ]
     )
 
 


### PR DESCRIPTION
After https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/873 was merged, this enables xges adapter tests on the same platforms/python version as other adapters.