### PR TITLE
Cxx conform example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(${PROJECT_SOURCE_DIR}/src
     ${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include
     ${PYTHON_INCLUDE_DIRS})
 
+list(APPEND examples conform)
 list(APPEND examples flatten_video_tracks)
 list(APPEND examples summarize_timing)
 if(OTIO_PYTHON_INSTALL)

--- a/examples/conform.cpp
+++ b/examples/conform.cpp
@@ -117,7 +117,7 @@ int conform_timeline(
         // relink to the found path
         clip->set_media_reference(new otio::ExternalReference(
             "file://" + new_path,
-            otio::nullopt // we don't know the available range
+            otio::nullopt // the available range is unknown without opening the file
         ));
         count += 1;
     }

--- a/examples/conform.cpp
+++ b/examples/conform.cpp
@@ -114,7 +114,7 @@ int conform_timeline(
         if (new_path.empty())
             continue;
 
-        // if we found one, then relink to the new path
+        // relink to the found path
         clip->set_media_reference(new otio::ExternalReference(
             "file://" + new_path,
             otio::nullopt // we don't know the available range

--- a/examples/conform.cpp
+++ b/examples/conform.cpp
@@ -23,7 +23,7 @@
 //
 
 // Example OTIO script that reads a timeline and then relinks clips
-// to movie files found in a given folder, based on matching names.
+// to movie files found in a given folder, based on matching clip names to filenames.
 //
 // Demo:
 //

--- a/examples/conform.cpp
+++ b/examples/conform.cpp
@@ -54,11 +54,11 @@ namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
 // Look for media with this name in this folder.
 std::string find_matching_media(std::string const& name, std::string const& folder)
 {
-    // In this case we're looking in the filesystem.
-    // In your case, you might want to look in your asset management system
-    // and you might want to use studio-specific metadata in the clip instead
-    // of just the clip name.
-    // Something like this:
+    // This function is an example which searches the file system for matching media.
+    // A real world studio implementation would likely look in an asset management system
+    // and use studio-specific metadata in the clip's metadata dictionary instead
+    // of matching the clip name.
+    // For example:
     // shot = asset_database->find_shot(
     //    otio::any_cast<std::map<std::string, std::string> >(clip->metadata()["mystudio"])["shotID"]);
     // new_media = shot->latest_render("mov");
@@ -161,4 +161,3 @@ int main(int argc, char** argv)
     
     return 0;
 }
-

--- a/examples/conform.cpp
+++ b/examples/conform.cpp
@@ -63,7 +63,7 @@ std::string find_matching_media(std::string const& name, std::string const& fold
     //    otio::any_cast<std::map<std::string, std::string> >(clip->metadata()["mystudio"])["shotID"]);
     // new_media = shot->latest_render("mov");
     
-    const auto matches = glob(folder, name + ".*");
+    const auto matches = examples::glob(folder, name + ".*");
     
     if (matches.size() == 0)
     {
@@ -101,7 +101,7 @@ int conform_timeline(
     const auto clips = timeline->clip_if(&error_status);
     if (error_status)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         exit(1);
     }
     
@@ -132,29 +132,29 @@ int main(int argc, char** argv)
         std::cout << "Usage: conform (input) (folder) (output)" << std::endl;
         return 1;
     }
-    const std::string input = normalize_path(argv[1]);
-    const std::string folder = normalize_path(argv[2]);
-    const std::string output = normalize_path(argv[3]);
+    const std::string input = examples::normalize_path(argv[1]);
+    const std::string folder = examples::normalize_path(argv[2]);
+    const std::string output = examples::normalize_path(argv[3]);
     
     otio::ErrorStatus error_status;
     otio::SerializableObject::Retainer<otio::Timeline> timeline(
         dynamic_cast<otio::Timeline*>(otio::Timeline::from_json_file(input, &error_status)));
     if (!timeline || error_status)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         exit(1);
     }
     const int count = conform_timeline(timeline, folder);
     std::cout << "Relinked " << count << " clips to new media." << std::endl;
     if (!timeline.value->to_json_file(output, &error_status))
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         exit(1);
     }
     const auto clips = timeline->clip_if(&error_status);
     if (error_status)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         exit(1);
     }
     std::cout << "Saved " << output << " with " << clips.size() << " clips." << std::endl;

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -55,7 +55,7 @@ import opentimelineio as otio
 def parse_args():
     """ parse arguments out of sys.argv """
     parser = argparse.ArgumentParser(description=__doc__,
-        formatter_class=RawTextHelpFormatter)
+                                     formatter_class=RawTextHelpFormatter)
     parser.add_argument(
         '-i',
         '--input',

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -95,7 +95,7 @@ def _find_matching_media(name, folder):
     matches = glob.glob("{0}/{1}.*".format(folder, name))
     matches = list(map(os.path.abspath, matches))
 
-    if len(matches) == 0:
+    if not matches:
         # print "DEBUG: No match for clip '{0}'".format(name)
         return None
     if len(matches) == 1:

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -45,6 +45,7 @@ Saved conformed.otio with 100 clips.
 """
 
 import argparse
+from argparse import RawTextHelpFormatter
 import glob
 import os
 
@@ -53,12 +54,13 @@ import opentimelineio as otio
 
 def parse_args():
     """ parse arguments out of sys.argv """
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
     parser.add_argument(
-        'input',
+        '-i',
+        '--input',
         type=str,
         required=True,
-        help='Timeline file(s) to read. Supported formats: {adapters}'
+        help='Timeline file to read. Supported formats: {adapters}'
              ''.format(adapters=otio.adapters.available_adapter_names())
     )
     parser.add_argument(
@@ -90,7 +92,7 @@ def _find_matching_media(name, folder):
     # new_media = shot.latest_render(format='mov')
 
     matches = glob.glob("{0}/{1}.*".format(folder, name))
-    matches = map(os.path.abspath, matches)
+    matches = list(map(os.path.abspath, matches))
 
     if len(matches) == 0:
         # print "DEBUG: No match for clip '{0}'".format(name)

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -24,7 +24,7 @@
 #
 
 """Example OTIO script that reads a timeline and then relinks clips
-to movie files found in a given folder, based on matching names.
+to movie files found in a given folder, based on matching clip names to filenames.
 
 Demo:
 
@@ -84,11 +84,11 @@ def parse_args():
 def _find_matching_media(name, folder):
     """Look for media with this name in this folder."""
 
-    # In this case we're looking in the filesystem.
-    # In your case, you might want to look in your asset management system
-    # and you might want to use studio-specific metadata in the clip instead
-    # of just the clip name.
-    # Something like this:
+    # This function is an example which searches the file system for matching media.
+    # A real world studio implementation would likely look in an asset management system
+    # and use studio-specific metadata in the clip's metadata dictionary instead
+    # of matching the clip name.
+    # For example:
     # shot = asset_database.find_shot(clip.metadata['mystudio']['shotID'])
     # new_media = shot.latest_render(format='mov')
 
@@ -127,10 +127,10 @@ def _conform_timeline(timeline, folder):
         if not new_path:
             continue
 
-        # if we found one, then relink to the new path
+        # relink to the found path
         clip.media_reference = otio.schema.ExternalReference(
             target_url="file://" + new_path,
-            available_range=None  # we don't know the available range
+            available_range=None  # the available range is unknown without opening the file
         )
         count += 1
 

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -130,7 +130,8 @@ def _conform_timeline(timeline, folder):
         # relink to the found path
         clip.media_reference = otio.schema.ExternalReference(
             target_url="file://" + new_path,
-            available_range=None  # the available range is unknown without opening the file
+            available_range=None  # the available range is unknown without
+                                  # opening the file
         )
         count += 1
 

--- a/examples/conform.py
+++ b/examples/conform.py
@@ -54,7 +54,8 @@ import opentimelineio as otio
 
 def parse_args():
     """ parse arguments out of sys.argv """
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(description=__doc__,
+        formatter_class=RawTextHelpFormatter)
     parser.add_argument(
         '-i',
         '--input',

--- a/examples/flatten_video_tracks.cpp
+++ b/examples/flatten_video_tracks.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv)
     if (!timeline.value->to_json_file(argv[2], &error_status))
     {
         print_error(error_status);
-        return 1;            
+        return 1;
     }
 
     return 0;

--- a/examples/flatten_video_tracks.cpp
+++ b/examples/flatten_video_tracks.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
     otio::SerializableObject::Retainer<otio::Timeline> timeline(dynamic_cast<otio::Timeline*>(otio::Timeline::from_json_file(argv[1], &error_status)));
     if (!timeline)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
     auto video_tracks = timeline.value->video_tracks();
@@ -37,7 +37,7 @@ int main(int argc, char** argv)
     auto onetrack = otio::flatten_stack(video_tracks, &error_status);
     if (!onetrack)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
 
@@ -50,7 +50,7 @@ int main(int argc, char** argv)
     newtimeline.value->set_tracks(stack);
     if (!stack.value->append_child(onetrack, &error_status))
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;            
     }
 
@@ -60,12 +60,12 @@ int main(int argc, char** argv)
         auto clone = dynamic_cast<otio::Track*>(audio_track->clone(&error_status));
         if (!clone)
         {
-            print_error(error_status);
+            examples::print_error(error_status);
             return 1;
         }
         if (!stack.value->append_child(clone, &error_status))
         {
-            print_error(error_status);
+            examples::print_error(error_status);
             return 1;
         }
     }
