### PR TITLE
Fix escaping for ORIGIN in rpath settings

### DIFF
--- a/src/py-opentimelineio/opentime-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentime-bindings/CMakeLists.txt
@@ -36,7 +36,7 @@ if(APPLE)
         MACOSX_RPATH ON)
 elseif(UNIX)
     set_target_properties(_opentime PROPERTIES 
-        INSTALL_RPATH "\\\$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
         INSTALL_RPATH_USE_LINK_PATH OFF)
 endif()
 

--- a/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
@@ -45,7 +45,7 @@ if(APPLE)
         MACOSX_RPATH ON)
 elseif(UNIX)
     set_target_properties(_otio PROPERTIES 
-        INSTALL_RPATH "\\\$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
         INSTALL_RPATH_USE_LINK_PATH OFF)
 endif()
 


### PR DESCRIPTION
It turns out that we were escaping the value of `"$ORIGIN"` incorrectly in CMakeLists.txt, and this was causing an incorrect RPATH to be written into .so files on linux operating systems of "\$ORIGIN" instead of "$ORIGIN".  This fixes that escaping.