### PR TITLE
Add pybind11 subdirectory only if building python bindings

### DIFF
--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -12,7 +12,9 @@ foreach(submodule IN LISTS DEPS_SUBMODULES)
     endif()
 endforeach()
 
-add_subdirectory(pybind11)
+if(OTIO_PYTHON_INSTALL)
+    add_subdirectory(pybind11)
+endif()
 
 if(OTIO_DEPENDENCIES_INSTALL)
     install(FILES any/any.hpp 


### PR DESCRIPTION
**Summarize your change.**

We were adding pybind11 as a subdirectory in cmake even if the building python bindings was disabled. This PR conditionally adds pybind11.

To build the Java bindings for android we do not need the python bindings. While building for 32-bit android I was getting an error ([here](https://github.com/OpenTimelineIO/OpenTimelineIO-Java-Bindings/pull/3#issuecomment-791849975)) saying that the pybind11 cmake was looking for 32-bit python, but couldn't find it. The easy solution is to just disable building python bindings and not search for python at all. I've tested this and am able to build for 32-bit.