### PR TITLE
Add an env var to disable pkg_resources

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Quick Start
    :maxdepth: 2
 
    tutorials/quickstart
+   tutorials/otio-env-variables
 
 Tutorials
 ------------

--- a/docs/tutorials/otio-env-variables.md
+++ b/docs/tutorials/otio-env-variables.md
@@ -7,7 +7,7 @@ various aspects of OTIO.
 
 These variables must be set _before_ the OpenTimelineIO python library is imported.
 
-- `OTIO_PLUGIN_MANIFEST_PAT`H: a ":" separated string with paths to .manifest.json files that contain OTIO plugin manifests.  See: <a href="write-an-adapter.html" target="_blank">Tutorial on how to write an adapter plugin</a>.
+- `OTIO_PLUGIN_MANIFEST_PATH`: a ":" separated string with paths to .manifest.json files that contain OTIO plugin manifests.  See: <a href="write-an-adapter.html" target="_blank">Tutorial on how to write an adapter plugin</a>.
 - `OTIO_DEFAULT_MEDIA_LINKER`: the name of the default media linker to use after reading a file, if "" then no media linker is automatically invoked.
 - O`TIO_DISABLE_PKG_RESOURCE_PLUGINS`: By default, OTIO will use the pkg_resource entry_points mechanism to discover plugins that have been installed into the current python environment.  pkg_resources, however, can be slow in certain cases, so for users who wish to disable this behavior, this variable can be set to 1.
 

--- a/docs/tutorials/otio-env-variables.md
+++ b/docs/tutorials/otio-env-variables.md
@@ -9,7 +9,7 @@ These variables must be set _before_ the OpenTimelineIO python library is import
 
 - `OTIO_PLUGIN_MANIFEST_PATH`: a ":" separated string with paths to .manifest.json files that contain OTIO plugin manifests.  See: <a href="write-an-adapter.html" target="_blank">Tutorial on how to write an adapter plugin</a>.
 - `OTIO_DEFAULT_MEDIA_LINKER`: the name of the default media linker to use after reading a file, if "" then no media linker is automatically invoked.
-- O`TIO_DISABLE_PKG_RESOURCE_PLUGINS`: By default, OTIO will use the pkg_resource entry_points mechanism to discover plugins that have been installed into the current python environment.  pkg_resources, however, can be slow in certain cases, so for users who wish to disable this behavior, this variable can be set to 1.
+- `OTIO_DISABLE_PKG_RESOURCE_PLUGINS`: By default, OTIO will use the pkg_resource entry_points mechanism to discover plugins that have been installed into the current python environment.  pkg_resources, however, can be slow in certain cases, so for users who wish to disable this behavior, this variable can be set to 1.
 
 ## Unit tests
 

--- a/docs/tutorials/otio-env-variables.md
+++ b/docs/tutorials/otio-env-variables.md
@@ -1,0 +1,18 @@
+# Environment Variables
+
+This document describes the environment variables that can be used to configure
+various aspects of OTIO.
+
+## Plugin Configuration
+
+These variables must be set _before_ the OpenTimelineIO python library is imported.
+
+- `OTIO_PLUGIN_MANIFEST_PAT`H: a ":" separated string with paths to .manifest.json files that contain OTIO plugin manifests.  See: <a href="write-an-adapter.html" target="_blank">Tutorial on how to write an adapter plugin</a>.
+- `OTIO_DEFAULT_MEDIA_LINKER`: the name of the default media linker to use after reading a file, if "" then no media linker is automatically invoked.
+- O`TIO_DISABLE_PKG_RESOURCE_PLUGINS`: By default, OTIO will use the pkg_resource entry_points mechanism to discover plugins that have been installed into the current python environment.  pkg_resources, however, can be slow in certain cases, so for users who wish to disable this behavior, this variable can be set to 1.
+
+## Unit tests
+
+These variables only impact unit tests.
+
+- `OTIO_DISABLE_SHELLOUT_TESTS`: When running the unit tests, skip the console tests that run the otiocat program and check output through the shell.  This is desirable in environments where running the commandline tests is not meaningful or problematic.  Does not disable the tests that run through python calling mechanisms.

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -28,9 +28,9 @@ import inspect
 import logging
 import os
 
-# pkg_resources can have bad performance characteristics in some circumstances
-# using this flag: OTIO_DISABLE_PKG_RESOURCE_PLUGINS prevents importing or
-# using the pkg_resources system.
+# In some circumstances pkg_resources has bad performance characteristics.
+# Using the envirionment variable: $OTIO_DISABLE_PKG_RESOURCE_PLUGINS disables
+# OpenTimelineIO's import and of use of the pkg_resources module.
 if os.environ.get("OTIO_DISABLE_PKG_RESOURCE_PLUGINS", False):
     pkg_resources = None
 else:

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -28,11 +28,17 @@ import inspect
 import logging
 import os
 
-# on some python interpreters, pkg_resources is not available
-try:
-    import pkg_resources
-except ImportError:
+# pkg_resources can have bad performance characteristics in some circumstances
+# using this flag: OTIO_DISABLE_PKG_RESOURCE_PLUGINS prevents importing or
+# using the pkg_resources system.
+if os.environ.get("OTIO_DISABLE_PKG_RESOURCE_PLUGINS", False):
     pkg_resources = None
+else:
+    try:
+        # on some python interpreters, pkg_resources is not available
+        import pkg_resources
+    except ImportError:
+        pkg_resources = None
 
 from .. import (
     core,


### PR DESCRIPTION
- in some cases, pkg_resources can be slow to both import and use
- adds the `OTIO_DISABLE_PKG_RESOURCE_PLUGINS` environment variable to
  disable using this library for users that have those issues.
- Even for users not experiencing those issues, this speeds up the
  import time of OTIO slightly.
- Also adds a new doc page with a description of OTIO environment variables.
