### PR TITLE
Force pybind to use same python as otio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,13 +114,6 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
             '-DCMAKE_BUILD_TYPE=' + self.build_config,
         ]
 
-        # Within the manylinux docker containers used for linux wheel builds
-        # pybind's findpython does not work for some reason
-        if not os.environ.get("CIBUILDWHEEL") or platform.system() != "Linux":
-            # Smart tool to find python's libs
-            # https://pybind11.readthedocs.io/en/latest/compiling.html#findpython-mode
-            cmake_args.append('-DPYBIND11_FINDPYTHON=ON')
-
         # install the C++ into the opentimelineio/cxx-sdk directory under the
         # python installation
         cmake_install_prefix = os.path.join(


### PR DESCRIPTION
Link the Issue(s) this Pull Request is related to.
Fixes #984

Summarize your change.

This is an attempt to fix building when multiple python versions are installed. Currently, the `PYBIND11_FINDPYTHON` will cause pybind to attempt to locate the version of python to use when generating the python bindings. The problem with this is that is may not match the version of python where the files will be installed. From my experimentation, it seems the FINDPYTHON option will search the PATH and take the first match to find python. Whereas setup.py will build the installation for the version of python that invoked it.

If these versions don't match, the python bindings will be built for a different version of python in which they are used and loading the resulting libraries will fail.

To fix it, we must remove the `PYBIND11_FINDPYTHON` option because this option is mutually exclusive with `PYTHON_EXECUTABLE` and when both are present, `PYBIND_FINDPYTHON` wins.  Without `PYTHON_EXECUTABLE` we have no way of guaranteeing that the python site-packages directory where OTIO will be installed will be the same version of Python as used by pybind. 

The `PYBIND11_FINDPYTHON` option was originally introduced for Blender on Windows, so this will cause a regression in that case.  I would suggest that they can set `PYBIND11_FINDPYTHON` in their own build files, since this options will win over the `PYTHON_EXECUTABLE` used by OTIO anyway.

*Note: there was a conflict with a recently submitted branch that only removed `PYBIND11_FINDPYTHON` in certain cases.  Here I remove it in all cases.

Describe the reason for the change.

To allow building with multiple versions of python installed.

Reference associated tests.

Build issue only. Building on as many different platforms is the best way to cover the changes.