### PR TITLE
Spatial Bounds with Imath

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/deps/any"]
 	path = src/deps/any
 	url = https://github.com/thelink2012/any.git
+[submodule "src/deps/Imath"]
+	path = src/deps/Imath
+	url = https://github.com/AcademySoftwareFoundation/Imath

--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -60,6 +60,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *metadata*
 - *name*
 
@@ -128,6 +129,13 @@ parameters:
 
 ## Module: opentimelineio.schema
 
+### Bounds.1
+
+parameters:
+- *box*
+- *metadata*
+- *name*
+
 ### Clip.1
 
 parameters:
@@ -149,6 +157,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *metadata*
 - *name*
 - *target_url*
@@ -174,6 +183,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *generator_kind*
 - *metadata*
 - *name*
@@ -183,6 +193,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *frame_step*
 - *frame_zero_padding*
 - *metadata*
@@ -214,6 +225,7 @@ parameters:
 
 parameters:
 - *available_range*
+- *bounds*
 - *metadata*
 - *name*
 

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -114,6 +114,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *metadata*: 
 - *name*: 
 
@@ -257,6 +258,21 @@ parameters:
 
 ## Module: opentimelineio.schema
 
+### Bounds.1
+
+*full module path*: `opentimelineio.schema.Bounds`
+
+*documentation*:
+
+```
+None
+```
+
+parameters:
+- *box*: 
+- *metadata*: 
+- *name*: 
+
 ### Clip.1
 
 *full module path*: `opentimelineio.schema.Clip`
@@ -302,6 +318,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *metadata*: 
 - *name*: 
 - *target_url*: 
@@ -351,6 +368,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *generator_kind*: 
 - *metadata*: 
 - *name*: 
@@ -428,6 +446,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *frame_step*: Step between frame numbers in file names.
 - *frame_zero_padding*: Number of digits to pad zeros out to in frame numbers.
 - *metadata*: 
@@ -483,6 +502,7 @@ None
 
 parameters:
 - *available_range*: 
+- *bounds*: 
 - *metadata*: 
 - *name*: 
 

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # detect if the submodules haven't been updated
-set(DEPS_SUBMODULES any optional-lite pybind11 rapidjson)
+set(DEPS_SUBMODULES any optional-lite pybind11 rapidjson Imath)
 foreach(submodule IN LISTS DEPS_SUBMODULES)
     file(GLOB SUBMOD_CONTENTS ${submodule})
     list(LENGTH SUBMOD_CONTENTS SUBMOD_CONTENT_LEN)
@@ -22,3 +22,15 @@ if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
     install(FILES optional-lite/include/nonstd/optional.hpp
     	    DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio/deps/nonstd")
 endif()
+
+# preserve BUILD_SHARED_LIBS options for this project, but set it off for Imath
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+set(BUILD_SHARED_LIBS OFF)
+
+# If we do not want Imath to install headers and CMake files use the EXCLUDE_FROM_ALL option
+if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
+  add_subdirectory(Imath)
+else()
+  add_subdirectory(Imath EXCLUDE_FROM_ALL)
+endif()
+

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -5,6 +5,7 @@ set(OPENTIMELINEIO_HEADER_FILES
     any.h
     anyDictionary.h
     anyVector.h
+    bounds.h
     clip.h
     composable.h
     composition.h
@@ -41,6 +42,7 @@ set(OPENTIMELINEIO_HEADER_FILES
     version.h)
 
 add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB} 
+            bounds.cpp
             clip.cpp
             composable.cpp
             composition.cpp
@@ -82,7 +84,7 @@ target_include_directories(opentimelineio PRIVATE
                            "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
                            "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
 
-target_link_libraries(opentimelineio PUBLIC opentime)
+target_link_libraries(opentimelineio PUBLIC opentime Imath::Imath)
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
     LIBRARY_OUTPUT_NAME "opentimelineio"

--- a/src/opentimelineio/bounds.cpp
+++ b/src/opentimelineio/bounds.cpp
@@ -1,0 +1,22 @@
+#include "opentimelineio/bounds.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
+
+Bounds::Bounds(std::string const& name,
+               optional<Imath::Box2d> const& box,
+               AnyDictionary const& metadata)
+    : Parent(name, metadata),
+      _box( box ) {
+}
+
+bool Bounds::read_from(Reader& reader) {
+    return reader.read("box", &_box) &&
+           Parent::read_from(reader);
+}
+
+void Bounds::write_to(Writer& writer) const {
+    Parent::write_to(writer);
+    writer.write("box", _box);
+}
+
+} }

--- a/src/opentimelineio/bounds.h
+++ b/src/opentimelineio/bounds.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "opentimelineio/serializableObjectWithMetadata.h"
+#include <ImathBox.h>
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
+
+class Bounds : public SerializableObjectWithMetadata {
+public:
+    struct Schema {
+       static auto constexpr name = "Bounds";
+       static int constexpr version = 1;
+    };
+
+    using Parent = SerializableObjectWithMetadata;
+
+    explicit Bounds(std::string const& name = std::string(),
+                    optional<Imath::Box2d> const& box = nullopt,
+                    AnyDictionary const& metadata = AnyDictionary());
+
+    optional<Imath::Box2d> const& box() const {
+        return _box;
+    }
+
+    void set_box(optional<Imath::Box2d> const & box) {
+        _box = box;
+    }
+
+protected:
+    virtual ~Bounds() = default;
+
+    virtual bool read_from(Reader&);
+    virtual void write_to(Writer&) const;
+
+private:
+    optional<Imath::Box2d> _box;
+};
+
+} }
+

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -50,4 +50,21 @@ TimeRange Clip::available_range(ErrorStatus* error_status) const {
     return _media_reference->available_range().value();
 }
 
+SerializableObject::Retainer<Bounds> 
+Clip::bounds(ErrorStatus* error_status) const {
+    if (!_media_reference) {
+        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+                                    "No media reference set on clip", this);
+        return Retainer<Bounds>();
+    }
+
+    if (!_media_reference.value->bounds()) {
+        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+                                    "No bounds set on media reference on clip", this);
+        return Retainer<Bounds>();
+    }
+
+    return _media_reference.value->bounds();
+}
+
 } }

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -26,6 +26,8 @@ public:
     
     virtual TimeRange available_range(ErrorStatus* error_status) const;
 
+    virtual Retainer<Bounds> bounds(ErrorStatus* error_status) const;
+
 protected:
     virtual ~Clip();
 

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -50,4 +50,10 @@ RationalTime Composable::duration(ErrorStatus* error_status) const {
     return RationalTime();
 }
 
+SerializableObject::Retainer<Bounds> 
+Composable::bounds(ErrorStatus* error_status) const {
+    *error_status = ErrorStatus::NOT_IMPLEMENTED;
+    return Retainer<Bounds>();
+}
+
 } }

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "opentimelineio/version.h"
+#include "opentimelineio/bounds.h"
 #include "opentimelineio/serializableObjectWithMetadata.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
@@ -27,6 +28,8 @@ public:
     }
     
     virtual RationalTime duration(ErrorStatus* error_status) const;
+
+    virtual Retainer<Bounds> bounds(ErrorStatus* error_status) const;
 
 protected:
     bool _set_parent(Composition*);

--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -1,5 +1,6 @@
 #include "opentimelineio/composition.h"
 #include "opentimelineio/vectorIndexing.h"
+#include "opentimelineio/clip.h"
 
 #include <assert.h>
 #include <set>
@@ -496,6 +497,20 @@ int64_t Composition::_bisect_left(
     }
 
     return *lower_search_bound;
+}
+
+bool Composition::has_clips() const {
+    for (auto child: children()) {
+        if (dynamic_cast<Clip*>(child.value)) {
+            return true;
+        }
+        else if (auto child_comp = dynamic_cast<Composition*>(child.value)) {
+            if( child_comp->has_clips() ) {
+               return true;
+            }
+        }
+    }
+    return false;
 }
 
 } }

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -57,6 +57,8 @@ public:
 
     bool has_child(Composable* child) const;
     
+    bool has_clips() const;
+
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 
     // Return the child that overlaps with time search_time.

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -439,6 +439,16 @@ any SerializableObject::Reader::_decode(_Resolver& resolver) {
 
         return any(SerializableObject::ReferenceId { ref_id });
     }
