### PR TITLE
Ascii doc fix

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/cmx_3600.py
@@ -673,7 +673,7 @@ def _expand_transitions(timeline):
 
             # Using transition data for duration (with clip duration as backup.)
             # Link: https://ieeexplore.ieee.org/document/7291839
-            # Citation: "ST 258:2004 - SMPTE Standard - For Television — Transfer
+            # Citation: "ST 258:2004 - SMPTE Standard - For Television - Transfer
             #   of Edit Decision Lists," in ST 258:2004 , vol., no., pp.1-37,
             #   6 April 2004, doi: 10.5594/SMPTE.ST258.2004.
             if clip.metadata.get("cmx_3600", {}).get("transition_duration"):

--- a/src/py-opentimelineio/opentimelineio/adapters/file_bundle_utils.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/file_bundle_utils.py
@@ -109,7 +109,7 @@ def _prepped_otio_for_bundle_and_manifest(
     the OTIO will be relinked by the adapters to point to their output
     locations.
 
-    The otio[dz] adapters use this function to do further relinking and build
+    The otio[dz] adapters use this function to do further relinking and build
     their bundles.
 
     This is considered an internal API.


### PR DESCRIPTION
Found an additional non-ascii character in a doc string related to a citation. 
