### PR TITLE
Add child_if()

### DIFF
--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -51,11 +51,22 @@ public:
 
     // Return a vector of all objects that match the given template type.
     //
-    // An optional search_time may be provided to limit the search.
+    // An optional search_range may be provided to limit the search.
     //
     // If shallow_search is false, will recurse into children.
     template<typename T = Composable>
     std::vector<Retainer<T>> children_if(
+        ErrorStatus* error_status,
+        optional<TimeRange> search_range = nullopt,
+        bool shallow_search = false) const;
+
+    // Return the first object that matches the given template type.
+    //
+    // An optional search_range may be provided to limit the search.
+    //
+    // If shallow_search is false, will recurse into children.
+    template<typename T = Composable>
+    Retainer<T> child_if(
         ErrorStatus* error_status,
         optional<TimeRange> search_range = nullopt,
         bool shallow_search = false) const;
@@ -67,6 +78,16 @@ protected:
     virtual void write_to(Writer&) const;
 
 private:
+    enum ChildrenIfOptions {
+        match_first = 1,
+        shallow_search = 2
+    };
+    template<typename T = Composable>
+    std::vector<Retainer<T>> _children_if(
+        ErrorStatus* error_status,
+        optional<TimeRange> search_range,
+        int options) const;
+
     std::vector<Retainer<SerializableObject>> _children;
 };
 
@@ -76,6 +97,35 @@ inline std::vector<SerializableObject::Retainer<T>> SerializableCollection::chil
     optional<TimeRange> search_range,
     bool shallow_search) const
 {
+    int options = 0;
+    if (shallow_search)
+    {
+        options |= ChildrenIfOptions::shallow_search;
+    }
+    return _children_if<T>(error_status, search_range, options);
+}
+
+template<typename T>
+inline SerializableObject::Retainer<T> SerializableCollection::child_if(
+    ErrorStatus* error_status,
+    optional<TimeRange> search_range,
+    bool shallow_search) const
+{
+    int options = ChildrenIfOptions::match_first;
+    if (shallow_search)
+    {
+        options |= ChildrenIfOptions::shallow_search;
+    }
+    const auto l = _children_if<T>(error_status, search_range, options);
+    return !l.empty() ? l[0] : nullptr;
+}
+
+template<typename T>
+inline std::vector<SerializableObject::Retainer<T>> SerializableCollection::_children_if(
+    ErrorStatus* error_status,
+    optional<TimeRange> search_range,
+    int options) const
+{
     std::vector<Retainer<T>> out;
     for (const auto& child : _children)
     {
@@ -83,31 +133,53 @@ inline std::vector<SerializableObject::Retainer<T>> SerializableCollection::chil
         if (auto valid_child = dynamic_cast<T*>(child.value))
         {
             out.push_back(valid_child);
+            if (options & ChildrenIfOptions::match_first)
+            {
+                break;
+            }
         }
-
 
         // if not a shallow_search, for children that are serialiable collections or compositions,
         // recurse into their children
-        if (!shallow_search)
+        if (!(options & ChildrenIfOptions::shallow_search))
         {
             if (auto collection = dynamic_cast<SerializableCollection*>(child.value))
             {
-                const auto valid_children = collection->children_if<T>(error_status, search_range);
+                const auto valid_children = collection->_children_if<T>(error_status, search_range, options);
                 if (!error_status) {
                     *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
                 }
                 for (const auto& valid_child : valid_children) {
                     out.push_back(valid_child);
+                }
+                if (!out.empty() && (options & ChildrenIfOptions::match_first))
+                {
+                    break;
                 }
             }
             else if (auto composition = dynamic_cast<Composition*>(child.value))
             {
-                const auto valid_children = composition->children_if<T>(error_status, search_range);
+                std::vector<Retainer<T>> valid_children;
+                if (options & ChildrenIfOptions::match_first)
+                {
+                    if (auto valid_child = composition->child_if<T>(error_status, search_range, options & ChildrenIfOptions::shallow_search))
+                    {
+                        valid_children.push_back(valid_child);
+                    }
+                }
+                else
+                {
+                    valid_children = composition->children_if<T>(error_status, search_range, options & ChildrenIfOptions::shallow_search);
+                }
                 if (!error_status) {
                     *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
                 }
                 for (const auto& valid_child : valid_children) {
                     out.push_back(valid_child);
+                }
+                if (!out.empty() && (options & ChildrenIfOptions::match_first))
+                {
+                    break;
                 }
             }
         }

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -63,11 +63,22 @@ public:
 
     // Return a vector of all objects that match the given template type.
     //
-    // An optional search_time may be provided to limit the search.
+    // An optional search_range may be provided to limit the search.
     //
     // If shallow_search is false, will recurse into children.
     template<typename T = Composable>
     std::vector<Retainer<T>> children_if(
+        ErrorStatus* error_status,
+        optional<TimeRange> search_range = nullopt,
+        bool shallow_search = false) const;
+
+    // Return the first object that matches the given template type.
+    //
+    // An optional search_range may be provided to limit the search.
+    //
+    // If shallow_search is false, will recurse into children.
+    template<typename T = Composable>
+    Retainer<T> child_if(
         ErrorStatus* error_status,
         optional<TimeRange> search_range = nullopt,
         bool shallow_search = false) const;
@@ -90,6 +101,15 @@ inline std::vector<SerializableObject::Retainer<T>> Timeline::children_if(
     bool shallow_search) const
 {
     return _tracks.value->children_if<T>(error_status, search_range, shallow_search);
+}
+
+template<typename T>
+inline SerializableObject::Retainer<T> Timeline::child_if(
+    ErrorStatus* error_status,
+    optional<TimeRange> search_range,
+    bool shallow_search) const
+{
+    return _tracks.value->child_if<T>(error_status, search_range, shallow_search);
 }
 
 } }

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -52,39 +52,84 @@ namespace {
             return py::str(thing);
         }
     }
