### PR TITLE
install mock on CI builds for python 2.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
         sudo apt-get install lcov
     - name: Install python build dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel flake8>=3.5 check-manifest
+        python -m pip install --upgrade pip setuptools wheel flake8>=3.5 check-manifest mock
     - name: Run check-manifest and lint check
       run: make ci-prebuild
     - name: Build and Install

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,10 @@ jobs:
         sudo apt-get install lcov
     - name: Install python build dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel flake8>=3.5 check-manifest mock
+        python -m pip install --upgrade pip setuptools wheel flake8>=3.5 check-manifest
+    - name: install mock for python 2.7 tests only
+      if: matrix.python-version == 2.7
+      run: python -m pip install --upgrade mock
     - name: Run check-manifest and lint check
       run: make ci-prebuild
     - name: Build and Install


### PR DESCRIPTION
Our CI builds do not have the `mock` module installed, so not all unit tests are running for python 2.7.  This installs that library for python2.7 builds only to ensure that all the tests are running.