### PR TITLE
Don't override user supplied C++ preferences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,11 @@ endif()
 #------------------------------------------------------------------------------
 # Global language settings
 
-set(CMAKE_CXX_STANDARD 11)
+
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
Currently we override C++ compiler versions to c++11. This causes problems if you are building a project, c++ based, that links to opentimelineio, because non_std optional has shenanigans in it. If you build otio with 11, then try to link your project with 14, then linking will fail, because non_std will have re-routed all the optional references to std, but otio was linked with non_std optional. This change allows a build to specified consistently all the way through for the same compiler. 