### PR TITLE
Build wheels as a github action

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest, macos-11.0]
         python-build: [cp27*, cp37*, cp38*]
 
     steps:

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -1,0 +1,31 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macOS-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # Used to host cibuildwheel
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.10.0
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        # TODO: Solve for the 32-bit errors in windows python 2.7:
+        #   https://github.com/pybind/cmake_example/blob/master/.github/workflows/wheels.yml#L66
+        env:
+          CIBW_SKIP: cp27-win*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-latest, macOS-latest]
+        python-build: [cp27*, cp37*, cp38*]
 
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +26,9 @@ jobs:
         #   https://github.com/pybind/cmake_example/blob/master/.github/workflows/wheels.yml#L66
         env:
           CIBW_SKIP: cp27-win*
+          CIBW_BUILD: ${{ matrix.python-build }}
 
       - uses: actions/upload-artifact@v2
         with:
+          name: wheels
           path: ./wheelhouse/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wheel",
+    "cmake>=3.12",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -112,8 +112,14 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
             '-DOTIO_PYTHON_INSTALL:BOOL=ON',
             '-DOTIO_CXX_INSTALL:BOOL=ON',
             '-DCMAKE_BUILD_TYPE=' + self.build_config,
-            '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs
-        ]  # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
+        ]
+
+        # Within the manylinux docker containers used for linux wheel builds
+        # pybind's findpython does not work for some reason
+        if not os.environ.get("CIBUILDWHEEL") or platform.system() != "Linux":
+            # Smart tool to find python's libs
+            # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
+            cmake_args.append('-DPYBIND11_FINDPYTHON=ON')
 
         # install the C++ into the opentimelineio/cxx-sdk directory under the
         # python installation


### PR DESCRIPTION
Adds Github action to invoke [cibuildwheel](https://github.com/joerick/cibuildwheel) to generate python wheels.

Fixes #666

**Summarize your change.**

Adds github action and pyptoject.toml to specify needed dependencies for that action.

Left to do:

- [ ] Get Windows wheels working
- [ ] Get community help testing the new wheels in a variety of environments
- [ ] Discuss if we want `opentimelineio/cxx-sdk/` included in the wheels
- [ ] Validate the specified build matrix
- [ ] Figure out best way to make wheels build ONLY after the other builds have passed