@@ -75,7 +75,7 @@ int main(int argc, char** argv)
         newtimeline.value->audio_tracks().size() << " audio tracks." << std::endl;
     if (!timeline.value->to_json_file(argv[2], &error_status))
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
 

--- a/examples/python_adapters_child_process.cpp
+++ b/examples/python_adapters_child_process.cpp
@@ -50,9 +50,9 @@ otio::SerializableObject::Retainer<otio::Timeline> PythonAdapters::read_from_fil
     otio::ErrorStatus* error_status)
 {
     // Convert the input file to a temporary JSON file.
-    const std::string temp_file_name = create_temp_dir() + "/temp.otio";
+    const std::string temp_file_name = examples::create_temp_dir() + "/temp.otio";
     std::stringstream ss;
-    ss << "otioconvert" << " -i " << normalize_path(file_name) << " -o " << temp_file_name;
+    ss << "otioconvert" << " -i " << examples::normalize_path(file_name) << " -o " << temp_file_name;
     _run_process(ss.str(), error_status);
 
     // Read the temporary JSON file.
@@ -65,7 +65,7 @@ bool PythonAdapters::write_to_file(
     otio::ErrorStatus* error_status)
 {
     // Write the temporary JSON file.
-    const std::string temp_file_name = create_temp_dir() + "/temp.otio";
+    const std::string temp_file_name = examples::create_temp_dir() + "/temp.otio";
     if (!timeline.value->to_json_file(temp_file_name, error_status))
     {
         return false;
@@ -73,7 +73,7 @@ bool PythonAdapters::write_to_file(
 
     // Convert the temporary JSON file to the output file.
     std::stringstream ss;
-    ss << "otioconvert" << " -i " << temp_file_name << " -o " << normalize_path(file_name);
+    ss << "otioconvert" << " -i " << temp_file_name << " -o " << examples::normalize_path(file_name);
     _run_process(ss.str(), error_status);
 
     return true;
@@ -184,7 +184,7 @@ int main(int argc, char** argv)
     auto timeline = PythonAdapters::read_from_file(argv[1], &error_status);
     if (!timeline)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
 
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
 
     if (!PythonAdapters::write_to_file(timeline, argv[2], &error_status))
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
 

--- a/examples/python_adapters_embed.cpp
+++ b/examples/python_adapters_embed.cpp
@@ -87,7 +87,7 @@ otio::SerializableObject::Retainer<otio::Timeline> PythonAdapters::read_from_fil
         // Read the timeline into Python.
         auto p_read_from_file = PyObjectRef(PyObject_GetAttrString(p_module, "read_from_file"));
         auto p_read_from_file_args = PyObjectRef(PyTuple_New(1));
-        const std::string file_name_normalized = normalize_path(file_name);
+        const std::string file_name_normalized = examples::normalize_path(file_name);
         auto p_read_from_file_arg = PyUnicode_FromStringAndSize(file_name_normalized.c_str(), file_name_normalized.size());
         if (!p_read_from_file_arg)
         {
@@ -146,7 +146,7 @@ bool PythonAdapters::write_to_file(
         // Write the Python timeline.
         auto p_write_to_file = PyObjectRef(PyObject_GetAttrString(p_module, "write_to_file"));
         auto p_write_to_file_args = PyObjectRef(PyTuple_New(2));
-        const std::string file_name_normalized = normalize_path(file_name);
+        const std::string file_name_normalized = examples::normalize_path(file_name);
         auto p_write_to_file_arg = PyUnicode_FromStringAndSize(file_name_normalized.c_str(), file_name_normalized.size());
         if (!p_write_to_file_arg)
         {
@@ -183,7 +183,7 @@ int main(int argc, char** argv)
     auto timeline = adapters.read_from_file(argv[1], &error_status);
     if (!timeline)
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
 
@@ -192,7 +192,7 @@ int main(int argc, char** argv)
 
     if (!adapters.write_to_file(timeline, argv[2], &error_status))
     {
-        print_error(error_status);
+        examples::print_error(error_status);
         return 1;
     }
 

--- a/examples/summarize_timing.cpp
+++ b/examples/summarize_timing.cpp
@@ -39,7 +39,7 @@ void summarize_effects(otio::SerializableObject::Retainer<otio::Item> const& ite
     }
 }
 
-void _summarize_range(std::string const& label, otio::TimeRange const& time_range, otio::ErrorStatus const& errorStatus)
+void summarize_range(std::string const& label, otio::TimeRange const& time_range, otio::ErrorStatus const& errorStatus)
 {
     if (errorStatus.outcome != otio::ErrorStatus::Outcome::OK)
     {
@@ -80,9 +80,9 @@ void summarize_timeline(otio::SerializableObject::Retainer<otio::Timeline> const
                         // See the documentation to understand the difference
                         // between each of these ranges:
                         // https://opentimelineio.readthedocs.io/en/latest/tutorials/time-ranges.html
-                        _summarize_range("  Trimmed Range", clip->trimmed_range(&errorStatus), errorStatus);
-                        _summarize_range("  Visible Range", clip->visible_range(&errorStatus), errorStatus);
-                        _summarize_range("Available Range", clip->available_range(&errorStatus), errorStatus);
+                        summarize_range("  Trimmed Range", clip->trimmed_range(&errorStatus), errorStatus);
+                        summarize_range("  Visible Range", clip->visible_range(&errorStatus), errorStatus);
+                        summarize_range("Available Range", clip->available_range(&errorStatus), errorStatus);
                     }
                     else if (auto gap = dynamic_cast<otio::Gap*>(item))
                     {

--- a/examples/summarize_timing.cpp
+++ b/examples/summarize_timing.cpp
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
         otio::SerializableObject::Retainer<otio::Timeline> timeline(dynamic_cast<otio::Timeline*>(otio::Timeline::from_json_file(argv[i], &error_status)));
         if (!timeline)
         {
-            print_error(error_status);
+            examples::print_error(error_status);
             return 1;
         }
         

--- a/examples/util.cpp
+++ b/examples/util.cpp
@@ -28,6 +28,8 @@
 
 namespace otio = opentimelineio::OPENTIMELINEIO_VERSION;
 
+namespace examples {
+
 #if defined(_WINDOWS)
 
 std::string normalize_path(std::string const& in)
@@ -188,5 +190,7 @@ void print_error(otio::ErrorStatus const& error_status)
     std::cout << "ERROR: " <<
         otio::ErrorStatus::outcome_to_string(error_status.outcome) << ": " <<
         error_status.details << std::endl;
+}
+
 }
 

--- a/examples/util.cpp
+++ b/examples/util.cpp
@@ -70,6 +70,12 @@ std::string create_temp_dir()
     return out;
 }
 
+std::vector<std::string> glob(std::string const& in)
+{
+    std::vector<std::string> out;
+    return out;
+}
+
 #else // _WINDOWS
 
 std::string normalize_path(std::string const& in)
@@ -105,6 +111,12 @@ std::string create_temp_dir()
     memcpy(buf.data(), path.c_str(), size);
     buf[size] = 0;
     return mkdtemp(buf.data());
+}
+
+std::vector<std::string> glob(std::string const& in)
+{
+    std::vector<std::string> out;
+    return out;
 }
 
 #endif // _WINDOWS

--- a/examples/util.h
+++ b/examples/util.h
@@ -7,11 +7,14 @@
 // Normalize path (change '\' path delimeters to '/').
 std::string normalize_path(std::string const&);
 
+// Get the absolute path.
+std::string absolute(std::string const&);
+
 // Create a temporary directory.
 std::string create_temp_dir();
 
 // Get a list of files from a directory.
-std::vector<std::string> glob(std::string const&);
+std::vector<std::string> glob(std::string const& path, std::string const& pattern);
 
 // Print an error to std::cerr.
 void print_error(opentimelineio::OPENTIMELINEIO_VERSION::ErrorStatus const&);

--- a/examples/util.h
+++ b/examples/util.h
@@ -2,11 +2,16 @@
 
 #include <opentimelineio/errorStatus.h>
 
+#include <vector>
+
 // Normalize path (change '\' path delimeters to '/').
 std::string normalize_path(std::string const&);
 
 // Create a temporary directory.
 std::string create_temp_dir();
+
+// Get a list of files from a directory.
+std::vector<std::string> glob(std::string const&);
 
 // Print an error to std::cerr.
 void print_error(opentimelineio::OPENTIMELINEIO_VERSION::ErrorStatus const&);

--- a/examples/util.h
+++ b/examples/util.h
@@ -4,6 +4,8 @@
 
 #include <vector>
 
+namespace examples {
+
 // Normalize path (change '\' path delimeters to '/').
 std::string normalize_path(std::string const&);
 
@@ -18,4 +20,6 @@ std::vector<std::string> glob(std::string const& path, std::string const& patter
 
 // Print an error to std::cerr.
 void print_error(opentimelineio::OPENTIMELINEIO_VERSION::ErrorStatus const&);
+
+}
 


### PR DESCRIPTION
```Fixes #994```

This PR adds a C++ version of the conform.py example. The code is mostly identical to the Python version except for the ```argparse``` command line parsing which doesn't have an equivalent in C++.

There are also a couple minor fixes to other example files, I can break those out into a separate PR if necessary. Specifically conform.py had some syntax errors with my Python 3 setup, hopefully the changes I made are also compatible with Python 2. It might be worthwhile to add the examples to the CI at some point...