-
+    
+    // Convenience function for calling t->children_if().
     template<typename T, typename U>
-    bool children_if(T* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search, std::vector<SerializableObject*>& l) {
-        if (descended_from_type.is(py::type::handle_of<U>()))
-        {
-            for (const auto& child : t->template children_if<U>(ErrorStatusHandler(), search_range, shallow_search)) {
-                l.push_back(child.value);
-            }
-            return true;
+    void children_if(T* t, optional<TimeRange> const& search_range, bool shallow_search, std::vector<SerializableObject*>& l) {
+        for (const auto& child : t->template children_if<U>(ErrorStatusHandler(), search_range, shallow_search)) {
+            l.push_back(child.value);
         }
-        return false;
     }
-
+    
+    // Convenience function for calling children_if(), mapping from a py::object to a C++ class.
     template<typename T>
     std::vector<SerializableObject*> children_if(T* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search = false) {
         std::vector<SerializableObject*> l;
-        if (children_if<T, Clip>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Composition>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Gap>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Item>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Stack>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Timeline>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Track>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else if (children_if<T, Transition>(t, descended_from_type, search_range, shallow_search, l)) ;
-        else
-        {
-            for (const auto& child : t->template children_if<Composable>(ErrorStatusHandler(), search_range, shallow_search)) {
-                l.push_back(child.value);
-            }
+        if (descended_from_type.is(py::type::handle_of<Clip>())) {
+            children_if<T, Clip>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Composition>())) {
+            children_if<T, Composition>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Gap>())) {
+            children_if<T, Gap>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Item>())) {
+            children_if<T, Item>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Stack>())) {
+            children_if<T, Stack>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Timeline>())) {
+            children_if<T, Timeline>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Track>())) {
+            children_if<T, Track>(t, search_range, shallow_search, l);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Transition>())) {
+            children_if<T, Transition>(t, search_range, shallow_search, l);
+        }
+        else {
+            children_if<T, Composable>(t, search_range, shallow_search, l);
         }
         return l;
     }
+
+    // Convenience function for calling t->child_if(), mapping from a py::object to a C++ class.
+    template<typename T>
+    SerializableObject* child_if(T* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search = false) {
+        SerializableObject* o = nullptr;
+        if (descended_from_type.is(py::type::handle_of<Clip>())) {
+            o = t->template child_if<Clip>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Composition>())) {
+            o = t->template child_if<Composition>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Gap>())) {
+            o = t->template child_if<Gap>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Item>())) {
+            o = t->template child_if<Item>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Stack>())) {
+            o = t->template child_if<Stack>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Timeline>())) {
+            o = t->template child_if<Timeline>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Track>())) {
+            o = t->template child_if<Track>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else if (descended_from_type.is(py::type::handle_of<Transition>())) {
+            o = t->template child_if<Transition>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        else {
+            o = t->template child_if<Composable>(ErrorStatusHandler(), search_range, shallow_search);
+        }
+        return o;
+    }
     
+    // Convenience function for calling t->clip_if().
     template<typename T>
     std::vector<SerializableObject*> clip_if(T* t, optional<TimeRange> const& search_range, bool shallow_search = false) {
         std::vector<SerializableObject*> l;
@@ -292,6 +337,9 @@ static void define_bases2(py::module m) {
             }, "search_range"_a = nullopt)
         .def("children_if", [](SerializableCollection* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
                 return children_if(t, descended_from_type, search_range);
+            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt)
+        .def("child_if", [](SerializableCollection* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
+                return child_if(t, descended_from_type, search_range);
             }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt);
 }
 
@@ -464,6 +512,9 @@ static void define_items_and_compositions(py::module m) {
         .def("children_if", [](Composition* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search) {
                 return children_if(t, descended_from_type, search_range, shallow_search);
             }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt, "shallow_search"_a = false)
+        .def("child_if", [](Composition* t, py::object descended_from_type, optional<TimeRange> const& search_range, bool shallow_search) {
+                return child_if(t, descended_from_type, search_range, shallow_search);
+            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt, "shallow_search"_a = false)
         .def("handles_of_child", [](Composition* c, Composable* child) {
                 auto result = c->handles_of_child(child, ErrorStatusHandler());
                 return py::make_tuple(py::cast(result.first), py::cast(result.second));
@@ -597,6 +648,9 @@ static void define_items_and_compositions(py::module m) {
             }, "search_range"_a = nullopt)
         .def("children_if", [](Timeline* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
                 return children_if(t, descended_from_type, search_range);
+            }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt)
+        .def("child_if", [](Timeline* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
+                return child_if(t, descended_from_type, search_range);
             }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt);
 }
 


### PR DESCRIPTION
```Fixes #1001```

In PR #998 I suggested it might be nice to use the general purpose children_if() function to test if a composition has any child clips. @rogernelson pointed out that children_if() might be expensive since it iterates over every child, as opposed to just stopping at the first instance. So maybe it would be nice to have a child_if() function that is similar to children_if(), but only returns the first child? In addition to Roger's use case this could also be useful for other tests, like if a timeline has any transitions.

The caveat here is that by making this a general function and supporting the various otio container types, this turned out to be more code changes than I was hoping for... I'm setting this as a draft PR for now, if this seems like a good change I can add test coverage.