### PR TITLE
Create cmake alias targets for the OTIO namespace

### DIFF
--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(opentime ${OTIO_SHARED_OR_STATIC_LIB}
             rationalTime.cpp
             ${OPENTIME_HEADER_FILES})
 
+add_library(OTIO::opentime ALIAS opentime)
+
 target_include_directories(opentime PRIVATE "${PROJECT_SOURCE_DIR}/src")
 
 set_target_properties(opentime PROPERTIES 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -74,6 +74,8 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
             unknownSchema.cpp 
             ${OPENTIMELINEIO_HEADER_FILES})
 
+add_library(OTIO::opentimelineio ALIAS opentimelineio)
+
 target_include_directories(opentimelineio PRIVATE
                            "${PROJECT_SOURCE_DIR}/src"
                            "${PROJECT_SOURCE_DIR}/src/deps"


### PR DESCRIPTION
Create cmake alias targets for the OTIO namespace

We create and populate the necessary targets and namespace, but neglecto actually set up the alias.