### PR TITLE
Only load a manifest if it has not been loaded

### DIFF
--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -221,11 +221,13 @@ parameters:
 ```
 Defines an OTIO plugin Manifest.
 
-    This is an internal OTIO implementation detail.  A manifest tracks a
-    collection of adapters and allows finding specific adapters by suffix
+    This is considered an internal OTIO implementation detail.
 
-    For writing your own adapters, consult:
-        https://opentimelineio.readthedocs.io/en/latest/tutorials/write-an-adapter.html#
+    A manifest tracks a collection of plugins and enables finding them by name
+    or other features (in the case of adapters, what file suffixes they
+    advertise support for).
+
+    For more information, consult the documenation.
     
 ```
 

--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -266,6 +266,21 @@ def load_manifest():
                 plugin_entry_point = plugin.load()
                 try:
                     plugin_manifest = plugin_entry_point.plugin_manifest()
+
+                    # this ignores what the plugin_manifest() function might
+                    # put into source_files in favor of using the path to the
+                    # python package as the unique identifier
+
+                    manifest_path = os.path.abspath(
+                        plugin_entry_point.__file__
+                    )
+
+                    if manifest_path in result.source_files:
+                        continue
+
+                    plugin_manifest.source_files = [manifest_path]
+                    plugin_manifest._update_plugin_source(manifest_path)
+
                 except AttributeError:
                     if not pkg_resources.resource_exists(
                             plugin.module_name,
@@ -291,6 +306,7 @@ def load_manifest():
                         manifest_stream.read().decode('utf-8')
                     )
                     manifest_stream.close()
+
                     plugin_manifest._update_plugin_source(filepath)
                     plugin_manifest.source_files.append(filepath)
 

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -153,15 +153,26 @@ class TestSetuptoolsPlugin(unittest.TestCase):
         # back up existing manifest
         bak_env = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
 
+        relative_path = self.mock_module_manifest_path.replace(os.getcwd(), '.')
+
         # set where to find the new manifest
-        os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = (
-            self.mock_module_manifest_path
+        os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = os.pathsep.join(
+            (
+                # absolute
+                self.mock_module_manifest_path,
+
+                # relative
+                relative_path
+            )
         )
+
         result = otio.plugins.manifest.load_manifest()
         self.assertEqual(
             result.source_files.count(self.mock_module_manifest_path),
             1
         )
+        if relative_path != self.mock_module_manifest_path:
+            self.assertNotIn(relative_path, result.source_files)
 
         if bak_env:
             os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env

--- a/tests/test_plugin_detection.py
+++ b/tests/test_plugin_detection.py
@@ -145,7 +145,12 @@ class TestSetuptoolsPlugin(unittest.TestCase):
         for linker in man.media_linkers:
             self.assertIsInstance(linker, otio.media_linker.MediaLinker)
 
-        self.assertIn(self.mock_module_manifest_path, man.source_files)
+        self.assertTrue(
+            any(
+                True for p in man.source_files
+                if self.mock_module_manifest_path in p
+            )
+        )
 
     def test_deduplicate_env_variable_paths(self):
         "Ensure that duplicate entries in the environment variable are ignored"
@@ -168,7 +173,12 @@ class TestSetuptoolsPlugin(unittest.TestCase):
 
         result = otio.plugins.manifest.load_manifest()
         self.assertEqual(
-            result.source_files.count(self.mock_module_manifest_path),
+            len(
+                [
+                    p for p in result.source_files
+                    if self.mock_module_manifest_path in p
+                ]
+            ),
             1
         )
         if relative_path != self.mock_module_manifest_path:


### PR DESCRIPTION
- During plugin loading, checks to see which source_files have already been loaded before loading a new plugin.
- For pkg_resource plugins that use the function approach rather than the manifest.json approach, generates a source_files path based on the path to the module containing the function.
- Adds unit tests to check duplicate entries.
- Also updates and clarifies some documentation around how the plugin manifests are loaded.