### PR TITLE
Fix typo that makes a string a tuple :D 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -334,8 +334,8 @@ setup(
             'otiopluginfo = opentimelineio.console.otiopluginfo:main',
             (
                 'otioautogen_serialized_schema_docs = '
-                'opentimelineio.console.autogen_serialized_datamodel:main',
-            )
+                'opentimelineio.console.autogen_serialized_datamodel:main'
+            ),
         ],
     },
     extras_require={


### PR DESCRIPTION
I haven't made an issue since this is just fixing a typo, but I'm happy to open one if needed.
There's also a quick conversation on the Slack regarding this quirk, titled `conda & OTIO`.

Basically, in `setup.py`, there's a tiny comma that needs to be moved downwards, otherwise it makes the `otioautogen_serialized_schema_docs..` entry a tuple made of one element, instead of a multiline string enclosed by parenthesis (which I suppose it was the original intent).

Pinging @ssteinbach since I'm not a `setup.py` expert and he originally authored that commit.

The main reason why I discovered that is that it breaks `conda skeleton`, which parses the `pkginfo.yaml` generated from the `setup.py` and doesn't expect a tuple/list there. See https://github.com/conda/conda-build/issues/4227

Thanks!

Valerio