### PR TITLE
Specify pyaaf2 requirement as a minimum version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ _ctx.debug = False
 
 
 INSTALL_REQUIRES = [
-    'pyaaf2==1.4.0',
+    'pyaaf2~=1.4.0',
 ]
 # python2 dependencies
 if sys.version_info[0] < 3:


### PR DESCRIPTION
**Summarize your change.**

bb60a6f9784b7cc05291c5df6c107a3f00f6c11f loosened the versions of packages that are required, and changed the specification of dependency versions from being exact versions to being minimum versions. However the same change was not applied to the pyaaf2 version specification. Given that pyaaf2 versions have remained backwards compatible, at least so far, it should be safe to allow users to use different versions of pyaaf2 than what is required in the setup.py currently. Therefore this change makes the version requirement of pyaaf2 also be a minimum version specification rather than an exact one.

**Reference associated tests.**

None required.