### PR TITLE
make Timeline::set_tracks(null_ptr) create a new Stack to fix crash

### DIFF
--- a/src/opentimelineio/timeline.cpp
+++ b/src/opentimelineio/timeline.cpp
@@ -13,6 +13,10 @@ Timeline::Timeline(std::string const& name,
 Timeline::~Timeline() {
 }
 
+void Timeline::set_tracks(Stack* stack) {
+    _tracks = stack ? stack : new Stack("tracks");
+}
+
 bool Timeline::read_from(Reader& reader) {
     return reader.read("tracks", &_tracks) &&
         reader.read_if_present("global_start_time", &_global_start_time) &&

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -30,9 +30,7 @@ public:
     }*/
     
 
-    void set_tracks(Stack* stack) {
-        _tracks = stack;
-    }
+    void set_tracks(Stack* stack);
     
     optional<RationalTime> const& global_start_time() const {
         return _global_start_time;

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -494,6 +494,23 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             [t.name for t in tl.audio_tracks()]
         )
 
+    def test_tracks_set_null_tracks(self):
+        tl = otio.schema.Timeline(tracks=[
+            otio.schema.Track(
+                name="V1",
+                kind=otio.schema.TrackKind.Video
+            ),
+            otio.schema.Track(
+                name="V2",
+                kind=otio.schema.TrackKind.Video
+            )])
+
+        self.assertEqual(len(tl.tracks), 2)
+        self.assertTrue(isinstance(tl.tracks, otio.schema.Stack))
+        tl.tracks = None
+        self.assertEqual(len(tl.audio_tracks()), 0)
+        self.assertEqual(len(tl.video_tracks()), 0)
+        self.assertTrue(isinstance(tl.tracks, otio.schema.Stack))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -512,5 +512,6 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(len(tl.video_tracks()), 0)
         self.assertTrue(isinstance(tl.tracks, otio.schema.Stack))
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
By David Baraff. Supercedes https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/852 which had rebasing issues.

Fixes Timeline::set_tracks(nullptr) leads to bad state #851

Summarize your change.

Sets _tracks to a new Stack() if the incoming pointer is null

Reference associated tests.

Added a new test in test_tracks_set_null_tracks in tests/test_timeline.py