### PR TITLE
add interval field to dependabot yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,10 @@ updates:
     directory: "/"
     schedule:
       day: "monday"
+      interval: "weekly"
 
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       day: "monday"
+      interval: "weekly"


### PR DESCRIPTION
Dependabot requires an "interval" property in its yaml file.  I missed that last time, whoops.