### PR TITLE
Avoid exporting build tree libraries

### DIFF
--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -47,10 +47,6 @@ if(OTIO_CXX_INSTALL)
             LIBRARY DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
             RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
 
-    export(TARGETS opentime
-           NAMESPACE OTIO::
-           FILE "${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfig.cmake")
-
     install(EXPORT OpenTimeConfig
             DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}"
             NAMESPACE OTIO:: )

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -113,10 +113,6 @@ if(OTIO_CXX_INSTALL)
            LIBRARY DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}"
            RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
 
-    export(TARGETS opentimelineio
-           NAMESPACE OTIO::
-           FILE "${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfig.cmake")
-
     install(EXPORT OpenTimelineIOConfig
            DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}"
            NAMESPACE OTIO:: )


### PR DESCRIPTION
```Fixes #910 ```

**Summarize your change.**

This branch removes the CMake `export` of the opentime and opentimelineio libraries.  In CMake, exporting generates a CMakeFile that makes the target available from the build tree to upstream projects.  An example use case is when there's a tool facilitating the build process that might also be needed by the upstream project.  However, this is not desirable from a library perspective, it would allow upstream projects to reference the library in the build folder (which is temporary) instead of the installed location (which is permanent).  See Issue for more details.

This is needed to properly link with libraries from other downstream projects, since an export will fail if its dependencies are not also exported.  Specifically, we would like to link with the Imath library for an upcoming PR, but this fails because Imath does not export its libraries.

From the git history this was originally done to facilitate a local pip install.  I tried doing this via `pip install .` and it works, so I assume its since been fixed by other CMake changes.

**Reference associated tests.**

A clean build on all platforms should be sufficient. 
