### PR TITLE
Force pybind to find the python version matching the setup.py interpr…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,13 +108,11 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
             install_dir += os.path.sep
 
         cmake_args = [
-            '-DPYTHON_EXECUTABLE=' + sys.executable,
             '-DOTIO_PYTHON_INSTALL:BOOL=ON',
             '-DOTIO_CXX_INSTALL:BOOL=ON',
             '-DCMAKE_BUILD_TYPE=' + self.build_config,
-            '-DPYBIND11_FINDPYTHON=ON',  # Smart tool to find python's libs
-        ]  # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
-
+            '-DPYBIND11_PYTHON_VERSION=' + platform.python_version(),
+        ]
         # install the C++ into the opentimelineio/cxx-sdk directory under the
         # python installation
         cmake_install_prefix = os.path.join(


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**
```Fixes #984```

**Summarize your change.**

This is an attempt to fix building when multiple python versions are installed.  Currently, the `PYBIND11_FINDPYTHON` will cause pybind to attempt to locate the version of python to use when generating the python bindings.  The problem with this is that is may not match the version of python where the files will be installed.  From my experimentation, it seems the `FINDPYTHON` option will search the PATH and take the first match to find python. Whereas setup.py will build the installation for the version of python that invoked it. 

If these versions don't match, the python bindings will be built for a different version of python in which they are used and loading the resulting libraries will fail.

To fix it, we will instead specify the version of python when we are installing python, and then let pybind11's `FINDPYTHON` find that particular version.

I am not 100% sure if this fixes the original Window's Blender that `FINDPYTHON` was intended to fix since I don't have access to it, since the same embedded python version could also be installed elsewhere.  But is my hope if `FINDPYTHON` fixed the problem, the pybind search for the python version will use the same approach to find that particular version and this will solve both issues.

Note that the `FINDPYTHON`, `PYTHON_VERSION` and `PYTHON_EXECUTABLE` options are mutually exclusive, so I removed the redundant `PYTHON_EXECUTABLE` option as well.

**Describe the reason for the change.**

To allow building with multiple versions of python installed.

**Reference associated tests.**

Build issue only.  Building on as many different platforms is the best way to cover the changes.