### PR TITLE
Prep for ASWF transfer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(OTIO_VERSION_PATCH "0")
 set(OTIO_VERSION ${OTIO_VERSION_MAJOR}.${OTIO_VERSION_MINOR}.${OTIO_VERSION_PATCH})
 
 set(OTIO_AUTHOR       "Contributors to the OpenTimelineIO project")
-set(OTIO_AUTHOR_EMAIL "opentimelineio@pixar.com")
+set(OTIO_AUTHOR_EMAIL "otio-discussion@lists.aswf.io")
 set(OTIO_LICENSE      "Modified Apache 2.0 License")
 
 project(OpenTimelineIO VERSION ${OTIO_VERSION} LANGUAGES C CXX)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ cd OpenTimelineIO
 git remote add upstream https://github.com/PixarAnimationStudios/OpenTimelineIO.git
 ```
 
-Now you fetch the latest changes from Pixar's OpenTimelineIO repo like this:
+Now you fetch the latest changes from the OpenTimelineIO repo like this:
 
 ```bash
 git fetch upstream

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/no_metadata.otio
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/no_metadata.otio
@@ -32,17 +32,17 @@
                             "target_url": "sample_data/one_clip.aaf"
                         }, 
                         "metadata": {
-                            "pixar": {
-                                "OTIO_SCHEMA": "PixarMetadata.1", 
+                            "example_studio": {
+                                "OTIO_SCHEMA": "ExampleStudioMetadata.1", 
                                 "cache": {
                                     "hitech": {
-                                        "OTIO_SCHEMA": "PixarHitech.1", 
+                                        "OTIO_SCHEMA": "ExampleDatabase.1", 
                                         "shot": null, 
                                         "take": null
                                     }
                                 }, 
                                 "take": {
-                                    "OTIO_SCHEMA": "PixarTake.1", 
+                                    "OTIO_SCHEMA": "ExampleStudioTake.1", 
                                     "globaltake": 1, 
                                     "prod": "ppjoshm", 
                                     "shot": "ppjoshm_1", 
@@ -100,17 +100,17 @@
                             "target_url": "sample_data/one_clip.aaf"
                         }, 
                         "metadata": {
-                            "pixar": {
-                                "OTIO_SCHEMA": "PixarMetadata.1", 
+                            "example_studio": {
+                                "OTIO_SCHEMA": "ExampleStudioMetadata.1", 
                                 "cache": {
                                     "hitech": {
-                                        "OTIO_SCHEMA": "PixarHitech.1", 
+                                        "OTIO_SCHEMA": "ExampleDatabase.1", 
                                         "shot": null, 
                                         "take": null
                                     }
                                 }, 
                                 "take": {
-                                    "OTIO_SCHEMA": "PixarTake.1", 
+                                    "OTIO_SCHEMA": "ExampleStudioTake.1", 
                                     "globaltake": 1, 
                                     "prod": "ppjoshm", 
                                     "shot": "ppjoshm_1", 

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/not_aaf.otio
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/not_aaf.otio
@@ -32,11 +32,11 @@
                             "target_url": "sample_data/one_clip.mov"
                         }, 
                         "metadata": {
-                            "pixar": {
-                                "OTIO_SCHEMA": "PixarMetadata.1", 
+                            "example_studio": {
+                                "OTIO_SCHEMA": "ExampleStudioMetadata.1", 
                                 "cache": {
                                     "hitech": {
-                                        "OTIO_SCHEMA": "PixarHitech.1", 
+                                        "OTIO_SCHEMA": "ExampleDatabase.1", 
                                         "shot": null, 
                                         "take": null
                                     }
@@ -100,11 +100,11 @@
                             "target_url": "sample_data/one_clip.mov"
                         }, 
                         "metadata": {
-                            "pixar": {
-                                "OTIO_SCHEMA": "PixarMetadata.1", 
+                            "example_studio": {
+                                "OTIO_SCHEMA": "ExampleStudioMetadata.1", 
                                 "cache": {
                                     "hitech": {
-                                        "OTIO_SCHEMA": "PixarHitech.1", 
+                                        "OTIO_SCHEMA": "ExampleDatabase.1", 
                                         "shot": null, 
                                         "take": null
                                     }

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.otio
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.otio
@@ -89,17 +89,17 @@
                             "target_url": "sample_data/one_clip.mov"
                         }, 
                         "metadata": {
-                            "pixar": {
-                                "OTIO_SCHEMA": "PixarMetadata.1", 
+                            "example_studio": {
+                                "OTIO_SCHEMA": "ExampleStudioMetadata.1", 
                                 "cache": {
                                     "hitech": {
-                                        "OTIO_SCHEMA": "PixarHitech.1", 
+                                        "OTIO_SCHEMA": "ExampleDatabase.1", 
                                         "shot": null, 
                                         "take": null
                                     }
                                 }, 
                                 "take": {
-                                    "OTIO_SCHEMA": "PixarTake.1", 
+                                    "OTIO_SCHEMA": "ExampleStudioTake.1", 
                                     "globaltake": 1, 
                                     "prod": "ppjoshm", 
                                     "shot": "ppjoshm_1", 

--- a/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
+++ b/contrib/opentimelineio_contrib/adapters/tests/sample_data/rv_metadata.rv
@@ -106,6 +106,6 @@ sourceGroup000001_source : RVFileSource (1)
 
     otio
     {
-        string metadata = "{\"pixar\":{\"OTIO_SCHEMA\":\"PixarMetadata.1\",\"cache\":{\"hitech\":{\"OTIO_SCHEMA\":\"PixarHitech.1\",\"shot\":null,\"take\":null}},\"take\":{\"OTIO_SCHEMA\":\"PixarTake.1\",\"globaltake\":1,\"prod\":\"ppjoshm\",\"shot\":\"ppjoshm_1\",\"unit\":\"none\"}}}"
+        string metadata = "{\"example_studio\":{\"OTIO_SCHEMA\":\"ExampleStudioMetadata.1\",\"cache\":{\"hitech\":{\"OTIO_SCHEMA\":\"ExampleDatabase.1\",\"shot\":null,\"take\":null}},\"take\":{\"OTIO_SCHEMA\":\"ExampleStudioTake.1\",\"globaltake\":1,\"prod\":\"ppjoshm\",\"shot\":\"ppjoshm_1\",\"unit\":\"none\"}}}"
     }
 }

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/PACKAGE
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/PACKAGE
@@ -1,7 +1,7 @@
 package: Example OTIO Reader
 author: Contributors to the OpenTimelineIO project
 organization: OpenTimelineIO project
-contact: opentimelineio@pixar.com
+contact: otio-discussion@lists.aswf.io
 version: 1.0
 url: http://opentimeline.io
 rv: 4.0.8

--- a/docs/tutorials/contributing.md
+++ b/docs/tutorials/contributing.md
@@ -38,7 +38,7 @@ cd OpenTimelineIO
 git remote add upstream https://github.com/PixarAnimationStudios/OpenTimelineIO.git
 ```
 
-Now you fetch the latest changes from Pixar's OpenTimelineIO repo like this:
+Now you fetch the latest changes from the OpenTimelineIO repo like this:
 
 ```bash
 git fetch upstream

--- a/docs/use-cases/conform-new-renders-into-cut.md
+++ b/docs/use-cases/conform-new-renders-into-cut.md
@@ -1,7 +1,7 @@
 # Conform New Renders Into The Cut
 
 **Status: Done**
-This use case is in active use at Pixar (Coco, Incredibles 2, etc.)
+This use case is in active use at several feature film production studios.
 
 ## Summary
 
@@ -20,17 +20,3 @@ Artists working on the animation or visual effects for shots in a sequence often
 3. In either case, we link the shots in the timeline to segments of the supplied QuickTime movie.
 3. The artist can now play the sequence and see exactly what the editor saw.
 4. The artist can now relink any or all of the shots to the latest renders (either via OpenTimelineIO or features of the video player tool)
-
-## Features Needed in OTIO
-
-- EDL reading (done)
-    - Single video track (done)
-    - Clip names (done)
-    - Source range for each clip (done)
-    - <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/6" target="_blank">Transitions</a> (done)
-- RV support
-    - <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/64" target="_blank">OTIO to RV Session file via adapter</a> (done)
-    - RV Plugin that uses OTIO to read an EDL (Pixar has use-case specific code for this) (done)
-- Relinking
-    - <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/94" target="_blank">Relinking the whole EDL to segments of the full sequence QuickTime movie.</a> (done)
-    - <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/94" target="_blank">Relinking of individual clips to renders of those shots.</a>(done)

--- a/examples/sample_plugin/setup.py
+++ b/examples/sample_plugin/setup.py
@@ -36,6 +36,6 @@ setup(
     description='Adapter writes number of tracks to file.',
     license='Modified Apache 2.0 License',
     author='Contributors to the OpenTimelineIO project',
-    author_email='opentimelineio@pixar.com',
+    author_email='otio-discussion@lists.aswf.io',
     url='http://opentimeline.io',
 )

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ if (
 PROJECT_METADATA = {
     "version": "0.15.0.dev1",
     "author": 'Contributors to the OpenTimelineIO project',
-    "author_email": 'opentimelineio@pixar.com',
+    "author_email": 'otio-discussion@lists.aswf.io',
     "license": 'Modified Apache 2.0 License',
 }
 

--- a/src/py-opentimelineio/opentimelineio/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/__init__.py
@@ -26,7 +26,7 @@
 
 see: http://opentimeline.io
 
-.. moduleauthor:: Contributors to the OpenTimelineIO project <opentimelineio@pixar.com>
+.. moduleauthor:: Contributors to the OpenTimelineIO project <otio-discussion@lists.aswf.io>
 """
 
 # flake8: noqa

--- a/src/py-opentimelineio/opentimelineio/console/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/console/__init__.py
@@ -24,7 +24,7 @@
 
 """Console scripts for OpenTimelineIO
 
-.. moduleauthor:: Contributors to the OpenTimelineIO project <opentimelineio@pixar.com>
+.. moduleauthor:: Contributors to the OpenTimelineIO project <otio-discussion@lists.aswf.io>
 """
 
 # flake8: noqa

--- a/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
@@ -4,7 +4,7 @@ Version: 1.0.0
 Summary: Dummy plugin used for testing.
 Home-page: http://opentimeline.io
 Author: Contributors to the OpenTimelineIO project
-Author-email: opentimelineio@pixar.com
+Author-email: otio-discussion@lists.aswf.io
 License: Modified Apache 2.0 License
 Description-Content-Type: UNKNOWN
 Description: UNKNOWN

--- a/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_jsonplugin.egg-info/PKG-INFO
@@ -3,7 +3,7 @@ Name: otio-jsonplugin
 Version: 1.0.0
 Summary: Dummy plugin used for testing.
 Home-page: http://opentimeline.io
-Author: Pixar Animation Studios
+Author: Contributors to the OpenTimelineIO project
 Author-email: opentimelineio@pixar.com
 License: Modified Apache 2.0 License
 Description-Content-Type: UNKNOWN

--- a/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
@@ -4,7 +4,7 @@ Version: 1.0.0
 Summary: Dummy plugin used for testing.
 Home-page: http://opentimeline.io
 Author: Contributors to the OpenTimelineIO project
-Author-email: opentimelineio@pixar.com
+Author-email: otio-discussion@lists.aswf.io
 License: Modified Apache 2.0 License
 Description-Content-Type: UNKNOWN
 Description: UNKNOWN

--- a/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
+++ b/tests/baselines/plugin_module/otio_mockplugin.egg-info/PKG-INFO
@@ -3,7 +3,7 @@ Name: otio-mockplugin
 Version: 1.0.0
 Summary: Dummy plugin used for testing.
 Home-page: http://opentimeline.io
-Author: Pixar Animation Studios
+Author: Contributors to the OpenTimelineIO project
 Author-email: opentimelineio@pixar.com
 License: Modified Apache 2.0 License
 Description-Content-Type: UNKNOWN


### PR DESCRIPTION
This PR removes some, but not all, of the mentions of Pixar from the repo, as part of our prep for transitioning the project to ASWF ownership.