### PR TITLE
CMakeTexts fix: stop using the modname variable

### DIFF
--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(opentime PRIVATE "${PROJECT_SOURCE_DIR}/src")
 
 set_target_properties(opentime PROPERTIES 
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
-    LIBRARY_OUTPUT_NAME "${MODNAME}"
+    LIBRARY_OUTPUT_NAME "opentime"
     POSITION_INDEPENDENT_CODE TRUE
     WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -83,7 +83,7 @@ target_include_directories(opentimelineio PRIVATE
 target_link_libraries(opentimelineio PUBLIC opentime)
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
-    LIBRARY_OUTPUT_NAME "${MODNAME}"
+    LIBRARY_OUTPUT_NAME "opentimelineio"
     POSITION_INDEPENDENT_CODE TRUE
     WINDOWS_EXPORT_ALL_SYMBOLS true)
 

--- a/src/py-opentimelineio/opentime-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentime-bindings/CMakeLists.txt
@@ -17,7 +17,7 @@ target_include_directories(_opentime
 target_link_libraries(_opentime PUBLIC opentimelineio opentime)
 
 set_target_properties(_opentime PROPERTIES
-    LIBRARY_OUTPUT_NAME "${MODNAME}"
+    LIBRARY_OUTPUT_NAME "_opentime"
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}")
 
 # The version of pybind11 we are currently using generates an overwhelming number of

--- a/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
@@ -36,7 +36,7 @@ target_compile_options(_otio PRIVATE
 )
 
 set_target_properties(_otio PROPERTIES
-    LIBRARY_OUTPUT_NAME "${modname}"
+    LIBRARY_OUTPUT_NAME "_otio"
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}")
 
 if(APPLE)


### PR DESCRIPTION
This variable was incorrectly set, fixed to use the explicit name.

