### PR TITLE
Use Pybind11's find python tool to correctly locate python install information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,8 +97,8 @@ def cmake_generate():
         '-DOTIO_PYTHON_INSTALL:BOOL=ON',
         '-DOTIO_CXX_INSTALL:BOOL=ON',
         '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release'),
-        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs:  https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
-    ]
+        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs
+    ]  # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
 
     python_inst_dir = get_python_lib()
 

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,8 @@ def cmake_generate():
         '-DPYTHON_EXECUTABLE=' + sys.executable,
         '-DOTIO_PYTHON_INSTALL:BOOL=ON',
         '-DOTIO_CXX_INSTALL:BOOL=ON',
-        '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release')
+        '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release'),
+        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs
     ]
 
     python_inst_dir = get_python_lib()

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def cmake_generate():
         '-DOTIO_PYTHON_INSTALL:BOOL=ON',
         '-DOTIO_CXX_INSTALL:BOOL=ON',
         '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release'),
-        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs
+        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs:  https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode 
     ]
 
     python_inst_dir = get_python_lib()

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def cmake_generate():
         '-DOTIO_PYTHON_INSTALL:BOOL=ON',
         '-DOTIO_CXX_INSTALL:BOOL=ON',
         '-DCMAKE_BUILD_TYPE=' + ('Debug' if _ctx.debug else 'Release'),
-        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs:  https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode 
+        '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs:  https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
     ]
 
     python_inst_dir = get_python_lib()


### PR DESCRIPTION
Fixes #813

**Link the Issue(s) this Pull Request is related to.**

Each PR should link at least one issue, in the form:

```Fixes #823```

Use one line for each Issue. This allows auto-closing the related issue when the fix is merged.

Added the pybind11 smart tool to find python: https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode

On windows: `/path/to/blender/python -m pip install` wasn't working.