+    else if (schema_name_and_version == "V2d.1") {
+        double x,y;
+        return _fetch("x", &x) && _fetch("y", &y) ? 
+            any(Imath::V2d(x,y)) : any();
+    }
+    else if (schema_name_and_version == "Box2d.1") {
+        Imath::V2d min, max; 
+        return _fetch("min", &min) && _fetch("max", &max) ? 
+            any(Imath::Box2d(std::move(min), std::move(max))) : any();
+    }
     else {
         std::string ref_id;
         if (_dict.find("OTIO_REF_ID") != _dict.end()) {
@@ -524,6 +534,14 @@ bool SerializableObject::Reader::read(std::string const& key, AnyVector* value) 
     return _fetch(key, value);
 }
 
+bool SerializableObject::Reader::read(std::string const& key, Imath::V2d* value) {
+    return _fetch(key, value);
+}
+
+bool SerializableObject::Reader::read(std::string const& key, Imath::Box2d* value) {
+    return _fetch(key, value);
+}
+
 template <typename T>
 bool SerializableObject::Reader::_read_optional(std::string const& key, optional<T>* value) {
     bool had_null;
@@ -556,6 +574,10 @@ bool SerializableObject::Reader::read(std::string const& key, optional<TimeRange
 }
 
 bool SerializableObject::Reader::read(std::string const& key, optional<TimeTransform>* value) {
+    return _read_optional(key, value);
+}
+
+bool SerializableObject::Reader::read(std::string const& key, optional<Imath::Box2d>* value) {
     return _read_optional(key, value);
 }
 

--- a/src/opentimelineio/errorStatus.cpp
+++ b/src/opentimelineio/errorStatus.cpp
@@ -52,6 +52,8 @@ std::string ErrorStatus::outcome_to_string(Outcome o) {
         return "cannot compute duration on this type of object";
     case CANNOT_TRIM_TRANSITION:
         return "cannot trim transition";
+    case CANNOT_COMPUTE_BOUNDS:
+        return "cannot compute bounds";
     default:
         return "unknown/illegal ErrorStatus::Outcome code";
     };

--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -37,7 +37,8 @@ struct ErrorStatus {
         INVALID_TIME_RANGE,
         OBJECT_WITHOUT_DURATION,
         CANNOT_TRIM_TRANSITION,
-        OBJECT_CYCLE
+        OBJECT_CYCLE,
+        CANNOT_COMPUTE_BOUNDS
     };
 
     ErrorStatus()

--- a/src/opentimelineio/externalReference.cpp
+++ b/src/opentimelineio/externalReference.cpp
@@ -4,8 +4,9 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 ExternalReference::ExternalReference(std::string const& target_url,
                                      optional<TimeRange> const& available_range,
-                                     AnyDictionary const& metadata)
-    : Parent(std::string(), available_range, metadata),
+                                     AnyDictionary const& metadata, 
+                                     Bounds* bounds)
+    : Parent(std::string(), available_range, metadata, bounds ),
       _target_url(target_url) {
 }
 

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -16,7 +16,8 @@ public:
 
     ExternalReference(std::string const& target_url = std::string(),
                       optional<TimeRange> const& available_range = nullopt,
-                      AnyDictionary const& metadata = AnyDictionary());
+                      AnyDictionary const& metadata = AnyDictionary(),
+                      Bounds* bounds = nullptr);
         
     std::string const& target_url() const {
         return _target_url;

--- a/src/opentimelineio/generatorReference.cpp
+++ b/src/opentimelineio/generatorReference.cpp
@@ -6,8 +6,9 @@ GeneratorReference::GeneratorReference(std::string const& name,
                                        std::string const& generator_kind,
                                        optional<TimeRange> const& available_range,
                                        AnyDictionary const& parameters,
-                                       AnyDictionary const& metadata)
-    : Parent(name, available_range, metadata),
+                                       AnyDictionary const& metadata,
+                                       Bounds* bounds)
+    : Parent(name, available_range, metadata, bounds),
       _generator_kind(generator_kind),
       _parameters(parameters) {
 }

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -18,7 +18,8 @@ public:
                        std::string const& generator_kind = std::string(),
                        optional<TimeRange> const& available_range = nullopt,
                        AnyDictionary const& parameters = AnyDictionary(),
-                       AnyDictionary const& metadata = AnyDictionary());
+                       AnyDictionary const& metadata = AnyDictionary(),
+                       Bounds* bounds = nullptr);
         
     std::string const& generator_kind() const {
         return _generator_kind;

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -11,8 +11,9 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
                       int frame_zero_padding,
                       MissingFramePolicy const missing_frame_policy,
                       optional<TimeRange> const& available_range,
-                      AnyDictionary const& metadata)
-    : Parent(std::string(), available_range, metadata),
+                      AnyDictionary const& metadata,
+                      Bounds* bounds)
+    : Parent(std::string(), available_range, metadata, bounds),
     _target_url_base(target_url_base),
     _name_prefix(name_prefix),
     _name_suffix(name_suffix),

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -29,7 +29,8 @@ public:
                       int frame_zero_padding = 0,
                       MissingFramePolicy const missing_frame_policy = MissingFramePolicy::error,
                       optional<TimeRange> const& available_range = nullopt,
-                      AnyDictionary const& metadata = AnyDictionary());
+                      AnyDictionary const& metadata = AnyDictionary(), 
+                      Bounds* bounds = nullptr);
         
     std::string const& target_url_base() const {
         return _target_url_base;

--- a/src/opentimelineio/mediaReference.cpp
+++ b/src/opentimelineio/mediaReference.cpp
@@ -4,9 +4,11 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 MediaReference::MediaReference(std::string const& name,
                                optional<TimeRange> const& available_range,
-                               AnyDictionary const& metadata)
+                               AnyDictionary const& metadata,
+                               Bounds* bounds)
     : Parent(name, metadata),
-      _available_range(available_range) {
+      _available_range(available_range),
+      _bounds(bounds) {
 }
 
 MediaReference::~MediaReference() {
@@ -19,12 +21,14 @@ bool MediaReference::is_missing_reference() const {
 
 bool MediaReference::read_from(Reader& reader) {
     return reader.read_if_present("available_range", &_available_range) &&
+        reader.read_if_present("bounds", &_bounds) &&
         Parent::read_from(reader);
 }
 
 void MediaReference::write_to(Writer& writer) const {
     Parent::write_to(writer);
     writer.write("available_range", _available_range);
+    writer.write("bounds", _bounds);
 }
 
 } }

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -2,6 +2,7 @@
 
 #include "opentimelineio/version.h"
 #include "opentimelineio/serializableObjectWithMetadata.h"
+#include "opentimelineio/bounds.h"
 
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 
@@ -18,7 +19,8 @@ public:
 
     MediaReference(std::string const& name = std::string(),
                    optional<TimeRange> const& available_range = nullopt,
-                   AnyDictionary const& metadata = AnyDictionary());
+                   AnyDictionary const& metadata = AnyDictionary(),
+                   Bounds* bounds = nullptr);
 
     optional<TimeRange> const& available_range () const {
         return _available_range;
@@ -29,7 +31,15 @@ public:
     }
 
     virtual bool is_missing_reference() const;
-    
+   
+    Retainer<Bounds> bounds() const {
+        return _bounds;
+    }
+
+    void set_bounds(Bounds* bounds) {
+        _bounds = bounds;
+    } 
+
 protected:
     virtual ~MediaReference();
 
@@ -38,6 +48,7 @@ protected:
 
 private:
     optional<TimeRange> _available_range;
+    Retainer<Bounds> _bounds;
 };
 
 } }

--- a/src/opentimelineio/missingReference.cpp
+++ b/src/opentimelineio/missingReference.cpp
@@ -4,8 +4,9 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 MissingReference::MissingReference(std::string const& name,
                                    optional<TimeRange> const& available_range,
-                                   AnyDictionary const& metadata)
-    : Parent(name, available_range, metadata) {
+                                   AnyDictionary const& metadata,
+                                   Bounds* bounds)
+    : Parent(name, available_range, metadata, bounds) {
 }
 
 MissingReference::~MissingReference() {

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -16,7 +16,8 @@ public:
 
     MissingReference(std::string const& name = std::string(),
                      optional<TimeRange> const& available_range = nullopt,
-                     AnyDictionary const& metadata = AnyDictionary());
+                     AnyDictionary const& metadata = AnyDictionary(),
+                     Bounds* bounds = nullptr);
 
     virtual bool is_missing_reference() const;
 

--- a/src/opentimelineio/safely_typed_any.cpp
+++ b/src/opentimelineio/safely_typed_any.cpp
@@ -38,6 +38,14 @@ any create_safely_typed_any(TimeTransform&& value) {
     return any(value);
 }
 
+any create_safely_typed_any(Imath::V2d&& value) {
+    return any(value);
+}
+
+any create_safely_typed_any(Imath::Box2d&& value) {
+    return any(value);
+}
+
 any create_safely_typed_any(AnyVector&& value) {
     return any(std::move(value));
 }
