### PR TITLE
do not upload code coverage statistics if the PR is opened by dependabot

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
       run: |
         sudo apt-get install lcov
     - name: Install python build dependencies
@@ -54,10 +54,11 @@ jobs:
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)
     - name: Generate C++ coverage report
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+
       run: make lcov
     - name: Upload coverage to Codecov
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && ${{ github.actor }} != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
       run: |
         sudo apt-get install lcov
     - name: Install python build dependencies
@@ -54,10 +54,10 @@ jobs:
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)
     - name: Generate C++ coverage report
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && ${{ github.actor }} != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
       run: make lcov
     - name: Upload coverage to Codecov
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && ${{ github.actor }} != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && ${{ github.actor }} != "dependabot"
       run: |
         sudo apt-get install lcov
     - name: Install python build dependencies
@@ -54,10 +54,10 @@ jobs:
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)
     - name: Generate C++ coverage report
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && ${{ github.actor }} != "dependabot"
       run: make lcov
     - name: Upload coverage to Codecov
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && ${{ github.actor }} != "dependabot"
       uses: codecov/codecov-action@v1
       with:
         flags: unittests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -55,7 +55,6 @@ jobs:
     # (only on ubuntu/pyhton3.7)
     - name: Generate C++ coverage report
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
-
       run: make lcov
     - name: Upload coverage to Codecov
       if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,6 +7,7 @@ name: OpenTimelineIO
 env:
   GH_COV_PY: 3.7
   GH_COV_OS: ubuntu-latest
+  GH_DEPENDABOT: dependabot
 
 on:
   push:
@@ -35,7 +36,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install coverage dependency
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: |
         sudo apt-get install lcov
     - name: Install python build dependencies
@@ -54,10 +55,10 @@ jobs:
       run: make ci-postbuild
     # (only on ubuntu/pyhton3.7)
     - name: Generate C++ coverage report
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       run: make lcov
     - name: Upload coverage to Codecov
-      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != "dependabot"
+      if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS && github.actor != env.GH_DEPENDABOT
       uses: codecov/codecov-action@v1
       with:
         flags: unittests


### PR DESCRIPTION
Closes #970 

Looks like there is a specific interaction of codecov & dependabot.  This PR turns off uploading coverage from dependabot runs (which we probably did not want code coverage checks on anyway).

