### PR TITLE
Remove CXX sdk in Python site-packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,13 +47,10 @@ if(OTIO_PYTHON_INSTALL)
 
     # if nothing has been set,
     #   Python: ${Python_SITEARCH}/opentimelineio
-    #   C++:    ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk
     # if only CMAKE_INSTALL_PREFIX has been set,
     #   Python: ${CMAKE_INSTALL_PREFIX}/opentimelineio/python
-    #   C++:    ${CMAKE_INSTALL_PREFIX}/opentimelineio
     # if only OTIO_PYTHON_INSTALL_DIR has been set,
     #   Python: ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio
-    #   C++:    ${OTIO_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk
     #
     # In a Python install, the dylibs/dlls need to be installed where __init__.py
     # can find them, rather as part of the C++ SDK package; so the variable
@@ -63,37 +60,29 @@ if(OTIO_PYTHON_INSTALL)
         # neither install directory supplied from the command line
         find_package(Python REQUIRED COMPONENTS Interpreter Development)
         set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${Python_SITEARCH}")
-        set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk")
         set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
-        message(STATUS "OTIO Defaulting both Python and C++ install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
+        message(STATUS "OTIO Defaulting Python install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
     else()
         # either python_install or install_prefix have been set
         if(OTIO_PYTHON_INSTALL_DIR_INITIALIZED_TO_DEFAULT)
             # CMAKE_INSTALL_PREFIX was set, so install the python components there
             set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/python")
-            set(OTIO_RESOLVED_CXX_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}")
 
             # In order to not require setting $PYTHONPATH to point at the .so,
             # the shared libraries are installed into the python library
             # location.
             set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
             message(STATUS "OTIO Defaulting Python install to ${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
-            message(STATUS "Note: C++ linkable shared libraries can be found at: ${OTIO_RESOLVED_CXX_INSTALL_DIR}/lib")
         else()
             # OTIO_PYTHON_INSTALL_DIR was set, so install everything into the python package
             set(OTIO_RESOLVED_PYTHON_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}")
-            set(OTIO_RESOLVED_CXX_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio/cxx-sdk")
             set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
-            message(STATUS "OTIO Defaulting C++ install to ${OTIO_PYTHON_INSTALL_DIR}")
         endif()
     endif()
 else()
-    set(OTIO_RESOLVED_CXX_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}")
     set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib")
     message(STATUS "OTIO C++ installing to ${CMAKE_INSTALL_PREFIX}")
 endif()
-
-set(CMAKE_INSTALL_INCLUDEDIR "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include")
 
 if(OTIO_SHARED_LIBS)
     message(STATUS "Building shared libs")
@@ -102,11 +91,13 @@ else()
     message(STATUS "Building static libs")
     set(OTIO_SHARED_OR_STATIC_LIB "STATIC")
     if (OTIO_PYTHON_INSTALL AND NOT MSVC)
-        # TODO: add explicit visibility decorations for OpenTime and OpentimelineIO to resolve
-        # this issue. For reference, there is discussion here: https://gist.github.com/ax3l/ba17f4bb1edb5885a6bd01f58de4d542
-        message(WARNING "pybind11 forces visibility flags, used shared libraries instead.")
+        # If we're compiling for pybind, we can hide all our symbols, they'll only be called from pybind
+        set(CMAKE_CXX_VISIBILITY_PRESET hidden) 
+        set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
     endif()
 endif()
+
+set(OTIO_RESOLVED_CXX_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}")
 
 if(OTIO_CXX_INSTALL)
     message(STATUS "Installing C++ bindings to: ${OTIO_RESOLVED_CXX_INSTALL_DIR}")

--- a/setup.py
+++ b/setup.py
@@ -110,21 +110,10 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
         cmake_args = [
             '-DPYTHON_EXECUTABLE=' + sys.executable,
             '-DOTIO_PYTHON_INSTALL:BOOL=ON',
-            '-DOTIO_CXX_INSTALL:BOOL=ON',
+            '-DOTIO_CXX_INSTALL:BOOL=OFF',
+            '-DOTIO_SHARED_LIBS:BOOL=OFF',
             '-DCMAKE_BUILD_TYPE=' + self.build_config,
-        ]
-
-        # install the C++ into the opentimelineio/cxx-sdk directory under the
-        # python installation
-        cmake_install_prefix = os.path.join(
-            install_dir,
-            "opentimelineio",
-            "cxx-sdk"
-        )
-
-        cmake_args += [
             '-DOTIO_PYTHON_INSTALL_DIR=' + install_dir,
-            '-DCMAKE_INSTALL_PREFIX=' + cmake_install_prefix,
         ]
 
         if platform.system() == "Windows":

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -16,7 +16,7 @@ if(OTIO_PYTHON_INSTALL)
     add_subdirectory(pybind11)
 endif()
 
-if(OTIO_DEPENDENCIES_INSTALL)
+if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
     install(FILES any/any.hpp 
             DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio/deps/any")
     install(FILES optional-lite/include/nonstd/optional.hpp

--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -49,7 +49,7 @@ if(OTIO_CXX_INSTALL)
             RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
 
     install(EXPORT OpenTimeConfig
-            DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}"
+            DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime"
             NAMESPACE OTIO:: )
 endif()
 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -120,6 +120,6 @@ if(OTIO_CXX_INSTALL)
            RUNTIME DESTINATION "${OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR}")
 
     install(EXPORT OpenTimelineIOConfig
-           DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}"
+           DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio"
            NAMESPACE OTIO:: )
 endif()


### PR DESCRIPTION
```Fixes #666 ```
```Fixes #771  ```

**Summarize your change.**

This branch fixes building issues, both for building wheels and building with third-party projects.  In my particular case (#771) it allows building with Imath. 

The problem with the current setup is that it does not allow building with any sub-projects that use the standard `CMAKE_INSTALL_INCLUDEDIR` variable.  These are not be able to correctly install, since the `setup.py` effectively sets this variable to the build directory which generates the following error (in the case of Imath when compiled on Windows):

```
CMake Error in src/deps/Imath/config/CMakeLists.txt:
    Target "ImathConfig" INTERFACE_INCLUDE_DIRECTORIES property contains path:

      "C:\Users\runneradmin\AppData\Local\Temp\pip-req-build-wwijcqv7\build\lib.win-amd64-3.8\/opentimelineio/cxx-sdk/include/Imath"

    which is prefixed in the source directory.
```

We would run into the same problem with any other CMake projects in the future that we decided to add with the  `add_subdirectory` command, so it's worth fixing this properly rather than just overriding the option for that project.

Even though this is currently only generating an error on Windows, it also has an undesirable effect on posix systems as well.  If we look at the CMake config files that are exported to `[python site-packages]/cxx-sdk` we can see the lines:

```
# The installation prefix configured by this project.
set(_IMPORT_PREFIX [build directory])

# Create imported target OTIO::opentimelineio
add_library(OTIO::opentimelineio SHARED IMPORTED)

set_target_properties(OTIO::opentimelineio PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES " [build directory]; [build directory]/opentimelineio/deps"
  INTERFACE_LINK_LIBRARIES "OTIO::opentime"
)
```
**Note: edited to replace my build directories with [build directory]**

This means the CMake configs exported by OTIO are pointing to temporary build directories and not useable (cannot be imported by the CMake `find_package` command).

The setup.py script is deliberately changing the install directory to the build directory so that it can build wheels in the build directory which can then be then be installed by Python, so we can't just set the install directory to the final installation directory without breaking the wheel installation.

After a discussion on [slack](https://academysoftwarefdn.slack.com/archives/CMQ9J4BQC/p1624391316301600) with @meshula and @reinecke we determined the best course of action is to not install the C++ SDK in the python site-packages.  It's annoying for C++ devs to know the version of Python that installed the package and the CMake files in the project don't work anyway.  Since disabling the C++ install also disables installing the opentime/opentimelineio C++ libraries that the pybind libraries depend on, we decided to install these statically at the same time.  This is more convenient for wheel building anyway, since it makes the package more self-contained.

When statically linking I ran into warnings about symbol visibility since the pybind symbols are not visible and the otio ones are and they're now being compiled into the same translation unit. To solve this, I simply hid all otio symbols when linking with pybind.  In this scenario all otio symbols are only accessed by Python via pybind, so no need to expose them anyway.  This will also speed up our library load time since there's no reason the symbols will have to be loaded into the global symbol table.

I also fixed an issue where the deps c++ headers where being installed even when the c++ install was being turned off.  

Lastly, I also moved the installation of the cmake config files to be in `[install root]/share/opentime` and `[install root]/share/opentimelineio`.  The reason is on most systems the default `[install root]` (ie /usr/local) is not writeable.  You are expected to install into one of the standard /usr/local subdirectories, so I chose `share` which is meant for architecture independent files.

**Reference associated tests.**

Build tests should cover this.  

The package should be installable as either python or C++ or both.  The C++ includes should be in the default `CMAKE_INSTALL_PREFIX` unless overridden by the user and the installed CMake configs should be pointing at the correct install location.