@@ -85,6 +93,14 @@ TimeRange safely_cast_time_range_any(any const& a) {
 
 TimeTransform safely_cast_time_transform_any(any const& a) {
     return any_cast<TimeTransform>(a);
+}
+
+Imath::V2d safely_cast_point_any(any const& a) {
+    return any_cast<Imath::V2d>(a);
+}
+
+Imath::Box2d safely_cast_box_any(any const& a) {
+    return any_cast<Imath::Box2d>(a);
 }
 
 AnyDictionary safely_cast_any_dictionary_any(any const& a) {

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -33,6 +33,8 @@ any create_safely_typed_any(std::string&&);
 any create_safely_typed_any(RationalTime&&);
 any create_safely_typed_any(TimeRange&&);
 any create_safely_typed_any(TimeTransform&&);
+any create_safely_typed_any(Imath::V2d&&);
+any create_safely_typed_any(Imath::Box2d&&);
 any create_safely_typed_any(AnyVector&&);
 any create_safely_typed_any(AnyDictionary&&);
 any create_safely_typed_any(SerializableObject*);
@@ -46,6 +48,8 @@ std::string safely_cast_string_any(any const& a);
 RationalTime safely_cast_rational_time_any(any const& a);
 TimeRange safely_cast_time_range_any(any const& a);
 TimeTransform safely_cast_time_transform_any(any const& a);
+Imath::V2d safely_cast_point_any(any const& a);
+Imath::Box2d safely_cast_box_any(any const& a);
 SerializableObject* safely_cast_retainer_any(any const& a);
 
 AnyDictionary safely_cast_any_dictionary_any(any const& a);

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -11,6 +11,8 @@
 #include "opentime/timeRange.h"
 #include "opentime/timeTransform.h"
 
+#include <ImathBox.h>
+
 #include <list>
 #include <type_traits>
 
@@ -74,6 +76,8 @@ public:
         bool read(std::string const& key, RationalTime* dest);
         bool read(std::string const& key, TimeRange* dest);
         bool read(std::string const& key, class TimeTransform* dest);
+        bool read(std::string const& key, Imath::V2d* value);
+        bool read(std::string const& key, Imath::Box2d* value);
         bool read(std::string const& key, AnyVector* dest);
         bool read(std::string const& key, AnyDictionary* dest);
         bool read(std::string const& key, any* dest);
@@ -84,6 +88,8 @@ public:
         bool read(std::string const& key, optional<RationalTime>* dest);
         bool read(std::string const& key, optional<TimeRange>* dest);
         bool read(std::string const& key, optional<TimeTransform>* dest);
+        bool read(std::string const& key, optional<Imath::Box2d>* value);
+
         // skipping std::string because we translate null into the empty
         // string, so the conversion is somewhat ambiguous
 
@@ -324,8 +330,11 @@ public:
         void write(std::string const& key, std::string const& value);
         void write(std::string const& key, RationalTime value);
         void write(std::string const& key, TimeRange value);
+        void write(std::string const& key, Imath::V2d value);
+        void write(std::string const& key, Imath::Box2d value);
         void write(std::string const& key, optional<RationalTime> value);
         void write(std::string const& key, optional<TimeRange> value);
+        void write(std::string const& key, optional<Imath::Box2d> value);
         void write(std::string const& key, class TimeTransform value);
         void write(std::string const& key, SerializableObject const* value);
         void write(std::string const& key, SerializableObject* value) {

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -54,6 +54,7 @@ public:
     virtual void write_value(class TimeRange const& value) = 0;
     virtual void write_value(class TimeTransform const& value) = 0;
     virtual void write_value(struct SerializableObject::ReferenceId) = 0;
+    virtual void write_value(Imath::Box2d const&) = 0;
 
 protected:
     void _error(ErrorStatus const& error_status) {
@@ -154,6 +155,14 @@ public:
     }
     
     void write_value(SerializableObject::ReferenceId value) {
+        _store(any(value));
+    }
+
+    void write_value(Imath::V2d const& value) {
+        _store(any(value));
+    }
+
+    void write_value(Imath::Box2d const& value) {
         _store(any(value));
     }
 
@@ -357,6 +366,36 @@ public:
         _writer.EndObject();
     }
 
+    void write_value(Imath::V2d const& value) {
+        _writer.StartObject();
+
+        _writer.Key("OTIO_SCHEMA");
+        _writer.String("V2d.1");
+
+        _writer.Key("x");
+        _writer.Double(value.x);
+
+        _writer.Key("y");
+        _writer.Double(value.y);
+
+        _writer.EndObject();
+    }
+
+    void write_value(Imath::Box2d const& value) {
+        _writer.StartObject();
+
+        _writer.Key("OTIO_SCHEMA");
+        _writer.String("Box2d.1");
+
+        _writer.Key("min");
+        write_value(value.min);
+
+        _writer.Key("max");
+        write_value(value.max);
+
+        _writer.EndObject();
+    }
+
     void start_array(size_t) {
         _writer.StartArray();
     }
@@ -409,6 +448,9 @@ void SerializableObject::Writer::_build_dispatch_tables() {
     wt[&typeid(RationalTime)] = [this](any const& value) { _encoder.write_value(any_cast<RationalTime const&>(value)); };
     wt[&typeid(TimeRange)] = [this](any const& value) { _encoder.write_value(any_cast<TimeRange const&>(value)); };
     wt[&typeid(TimeTransform)] = [this](any const& value) { _encoder.write_value(any_cast<TimeTransform const&>(value)); };
+    wt[&typeid(Imath::V2d)] = [this](any const& value) { _encoder.write_value(any_cast<Imath::V2d const&>(value)); };
+    wt[&typeid(Imath::Box2d)] = [this](any const& value) { _encoder.write_value(any_cast<Imath::Box2d const&>(value)); };
+
 
     /*
      * These next recurse back through the Writer itself:
@@ -441,6 +483,9 @@ void SerializableObject::Writer::_build_dispatch_tables() {
     et[&typeid(TimeRange)] = &_simple_any_comparison<TimeRange>;
     et[&typeid(TimeTransform)] = &_simple_any_comparison<TimeTransform>;
     et[&typeid(SerializableObject::ReferenceId)] = &_simple_any_comparison<SerializableObject::ReferenceId>;
+    et[&typeid(Imath::V2d)] = &_simple_any_comparison<Imath::V2d>;
+    et[&typeid(Imath::Box2d)] = &_simple_any_comparison<Imath::Box2d>;
+
 
     /*
      * These next recurse back through the Writer itself:
@@ -551,6 +596,11 @@ void SerializableObject::Writer::write(std::string const& key, optional<TimeRang
     value ? _encoder.write_value(*value) : _encoder.write_null_value();
 }
 
+void SerializableObject::Writer::write(std::string const& key, optional<Imath::Box2d> value) {
+    _encoder_write_key(key);
+    value ? _encoder.write_value(*value) : _encoder.write_null_value();
+}
+
 void SerializableObject::Writer::write(std::string const& key, TimeTransform value) {
     _encoder_write_key(key);
     _encoder.write_value(value);
@@ -617,6 +667,16 @@ void SerializableObject::Writer::write(std::string const& key, SerializableObjec
         _id_for_object.erase(valueEntry);
     }
 #endif    
+}
+
+void SerializableObject::Writer::write(std::string const& key, Imath::V2d value) {
+    _encoder_write_key(key);
+    _encoder.write_value(value);
+}
+
+void SerializableObject::Writer::write(std::string const& key, Imath::Box2d value) {
+    _encoder_write_key(key);
+    _encoder.write_value(value);
 }
 
 void SerializableObject::Writer::write(std::string const& key, AnyDictionary const& value) {

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -93,4 +93,45 @@ std::vector<SerializableObject::Retainer<Clip>> Stack::clip_if(
     return children_if<Clip>(error_status, search_range, shallow_search);
 }
 
+SerializableObject::Retainer<Bounds> 
+Stack::bounds(ErrorStatus* error_status) const {
+    optional<Imath::Box2d> box;
+    bool found_first_child = false;
+    for (auto child: children()) {
+        optional<Imath::Box2d> child_box;
+        if (auto comp = dynamic_cast<Composition*>(child.value)) {
+            if (!comp->has_clips()) {
+                continue;
+            }
+            if (auto child_bounds = comp->bounds(error_status)) {
+               
+                child_box = (*child_bounds).box();
+            }
+        }
+        else if (auto clip = dynamic_cast<Clip*>(child.value)) {
+            if (auto child_bounds = clip->bounds(error_status)) {
+                child_box = (*child_bounds).box();
+            }
+        }
+        else {
+           continue;
+        }
+
+        if (*error_status) {
+           return Retainer<Bounds>();
+        }
+
+        if ( child_box ) {
+            if (found_first_child) {
+                box->extendBy(*child_box);
+            }
+            else {
+                box = child_box;
+                found_first_child = true;
+            }          
+        }
+    }
+    return Retainer<Bounds>( box ? new Bounds( std::string(), *box ) : nullptr );
+}
+
 } }

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -29,6 +29,8 @@ public:
 
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 
+    Retainer<Bounds> bounds(ErrorStatus* error_status) const;
+
     // Return a vector of clips.
     //
     // An optional search_range may be provided to limit the search.

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -72,6 +72,10 @@ public:
         optional<TimeRange> search_range = nullopt,
         bool shallow_search = false) const;
     
+    Retainer<Bounds> bounds(ErrorStatus* error_status) const {
+        return _tracks.value->bounds(error_status);
+    }
+
 protected:
     virtual ~Timeline();
 

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -1,6 +1,7 @@
 #include "opentimelineio/track.h"
 #include "opentimelineio/clip.h"
 #include "opentimelineio/transition.h"
+#include "opentimelineio/clip.h"
 #include "opentimelineio/gap.h"
 #include "opentimelineio/vectorIndexing.h"
 
@@ -216,6 +217,32 @@ std::vector<SerializableObject::Retainer<Clip>> Track::clip_if(
     bool shallow_search) const
 {
     return children_if<Clip>(error_status, search_range, shallow_search);
+}
+
+SerializableObject::Retainer<Bounds> 
+Track::bounds(ErrorStatus* error_status) const {
+    optional<Imath::Box2d> box;
+    bool found_first_clip = false;
+    for (auto child: children()) {
+        if (auto clip = dynamic_cast<Clip*>(child.value)) {
+            if (auto clip_bounds = clip->bounds(error_status)) {
+                auto clip_box = (*clip_bounds).box();
+                if (clip_box) {
+                    if (found_first_clip) {
+                        box->extendBy(*clip_box);
+                    }
+                    else {
+                        box = clip_box;
+                        found_first_clip = true;
+                    }
+                }
+            }
+            if (*error_status) {
+                return Retainer<Bounds>();
+            }
+        }
+    }
+    return Retainer<Bounds>( box ? new Bounds( std::string(), *box ) : nullptr );
 }
 
 } }

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -51,6 +51,8 @@ public:
 
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 
+    Retainer<Bounds> bounds(ErrorStatus* error_status) const;
+
     // Return a vector of clips.
     //
     // An optional search_range may be provided to limit the search.

--- a/src/opentimelineio/typeRegistry.cpp
+++ b/src/opentimelineio/typeRegistry.cpp
@@ -1,6 +1,7 @@
 #include "opentimelineio/typeRegistry.h"
 #include "opentimelineio/stringUtils.h"
 
+#include "opentimelineio/bounds.h"
 #include "opentimelineio/clip.h"
 #include "opentimelineio/composable.h"
 #include "opentimelineio/composition.h"
@@ -45,6 +46,7 @@ TypeRegistry::TypeRegistry() {
                       return nullptr;
                   }, "UnknownSchema");
 
+    register_type<Bounds>();
     register_type<Clip>();
     register_type<Composable>();
     register_type<Composition>();

--- a/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
@@ -12,6 +12,7 @@ pybind11_add_module(_otio
                     otio_anyDictionary.cpp
                     otio_anyVector.cpp
                     otio_bindings.cpp
+                    otio_imath.cpp
                     otio_tests.cpp
                     otio_serializableObjects.cpp
                     otio_utils.cpp 
@@ -21,7 +22,8 @@ target_include_directories(_otio
     PRIVATE pybind11/include
     PRIVATE "${PROJECT_SOURCE_DIR}/src"
     PRIVATE "${PROJECT_SOURCE_DIR}/src/deps"
-    PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include")
+    PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
+)
 
 target_link_libraries(_otio PUBLIC opentimelineio opentime)
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(_otio, m) {
     otio_exception_bindings(m);
     otio_any_dictionary_bindings(m);
     otio_any_vector_bindings(m);
+    otio_imath_bindings(m);
     otio_serializable_object_bindings(m);
     otio_tests_bindings(m);
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.h
@@ -5,5 +5,6 @@
 void otio_exception_bindings(pybind11::module);
 void otio_any_dictionary_bindings(pybind11::module);
 void otio_any_vector_bindings(pybind11::module);
+void otio_imath_bindings(pybind11::module);
 void otio_serializable_object_bindings(pybind11::module);
 void otio_tests_bindings(pybind11::module);

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
@@ -1,0 +1,133 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "otio_utils.h"
+
+#include "ImathBox.h"
+#include "ImathVec.h"
+
+namespace py = pybind11;
+
+template <typename CLASS>
+CLASS _type_checked(py::object const& rhs, char const* op) {
+    try {
+        return py::cast<CLASS>(rhs);
+    }
+    catch (...) {
+        std::string rhs_type = py::cast<std::string>(rhs.get_type().attr("__name__"));
+        throw py::type_error(string_printf("unsupported operand type(s) for %s: "
+                                           "%s and %s", typeid(CLASS).name(), op, rhs_type.c_str()));
+    }
+}
+
+static void define_imath_2d(py::module m) {
+    py::class_<Imath::V2d>(m, "V2d")
+        .def(py::init<>())
+        .def(py::init<double>())
+        .def(py::init<double, double>())
+        .def_readwrite("x", &Imath::V2d::x)
+        .def_readwrite("y", &Imath::V2d::y)
+        .def("__getitem__", [](Imath::V2d const &v, size_t i) {
+                return v[i];
+            })
+        .def("__eq__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs == _type_checked<Imath::V2d>(rhs, "==");
+            })
+        .def("__ne__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs != _type_checked<Imath::V2d>(rhs, "!=");
+            })
+        .def("__xor__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs ^ _type_checked<Imath::V2d>(rhs, "^");
+            })
+        .def("__mod__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs % _type_checked<Imath::V2d>(rhs, "%");
+            })
+        .def("__iadd__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs += rhs;
+            })
+        .def("__isub__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs -= rhs;
+            })
+        .def("__imul__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs *= rhs;
+            })
+        .def("__idiv__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs /= rhs;
+            })
+        .def(py::self - py::self)
+        .def(py::self + py::self)
+        .def(py::self * py::self)
+        .def(py::self / py::self)
+        .def("equalWithAbsError", [](Imath::V2d* v, Imath::V2d const & v2, double e) {
+                return v->equalWithAbsError(v2, e);
+            })
+        .def("equalWithRelError", [](Imath::V2d* v, Imath::V2d const & v2, double e) {
+                return v->equalWithRelError(v2, e);
+            })
+        .def("dot", [](Imath::V2d* v, Imath::V2d const & v2) {
+                return v->dot(v2);
+            })
+        .def("cross", [](Imath::V2d* v, Imath::V2d const & v2) {
+                return v->cross(v2);
+            })
+        .def("length", &Imath::V2d::length)
+        .def("length2", &Imath::V2d::length2)
+        .def("normalize", &Imath::V2d::normalize)
+        .def("normalizeExc", &Imath::V2d::normalizeExc)
+        .def("normalizeNonNull", &Imath::V2d::normalizeNonNull)
+        .def("normalized", &Imath::V2d::normalized)
+        .def("normalizedExc", &Imath::V2d::normalizedExc)
+        .def("normalizedNonNull", &Imath::V2d::normalizedNonNull)
+        .def_static("baseTypeLowest", []() {
+                return Imath::V2d::baseTypeLowest();
+            })
+        .def_static("baseTypeMax", []() {
+                return Imath::V2d::baseTypeMax();
+            })
+        .def_static("baseTypeSmallest", []() {
+                return Imath::V2d::baseTypeSmallest();
+            })
+        .def_static("baseTypeEpsilon", []() {
+                return Imath::V2d::baseTypeEpsilon();
+            })
+        .def_static("dimensions", []() {
+                return Imath::V2d::dimensions();
+            });
+
+    py::class_<Imath::Box2d>(m, "Box2d")
+        .def(py::init<>())
+        .def(py::init<Imath::V2d>())
+        .def(py::init<Imath::V2d, Imath::V2d>())
+        .def_readwrite("min", &Imath::Box2d::min)
+        .def_readwrite("max", &Imath::Box2d::max)
+        .def("__eq__", [](Imath::Box2d lhs, py::object const& rhs) {
+            return lhs == _type_checked<Imath::Box2d>(rhs, "==");
+        })
+        .def("__ne__", [](Imath::Box2d lhs, py::object const& rhs) {
+            return lhs != _type_checked<Imath::Box2d>(rhs, "!=");
+        })
+        .def("makeEmpty", &Imath::Box2d::makeEmpty)
+        .def("makeInfinite", &Imath::Box2d::makeInfinite)
+        .def("isEmpty", &Imath::Box2d::isEmpty)
+        .def("isInfinite", &Imath::Box2d::isInfinite)
+        .def("hasVolume", &Imath::Box2d::hasVolume)
+        .def("size", &Imath::Box2d::size)
+        .def("center", &Imath::Box2d::center)
+        .def("extendBy", [](Imath::Box2d* box, Imath::V2d const& point ) {
+            return box->extendBy(point); 
+        })
+        .def("extendBy", [](Imath::Box2d* box, Imath::Box2d const& rhs ) {
+            return box->extendBy(rhs); 
+        })
+        .def("intersects", [](Imath::Box2d* box, Imath::V2d const& point ) {
+            return box->intersects(point); 
+        })
+        .def("intersects", [](Imath::Box2d* box, Imath::Box2d const& rhs ) {
+            return box->intersects(rhs); 
+        });
+}
+
+void otio_imath_bindings(py::module m) {
+    define_imath_2d(m);
+}
+

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -29,6 +29,8 @@
 #include "otio_utils.h"
 #include "otio_anyDictionary.h"
 
+#include "ImathBox.h"
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -293,6 +295,18 @@ static void define_bases2(py::module m) {
         .def("children_if", [](SerializableCollection* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
                 return children_if(t, descended_from_type, search_range);
             }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt);
+
+    py::class_<Bounds, SOWithMetadata,
+               managing_ptr<Bounds>>(m, "Bounds", py::dynamic_attr())
+        .def(py::init([](std::string const& name,
+                         optional<Imath::Box2d> const& box,
+                         py::object metadata) {
+                          return new Bounds(name, box, py_to_any_dictionary(metadata));
+                      }),
+             name_arg,
+             "box"_a = nullopt,
+             metadata_arg)
+        .def_property("box", &Bounds::box, &Bounds::set_box);
 }
 
 static void define_items_and_compositions(py::module m) {
@@ -338,7 +352,10 @@ static void define_items_and_compositions(py::module m) {
             }, "time"_a, "to_item"_a)
         .def("transformed_time_range", [](Item* item, TimeRange time_range, Item* to_item) {
             return item->transformed_time_range(time_range, to_item, ErrorStatusHandler());
-            }, "time_range"_a, "to_item"_a);
+            }, "time_range"_a, "to_item"_a)
+        .def_property_readonly("bounds", [](Item* item) {
+            return py::cast(item->bounds(ErrorStatusHandler()).take_value());
+            });
 
     auto transition_class =
         py::class_<Transition, Composable, managing_ptr<Transition>>(m, "Transition", py::dynamic_attr())
@@ -468,6 +485,7 @@ static void define_items_and_compositions(py::module m) {
                 auto result = c->handles_of_child(child, ErrorStatusHandler());
                 return py::make_tuple(py::cast(result.first), py::cast(result.second));
             }, "child_a")
+        .def("has_clips", &Composition::has_clips)
         .def("__internal_getitem__", [](Composition* c, int index) {
                 index = adjusted_vector_index(index, c->children());
                 if (index < 0 || index >= int(c->children().size())) {
@@ -643,28 +661,37 @@ static void define_media_references(py::module m) {
                managing_ptr<MediaReference>>(m, "MediaReference", py::dynamic_attr())
         .def(py::init([](std::string name,
                          optional<TimeRange> available_range,
-                         py::object metadata) {
-                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata)); }),
+                         py::object metadata,
+                         Bounds* bounds) {
+                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata), bounds); }),
              name_arg,
              "available_range"_a = nullopt,
-             metadata_arg)
+             metadata_arg,
+             "bounds"_a = nullptr)
         .def_property("available_range", &MediaReference::available_range, &MediaReference::set_available_range)
+        .def_property("bounds", [](MediaReference* m) { 
+                              return py::cast(m->bounds().take_value()); 
+                          }, 
+                      &MediaReference::set_bounds)
         .def_property_readonly("is_missing_reference", &MediaReference::is_missing_reference);
 
     py::class_<GeneratorReference, MediaReference,
                managing_ptr<GeneratorReference>>(m, "GeneratorReference", py::dynamic_attr())
         .def(py::init([](std::string name, std::string generator_kind,
                          optional<TimeRange> const& available_range,
-                         py::object parameters, py::object metadata) {
+                         py::object parameters, py::object metadata,
+                         Bounds* bounds) {
                           return new GeneratorReference(name, generator_kind,
                                                         available_range,
                                                         py_to_any_dictionary(parameters),
-                                                        py_to_any_dictionary(metadata)); }),
+                                                        py_to_any_dictionary(metadata),
+                                                        bounds); }),
              name_arg,
              "generator_kind"_a = std::string(),
              "available_range"_a = nullopt,
              "parameters"_a = py::none(),
-             metadata_arg)
+             metadata_arg,
+             "bounds"_a = nullptr)
         .def_property("generator_kind", &GeneratorReference::generator_kind, &GeneratorReference::set_generator_kind)
         .def_property_readonly("parameters", [](GeneratorReference* g) {
                 auto ptr = g->parameters().get_or_create_mutation_stamp();
@@ -676,28 +703,34 @@ static void define_media_references(py::module m) {
         .def(py::init([](
                         py::object name,
                         optional<TimeRange> available_range,
-                        py::object metadata) {
+                        py::object metadata,
+                        Bounds* bounds) {
                     return new MissingReference(
                                   string_or_none_converter(name),
                                   available_range,
-                                  py_to_any_dictionary(metadata)); 
+                                  py_to_any_dictionary(metadata),
+                                  bounds); 
                     }),
              name_arg,
              "available_range"_a = nullopt,
-             metadata_arg);
+             metadata_arg,
+             "bounds"_a = nullptr);
 
 
     py::class_<ExternalReference, MediaReference,
                managing_ptr<ExternalReference>>(m, "ExternalReference", py::dynamic_attr())
         .def(py::init([](std::string target_url,
                          optional<TimeRange> const& available_range,
-                         py::object metadata) {
+                         py::object metadata,
+                         Bounds* bounds) {
                           return new ExternalReference(target_url,
                                                         available_range,
-                                                        py_to_any_dictionary(metadata)); }),
+                                                        py_to_any_dictionary(metadata),
+                                                        bounds); }),
              "target_url"_a = std::string(),
              "available_range"_a = nullopt,
-             metadata_arg)
+             metadata_arg,
+             "bounds"_a = nullptr)
         .def_property("target_url", &ExternalReference::target_url, &ExternalReference::set_target_url);
 
     auto imagesequencereference_class = py:: class_<ImageSequenceReference, MediaReference,
@@ -778,7 +811,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                          int frame_zero_padding,
                          ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
-                         py::object metadata) {
+                         py::object metadata,
+                         Bounds* bounds) {
                           return new ImageSequenceReference(target_url_base,
                                                             name_prefix,
                                                             name_suffix,
@@ -788,7 +822,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                                                             frame_zero_padding,
                                                             missing_frame_policy,
                                                             available_range,
-                                                            py_to_any_dictionary(metadata)); }),
+                                                            py_to_any_dictionary(metadata),
+                                                            bounds); }),
                         "target_url_base"_a = std::string(),
                         "name_prefix"_a = std::string(),
                         "name_suffix"_a = std::string(),
@@ -798,7 +833,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                         "frame_zero_padding"_a = 0,
                         "missing_frame_policy"_a = ImageSequenceReference::MissingFramePolicy::error,
                         "available_range"_a = nullopt,
-                        metadata_arg)
+                        metadata_arg,
+                        "bounds"_a = nullptr)
         .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base, "Everything leading up to the file name in the ``target_url``.")
         .def_property("name_prefix", &ImageSequenceReference::name_prefix, &ImageSequenceReference::set_name_prefix, "Everything in the file name leading up to the frame number.")
         .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix, "Everything after the frame number in the file name.")

--- a/src/py-opentimelineio/opentimelineio/core/mediaReference.py
+++ b/src/py-opentimelineio/opentimelineio/core/mediaReference.py
@@ -4,10 +4,11 @@ from .. import _otio
 
 @add_method(_otio.MediaReference)
 def __str__(self):
-    return "{}({}, {}, {})".format(
+    return "{}({}, {}, {}, {})".format(
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
+        repr(self.bounds),
         repr(self.metadata)
     )
 
@@ -18,6 +19,7 @@ def __repr__(self):
         "otio.{}.{}("
         "name={},"
         " available_range={},"
+        " bounds={},"
         " metadata={}"
         ")"
     ).format(
@@ -25,5 +27,6 @@ def __repr__(self):
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
+        repr(self.bounds),
         repr(self.metadata)
     )

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -27,6 +27,8 @@
 """User facing classes."""
 
 from .. _otio import (
+    Bounds,
+    Box2d,
     Clip,
     Effect,
     TimeEffect,
@@ -42,7 +44,8 @@ from .. _otio import (
     Stack,
     Timeline,
     Track,
-    Transition
+    Transition,
+    V2d,
 )
 
 MarkerColor = Marker.Color
@@ -55,6 +58,8 @@ from . schemadef import (
 )
 
 from . import (
+    box2d,
+    bounds,
     clip,
     effect,
     external_reference,
@@ -66,6 +71,7 @@ from . import (
     timeline,
     track,
     transition,
+    v2d,
 )
 
 track.TrackKind = TrackKind

--- a/src/py-opentimelineio/opentimelineio/schema/bounds.py
+++ b/src/py-opentimelineio/opentimelineio/schema/bounds.py
@@ -1,0 +1,26 @@
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.Bounds)
+def __str__(self):
+    return 'Bounds("{}", {}, {})'.format(
+        self.name,
+        self.box,
+        self.metadata
+    )
+
+
+@add_method(_otio.Bounds)
+def __repr__(self):
+    return (
+        'otio.schema.Bounds('
+        'name={}, '
+        'box={}, '
+        'metadata={}'
+        ')'.format(
+            repr(self.name),
+            repr(self.box),
+            repr(self.metadata),
+        )
+    )

--- a/src/py-opentimelineio/opentimelineio/schema/box2d.py
+++ b/src/py-opentimelineio/opentimelineio/schema/box2d.py
@@ -1,0 +1,23 @@
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.Box2d)
+def __str__(self):
+    return 'Box2d({}, {})'.format(
+        self.min,
+        self.max
+    )
+
+
+@add_method(_otio.Box2d)
+def __repr__(self):
+    return (
+        'otio.schema.Box2d('
+        'min={}, '
+        'max={}'
+        ')'.format(
+            repr(self.min),
+            repr(self.max),
+        )
+    )

--- a/src/py-opentimelineio/opentimelineio/schema/generator_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/generator_reference.py
@@ -4,10 +4,11 @@ from .. import _otio
 
 @add_method(_otio.GeneratorReference)
 def __str__(self):
-    return 'GeneratorReference("{}", "{}", {}, {})'.format(
+    return 'GeneratorReference("{}", "{}", {}, {}, {})'.format(
         self.name,
         self.generator_kind,
         self.parameters,
+        self.bounds,
         self.metadata
     )
 
@@ -19,11 +20,13 @@ def __repr__(self):
         'name={}, '
         'generator_kind={}, '
         'parameters={}, '
+        'bounds={}, '
         'metadata={}'
         ')'.format(
             repr(self.name),
             repr(self.generator_kind),
             repr(self.parameters),
+            repr(self.bounds),
             repr(self.metadata),
         )
     )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -6,7 +6,7 @@ from .. import _otio
 def __str__(self):
     return (
         'ImageSequenceReference('
-        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {})' .format(
+        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {}, {})' .format(
             self.target_url_base,
             self.name_prefix,
             self.name_suffix,
@@ -16,6 +16,7 @@ def __str__(self):
             self.frame_zero_padding,
             self.missing_frame_policy,
             self.available_range,
+            self.bounds,
             self.metadata,
         )
     )
@@ -34,6 +35,7 @@ def __repr__(self):
         'frame_zero_padding={}, '
         'missing_frame_policy={}, '
         'available_range={}, '
+        'bounds={}, '
         'metadata={}'
         ')' .format(
             repr(self.target_url_base),
@@ -45,6 +47,7 @@ def __repr__(self):
             repr(self.frame_zero_padding),
             repr(self.missing_frame_policy),
             repr(self.available_range),
+            repr(self.bounds),
             repr(self.metadata),
         )
     )

--- a/src/py-opentimelineio/opentimelineio/schema/v2d.py
+++ b/src/py-opentimelineio/opentimelineio/schema/v2d.py
@@ -1,0 +1,23 @@
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.V2d)
+def __str__(self):
+    return 'V2d({}, {})'.format(
+        self.x,
+        self.y
+    )
+
+
+@add_method(_otio.V2d)
+def __repr__(self):
+    return (
+        'otio.schema.V2d('
+        'x={}, '
+        'y={}'
+        ')'.format(
+            repr(self.x),
+            repr(self.y),
+        )
+    )

--- a/tests/baselines/empty_external_reference.json
+++ b/tests/baselines/empty_external_reference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "ExternalReference.1",
     "available_range" : null,
+    "bounds" : null,
     "metadata" : {},
     "name" : "",
     "target_url" : "foo.bar"

--- a/tests/baselines/empty_generator_reference.json
+++ b/tests/baselines/empty_generator_reference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "GeneratorReference.1",
     "available_range" : null,
+    "bounds" : null,
     "generator_kind" : "",
     "metadata" : {},
     "parameters" : {},

--- a/tests/baselines/empty_missingreference.json
+++ b/tests/baselines/empty_missingreference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "MissingReference.1",
     "available_range" : null,
+    "bounds" : null,
     "metadata" : {},
     "name" : ""
 }

--- a/tests/sample_data/clip_example.otio
+++ b/tests/sample_data/clip_example.otio
@@ -48,6 +48,22 @@
                 }
               },
               "metadata": {},
+              "bounds": {
+                "OTIO_SCHEMA": "Bounds.1",
+                "box": {
+                  "OTIO_SCHEMA": "Box2d.1",
+                  "min": {
+                    "OTIO_SCHEMA":"V2d.1",
+                    "x": 0.0,
+                    "y": 0.0
+                  },
+                  "max": {
+                    "OTIO_SCHEMA":"V2d.1",
+                    "x": 16.0,
+                    "y": 9.0
+                  }
+                }
+              },
               "name": null
             },
             "metadata": {},

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,0 +1,103 @@
+#
+# Copyright Contributors to the OpenTimelineIO project
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import unittest
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+
+class BoundsTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_cons(self):
+        name = "test"
+        box = otio.schema.Box2d(
+            otio.schema.V2d(1.0, 2.0),
+            otio.schema.V2d(3.0, 4.0)
+        )
+
+        bounds = otio.schema.Bounds(
+            name=name,
+            box=box
+        )
+
+        self.assertEqual(bounds.name, name)
+        self.assertEqual(bounds.box, box)
+
+        encoded = otio.adapters.otio_json.write_to_string(bounds)
+        decoded = otio.adapters.otio_json.read_from_string(encoded)
+        self.assertIsOTIOEquivalentTo(bounds, decoded)
+
+    def test_str(self):
+        name = "str_test"
+
+        minV = otio.schema.V2d(1.0, 2.0)
+        maxV = otio.schema.V2d(3.0, 4.0)
+
+        box = otio.schema.Box2d(minV, maxV)
+
+        bounds = otio.schema.Bounds(
+            name=name,
+            box=box
+        )
+
+        self.assertMultiLineEqual(
+            str(bounds),
+            'Bounds("str_test", Box2d(V2d(1.0, 2.0), V2d(3.0, 4.0)), {})'
+        )
+
+        self.assertMultiLineEqual(
+            repr(bounds),
+            'otio.schema.Bounds('
+            "name='str_test', "
+            'box=otio.schema.Box2d('
+            'min=otio.schema.V2d(x=1.0, y=2.0), '
+            'max=otio.schema.V2d(x=3.0, y=4.0)'
+            '), '
+            'metadata={}'
+            ')'
+        )
+
+    def test_get_set_box(self):
+        box = otio.schema.Box2d(
+            otio.schema.V2d(1.0, 2.0),
+            otio.schema.V2d(3.0, 4.0)
+        )
+
+        bounds = otio.schema.Bounds(
+            box=box
+        )
+
+        self.assertEqual(box, bounds.box)
+
+        box2 = otio.schema.Box2d(
+            otio.schema.V2d(5.0, 6.0),
+            otio.schema.V2d(7.0, 8.0)
+        )
+
+        bounds.box = box2
+        self.assertEqual(box2, bounds.box)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_box2d.py
+++ b/tests/test_box2d.py
@@ -1,0 +1,129 @@
+#
+# Copyright Contributors to the OpenTimelineIO project
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+import unittest
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+
+class Box2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_cons(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box = otio.schema.Box2d(v1, v2)
+
+        self.assertEqual(box.min, v1)
+        self.assertEqual(box.max, v2)
+
+    def test_str(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box = otio.schema.Box2d(v1, v2)
+
+        self.assertMultiLineEqual(
+            str(box),
+            'Box2d(V2d(1.0, 2.0), V2d(3.0, 4.0))'
+        )
+
+        self.assertMultiLineEqual(
+            repr(box),
+            'otio.schema.Box2d('
+            'min=otio.schema.V2d(x=1.0, y=2.0), '
+            'max=otio.schema.V2d(x=3.0, y=4.0)'
+            ')'
+        )
+
+    def test_limits(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box = otio.schema.Box2d(v1, v2)
+
+        v_lowest = otio.schema.V2d(v1.baseTypeLowest(), v1.baseTypeLowest())
+        v_max = otio.schema.V2d(v1.baseTypeMax(), v1.baseTypeMax())
+
+        empty = otio.schema.Box2d(v_max, v_lowest)
+        inf = otio.schema.Box2d(v_lowest, v_max)
+
+        box.makeEmpty()
+        self.assertEqual(box, empty)
+        self.assertTrue(box.isEmpty())
+        self.assertFalse(box.hasVolume())
+        self.assertEqual(box.center(), otio.schema.V2d(0.0, 0.0))
+        self.assertEqual(box.size(), otio.schema.V2d(0.0, 0.0))
+
+        box.makeInfinite()
+        self.assertEqual(box, inf)
+        self.assertTrue(box.isInfinite())
+        self.assertTrue(box.hasVolume())
+        self.assertEqual(box.center(), otio.schema.V2d(0.0, 0.0))
+
+    def test_extend(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box1 = otio.schema.Box2d(v1, v2)
+
+        box1.extendBy(otio.schema.V2d(5.0, 5.0))
+        self.assertEqual(box1,
+                         otio.schema.Box2d(
+                             otio.schema.V2d(1.0, 2.0),
+                             otio.schema.V2d(5.0, 5.0)
+                         )
+                         )
+
+        v3 = otio.schema.V2d(2.0, 3.0)
+        v4 = otio.schema.V2d(6.0, 6.0)
+        box2 = otio.schema.Box2d(v3, v4)
+
+        box1.extendBy(box2)
+        self.assertEqual(box1,
+                         otio.schema.Box2d(
+                             otio.schema.V2d(1.0, 2.0),
+                             otio.schema.V2d(6.0, 6.0)
+                         )
+                         )
+
+    def test_intersects(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box1 = otio.schema.Box2d(v1, v2)
+
+        self.assertTrue(box1.intersects(otio.schema.V2d(2.0, 3.0)))
+
+        self.assertFalse(box1.intersects(otio.schema.V2d(0.0, 3.0)))
+
+        v3 = otio.schema.V2d(1.1, 1.9)
+        v4 = otio.schema.V2d(3.1, 3.9)
+        box2 = otio.schema.Box2d(v3, v4)
+
+        self.assertTrue(box1.intersects(box2))
+
+        v5 = otio.schema.V2d(3.1, 4.1)
+        v6 = otio.schema.V2d(4.1, 5.1)
+        box3 = otio.schema.Box2d(v5, v6)
+
+        self.assertFalse(box1.intersects(box3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -62,7 +62,7 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", MissingReference(\'\', None, {}), None, {})'
+            'Clip("test_clip", MissingReference(\'\', None, None, {}), None, {})'
         )
         self.assertMultiLineEqual(
             repr(cl),
@@ -134,6 +134,32 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(cl.trimmed_range(), cl.source_range)
         self.assertIsNot(cl.trimmed_range(), cl.source_range)
+
+    def test_bounds(self):
+        bounds = otio.schema.Bounds(
+            box=otio.schema.Box2d(
+                otio.schema.V2d(0.0, 0.0),
+                otio.schema.V2d(16.0, 9.0)
+            )
+        )
+
+        media_reference = otio.schema.ExternalReference(
+            "/var/tmp/foo.mov",
+            bounds=bounds
+        )
+
+        cl = otio.schema.Clip(
+            name="test_bounds",
+            media_reference=media_reference
+        )
+
+        self.assertEqual(bounds, cl.bounds)
+        self.assertEqual(cl.bounds, media_reference.bounds)
+
+        self.assertEqual(0.0, cl.bounds.box.min.x)
+        self.assertEqual(0.0, cl.bounds.box.min.y)
+        self.assertEqual(16.0, cl.bounds.box.max.x)
+        self.assertEqual(9.0, cl.bounds.box.max.y)
 
     def test_ref_default(self):
         cl = otio.schema.Clip()

--- a/tests/test_generator_reference.py
+++ b/tests/test_generator_reference.py
@@ -24,7 +24,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             },
             metadata={
                 "foo": "bar"
-            }
+            },
+            bounds=otio.schema.Bounds(
+                box=otio.schema.Box2d(
+                    otio.schema.V2d(0.0, 0.0),
+                    otio.schema.V2d(16.0, 9.0)
+                )
+            )
         )
 
     def test_constructor(self):
@@ -37,6 +43,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(100, 24),
+            )
+        )
+        self.assertEqual(
+            self.gen.bounds.box,
+            otio.schema.Box2d(
+                otio.schema.V2d(0.0, 0.0),
+                otio.schema.V2d(16.0, 9.0)
             )
         )
 
@@ -59,11 +72,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             '"{}", '
             '"{}", '
             '{}, '
+            '{}, '
             "{}"
             ")".format(
                 str(self.gen.name),
                 str(self.gen.generator_kind),
                 str(self.gen.parameters),
+                str(self.gen.bounds),
                 str(self.gen.metadata),
             )
         )
@@ -74,11 +89,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "name={}, "
             "generator_kind={}, "
             "parameters={}, "
+            "bounds={}, "
             "metadata={}"
             ")".format(
                 repr(self.gen.name),
                 repr(self.gen.generator_kind),
                 repr(self.gen.parameters),
+                repr(self.gen.bounds),
                 repr(self.gen.metadata),
             )
         )

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -64,6 +64,12 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             metadata={"custom": {"foo": "bar"}},
+            bounds=otio.schema.Bounds(
+                box=otio.schema.Box2d(
+                    otio.schema.V2d(0.0, 0.0),
+                    otio.schema.V2d(16.0, 9.0)
+                )
+            ),
         )
         self.assertEqual(
             str(ref),
@@ -77,6 +83,7 @@ class ImageSequenceReferenceTests(
             '5, '
             'MissingFramePolicy.error, '
             'TimeRange(RationalTime(0, 30), RationalTime(60, 30)), '
+            'Bounds("", Box2d(V2d(0.0, 0.0), V2d(16.0, 9.0)), {}), '
             "{'custom': {'foo': 'bar'}}"
             ')'
         )
@@ -95,6 +102,12 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
             ),
+            bounds=otio.schema.Bounds(
+                box=otio.schema.Box2d(
+                    otio.schema.V2d(0.0, 0.0),
+                    otio.schema.V2d(16.0, 9.0)
+                )
+            ),
             metadata={"custom": {"foo": "bar"}},
         )
         ref_value = (
@@ -108,6 +121,11 @@ class ImageSequenceReferenceTests(
             'frame_zero_padding=5, '
             'missing_frame_policy=<MissingFramePolicy.error: 0>, '
             'available_range={}, '
+            'bounds=otio.schema.Bounds('
+            "name='', box=otio.schema.Box2d("
+            'min=otio.schema.V2d(x=0.0, y=0.0), '
+            'max=otio.schema.V2d(x=16.0, y=9.0)), '
+            'metadata={{}}), '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
             ')'.format(repr(ref.available_range))
         )

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -51,12 +51,12 @@ class MediaReferenceTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         missing = otio.schema.MissingReference()
         self.assertMultiLineEqual(
             str(missing),
-            "MissingReference(\'\', None, {})"
+            "MissingReference(\'\', None, None, {})"
         )
         self.assertMultiLineEqual(
             repr(missing),
             "otio.schema.MissingReference("
-            "name='', available_range=None, metadata={}"
+            "name='', available_range=None, bounds=None, metadata={}"
             ")"
         )
 

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -324,6 +324,60 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             tl.tracks[0].range_of_child_at_index(0)
         )
 
+    def test_bounds(self):
+        track = otio.schema.Track(name="test_track")
+        tl = otio.schema.Timeline("test_timeline", tracks=[track])
+
+        # three clips, each successive clip partially overlaps the previous
+        cl = otio.schema.Clip(
+            name="test clip1",
+            media_reference=otio.schema.ExternalReference(
+                bounds=otio.schema.Bounds(
+                    box=otio.schema.Box2d(
+                        otio.schema.V2d(0.0, 0.0),
+                        otio.schema.V2d(1.0, 1.0)
+                    )
+                ),
+                target_url="/var/tmp/test.mov"
+            )
+        )
+        cl2 = otio.schema.Clip(
+            name="test clip2",
+            media_reference=otio.schema.ExternalReference(
+                bounds=otio.schema.Bounds(
+                    box=otio.schema.Box2d(
+                        otio.schema.V2d(1.0, 1.0),
+                        otio.schema.V2d(2.0, 2.0)
+                    )
+                ),
+                target_url="/var/tmp/test.mov"
+            )
+        )
+        cl3 = otio.schema.Clip(
+            name="test clip3",
+            media_reference=otio.schema.ExternalReference(
+                bounds=otio.schema.Bounds(
+                    box=otio.schema.Box2d(
+                        otio.schema.V2d(2.0, 2.0),
+                        otio.schema.V2d(3.0, 3.0)
+                    )
+                ),
+                target_url="/var/tmp/test.mov"
+            )
+        )
+        gap = otio.schema.Gap(name="gap")
+
+        tl.tracks[0].append(cl)
+        tl.tracks[0].extend([cl2, cl3, gap])
+
+        union = otio.schema.Box2d(
+            otio.schema.V2d(0.0, 0.0),
+            otio.schema.V2d(3.0, 3.0)
+        )
+
+        # union should be overlapping area, gap should be ignored
+        self.assertEqual(tl.tracks[0].bounds.box, union)
+
     def test_iterators(self):
         self.maxDiff = None
         track = otio.schema.Track(name="test_track")

--- a/tests/test_v2d.py
+++ b/tests/test_v2d.py
@@ -1,0 +1,130 @@
+#
+# Copyright Contributors to the OpenTimelineIO project
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import unittest
+import sys
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+
+class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_cons(self):
+        v = otio.schema.V2d(1.0, 2.0)
+
+        self.assertEqual(v.x, 1.0)
+        self.assertEqual(v.y, 2.0)
+
+        self.assertEqual(v[0], 1.0)
+        self.assertEqual(v[1], 2.0)
+
+    def test_str(self):
+        v = otio.schema.V2d(1.0, 2.0)
+
+        self.assertMultiLineEqual(
+            str(v),
+            'V2d(1.0, 2.0)'
+        )
+
+        self.assertMultiLineEqual(
+            repr(v),
+            'otio.schema.V2d(x=1.0, y=2.0)'
+        )
+
+    def test_equality(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+
+        self.assertFalse(v1 == v2)
+        self.assertTrue(v1 != v2)
+
+        v3 = otio.schema.V2d(1.0, 2.0)
+        self.assertTrue(v1 == v3)
+        self.assertFalse(v1 != v3)
+
+        self.assertTrue(v1.equalWithAbsError(v3, 0.0))
+        self.assertTrue(v1.equalWithRelError(v3, 0.0))
+
+    def test_math_ops(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+
+        self.assertEqual(v1 ^ v2, 11.0)
+        self.assertEqual(v1.dot(v2), 11.0)
+
+        self.assertEqual(v1 % v2, -2.0)
+        self.assertEqual(v1.cross(v2), -2.0)
+
+        self.assertEqual(v1 + v2, otio.schema.V2d(4.0, 6.0))
+        self.assertEqual(v1 - v2, otio.schema.V2d(-2.0, -2.0))
+        self.assertEqual(v1 * v2, otio.schema.V2d(3.0, 8.0))
+        self.assertEqual(v1 / v2, otio.schema.V2d(1.0 / 3.0, 0.5))
+
+        v1 += v2
+        self.assertEqual(v1, otio.schema.V2d(4.0, 6.0))
+
+        v1 -= v2
+        self.assertEqual(v1, otio.schema.V2d(1.0, 2.0))
+
+        v1 *= v2
+        self.assertEqual(v1, otio.schema.V2d(3.0, 8.0))
+
+        v1 /= v2
+        self.assertEqual(v1, otio.schema.V2d(1.0, 2.0))
+
+    def test_geometry(self):
+        v = otio.schema.V2d(3.0, 4.0)
+
+        self.assertEqual(v.length(), 5.0)
+        self.assertEqual(v.length2(), 25.0)
+
+    def test_normalize(self):
+        v = otio.schema.V2d(3.0, 4.0)
+
+        self.assertEqual(v.normalized(), otio.schema.V2d(0.6, 0.8))
+        self.assertEqual(v.normalizedNonNull(), otio.schema.V2d(0.6, 0.8))
+
+        v2 = v
+        v.normalize()
+        v2.normalizeNonNull()
+        self.assertEqual(v, otio.schema.V2d(0.6, 0.8))
+        self.assertEqual(v2, otio.schema.V2d(0.6, 0.8))
+
+        nv = otio.schema.V2d(0.0, 0.0)
+
+        with self.assertRaises(ValueError):
+            nv.normalizeExc()
+
+        with self.assertRaises(ValueError):
+            nv.normalizedExc()
+
+    def test_limits(self):
+        self.assertEqual(otio.schema.V2d.baseTypeLowest(), -1 * sys.float_info.max)
+        self.assertEqual(otio.schema.V2d.baseTypeMax(), sys.float_info.max)
+        self.assertEqual(otio.schema.V2d.baseTypeSmallest(), sys.float_info.min)
+        self.assertEqual(otio.schema.V2d.baseTypeEpsilon(), sys.float_info.epsilon)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
```Fixes #771```
MediaReference: spatial bounding box

**Summary**

This change addresses the need to have spatial bounds expressed in the MediaReference.  These are used to define a measurement-agnostic coordinate system representing the viewing area of the clip(s), which can be used by media players to determine how to display or scale/resize/center (if necessary) the media referenced by the Clips.  

The Imath library is used to implement the spatial bounding box, specifically the Box class and its dependency Vec.  Imath was selected since its already used by OpenExr, another ASWF project, and this helps establish a common standard between the two projects.  Since the 2d template specializations (ie Box2d, a box using 2 dimensional doubles) made the most sense in this context, I only implemented support for it, and its V2d (a 2d vector) dependency.  This, however, does not close the door to implementing support for more dimensions or other vector types if needed in the future.  The Imath types are contained within a Bounds class which derives from SerializableObject.  This encapsulation allows not only the serialization of bounds, but also for the concept to be extended in the future -- for example, support for additional Imath types or for a Transformation type to allow transformations between different coordinate systems. 

For a more in-depth explanation of the idea and motivations please see the issue linked here:
https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/771

I have flagged as many potential discussion points that I think might arise with **Note** below.  

**Files changed**
- .gitmodules
Add Imath as a submodule

- *.md files
Lists the additions to the schemas (automatically generated by Makefiles).

- src/deps/CMakeLists.txt
Include Imath submodule and set the option to build it statically (without overriding the option for the base OTIO project).  We want to build statically to keep the libraries self-contained so they can be made easily into Python wheels.

- src/opentime/CMakeLists.txt
Add new bounds class to compilation, link with static Imath library and remove OpenTimelineIOConfig export.  Remove export of build tree (this is the same issue seen here: https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/911).

- src/opentimelineio/bounds.cpp
Implement the Bounds class.  For the time being it contains only an optional Imath::Box2d.  The box is optional to avoid selecting default values for the Box.  Since its optional we can simply have no box as the default.

- src/opentimelineio/bounds.h
Add mutators and accessors to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/clip.cpp
Implement the bounds method.  Simply returns the Bounds if it has been set on the clip or an error otherwise (conforming to the standard of the available_range method).

- src/opentimelineio/clip.h
Adds the bounds method to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/composable.cpp
Implements the bounds method to return an error so that any derived classes that do not explicitly override the virtual method return the error (it is overriden by Clip, Stack and Track).  

- src/opentimelineio/composable.h
Adds the bounds method to the public interface
**Python Bindings**: Also added

- src/opentimelineio/composition.cpp
Implements the has_clips method for composition, which returns true if the Composition contains at least one clip.  This function is used by bounds method of the derived Stack class to exclude any tracks that do not contain any clips when it calculates the union of the bounds.  Since the bounds default to width, height and center of {0, 0, (0, 0)} we want to prevent the default values from affecting the result and thus use the has_clips method to skip over any tracks that do not contain clips. 

- src/opentimelineio/composition.h
Adds the has_clips method to the public interface. 
**Python Bindings**: Also added
**Note**: Even though this method is only needed by Stack, I thought it could be useful elsewhere so I made it public.  If you would prefer I could make it protected so only Stack could access it.  Or if you do not want it in the interface at all, I can also implement it as a lambda function (or in the anonymous namespace) inside of Stack::bounds.

- src/opentimelineio/deserialization.cpp
Implements the de/serialization of Imath::Box2d Imath::V2d and Bounds, including optional support for Imath::Box2d.  The code for serializing the Imath types follows the existing standard provided by Time and TimeRange.

- src/opentimelineio/errorStatus.cpp
Adds a new error value for when the bounds cannot be determined.  This occurs when the user asks for bounds on a Clip that does not contain bounds or asks for bounds on a Composition that has a Clip that does not contain bounds.

- src/opentimelineio/externalReference.cpp, src/opentimelineio/generatorReference.cpp, src/opentimelineio/imageSequenceReference.cpp, src/opentimelineio/missingReference.h
Pass bounds constructor argument to MediaReference parent constructor 

- src/opentimelineio/externalReference.h, src/opentimelineio/generatorReference.h, src/opentimelineio/imageSequenceReference.h, src/opentimelineio/missingReference.h
Adds optional constructor argument for bounds.

- src/opentimelineio/mediaReference.cpp
Initializes bounds member and add it to the read/write method for serialization.  A Retainer is used to store Bounds so the memory can be managed in the Python bindings similar to the Effect class.

- src/opentimelineio/mediaReference.h
Add bounds member and constructor argument as well as a mutator and accessor method.
**Python Bindings**: Also added (includes derived classes)

- src/opentimelineio/safely_typed_any.cpp
Adds casting support for Box2d  and V2d (required by serialization code).

- src/opentimelineio/safely_typed_any.h
Adds casting methods for Box2d and V2d to public interface.

- src/opentimelineio/serializableObject.h
Adds de/serialization support for Box2d and V2d found within the Bounds schema.

- src/opentimelineio/serialization.cpp
Adds de/serialization code for Box2d and V2d.

- src/opentimelineio/stack.cpp
Implements bounds method for a stack.  We begin by finding the first bounding box, defined as the Box of the first Clip or of the first Composition that contains at least one Clip. After this is found, we then extend the box to contain each subsequent Clip or Composition containing at least one Clip.  If no Clips are found or no Boxes are found, we return nullptr.  If an error is found, we return the error (as a parameter). This follows the standard defined by the available_range method.

- src/opentimelineio/stack.h
Adds bounds method to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/timeline.h
Adds bounds to the public interface and implements it by redirecting the call to it's Stack.
**Python Bindings**: Also added

- src/opentimelineio/track.cpp
Implements bounds method for a track.  Similarly to Stack, we begin by finding the first bounding box, however in this case we don't need to consider Compositions, only Clips.  Once we have the bounding Box of the first clip, we extend it with the Box of each subsequent Clip.  If no Clips or Boxes are found, we return nullptr.  If an error is found, we return the error (as a parameter) and the default Box. This follows the standard defined by the available_range method.

- src/opentimelineio/track.h
Adds bounds method to the public interface.
**Python Bindings**: Also added

- src/opentimelineio/typeRegistry.cpp
Register Bounds as a SerializableObject.

- src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
Adds compilation of Python bindings for Imath types.

- src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
Initialize Imath bindings

- src/py-opentimelineio/opentimelineio-bindings/otio_bindings.h
Imath bindings function prototype 

- src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
Create pybind bindings for Imath types.
**Note**: I did not use the existing Python bindings for Imath here because they are done using boost.  Using them would create a dependency on boost that we want to avoid.  We don't want to break the self-contained nature of the Python binding libraries by depending on a dynamic system library.  Because of this if we want to use the Imath types in the Python OTIO library with the Imath Python library, we would need to create some kind bridge code. 

- src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
Adds all added opentimelineio public c++ interface methods to the Python bindings
**Note**: These are denoted by **Python Bindings** in descriptions above.

- src/py-opentimelineio/opentimelineio/core/mediaReference.py
Adds bounds to the __repr__ and __str__ method for MediaReference.

- src/py-opentimelineio/opentimelineio/schema/__init__.py 
Import schemas for Bounds, Box2d and V2d.

- src/py-opentimelineio/opentimelineio/schema/bounds.py
Create a Bounds schema

- src/py-opentimelineio/opentimelineio/schema/box2d.py
Create a Box schema

- src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
Adds bounds to the __repr__ and __str__ method for ImageSequence.

- src/py-opentimelineio/opentimelineio/schema/v2d.py
Create a Vector schema

**Tests**

- tests/baselines/*.json
Adds empty bounds to the json representations
**Note**: This is necessary even if the bounds don't exist in the metadata since the serialization code will add a null bounds member in this case.  If you'd prefer I could make it exclude the bounds member entirely if it is not defined.

- tests/sample_data/clip_example.otio
Added bounds to the example clip and associated test (test_documentation.py).

- tests/test_bounds.py
Test all the public bounds methods.  This is essentially just the schemas and getting and setting the box.

- tests/test_box2d.py 
Test all public Box2d methods. 
**Note**:  I did test each method but only on a basic level to ensure it was bound to the correct underlying C++ method. Imath has its own more rigorous unit testing to make sure the methods are working correctly.

- tests/test_clip.py
Updated the str test to include the bounds.  Also adds a bounding box to a clip and tests that they were set correctly using the contains methods to find the edges of the Box.

- tests/test_composition.py
Tests the added has_clips method on empty stacks and tracks and ones containing no Clips (only Gaps).  Also tests that the bounds are correctly applied to empty Stacks, single clip Stacks, multi-clip Stacks, Stacks with gaps, and Stacks containing Tracks containing Clips. Tracks are also tested for empty Tracks, gap-only Tracks, single Clip Tracks and multi-Clip Tracks.

- tests/test_media_reference.py
Tests for new bounds in schema

- tests/test_v2d.py
Test all public V2d methods. 
**Note**:  I did test each method but only on a basic level to ensure it was bound to the correct underlying C++ method. Imath has its own more rigorous unit testing to make sure the methods are working correctly.

- tests/test_generator_reference.py, tests/test_image_sequence_reference.py, tests/test_media_reference.py
Ensures the bounds can be passed to the constructor and the same bounds are returned from the accessor.
ImageSequenceReference and MediaRefererence also test the __str__ and __repr__ methods return the expected string.

- tests/test_timeline.py
Timeline bounds are tested to ensure a single track timeline has equal bounds between the Track and the Timeline.  
