### PR TITLE
Add spatial coords doc draft

### DIFF
--- a/docs/_static/spatial_coords_example1.svg
+++ b/docs/_static/spatial_coords_example1.svg
@@ -1,0 +1,60 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region -->
+    <rect x="0" y="-900" width="1600" height="900" />
+    <circle cx="0" cy="0" r="30" />
+    <circle cx="1600" cy="-900" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="0" y1="-450" x2="1600" y2="-450" stroke-width="30"/>
+    <polygon points="0,-450 50,-500 50,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="1600,-450 1550,-500 1550,-400" fill="#000000" stroke-width="0"/>
+
+    <line x1="800" y1="0" x2="800" y2="-900" stroke-width="30"/>
+    <polygon points="800,-900 750,-850 850,-850" fill="#000000" stroke-width="0"/>
+    <polygon points="800,0 750,-50 850,-50" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="8.0rem" font-weight="bold" text-anchor="end" dominant-baseline="hanging">
+    <text x="-25" y="25" >min = (0.0, 0.0)</text>
+    <text x="1675" y="-1100" >max = (16.0, 9.0)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="400" y="-500" >(Width=16.0)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="left" dominant-baseline="auto">
+    <text x="825" y="-650" >(Height=9.0)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_example2.svg
+++ b/docs/_static/spatial_coords_example2.svg
@@ -1,0 +1,60 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region -->
+    <rect x="-800" y="-450" width="1600" height="900" />
+    <circle cx="-800" cy="450" r="30" />
+    <circle cx="800" cy="-450" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="-800" y1="0" x2="800" y2="0" stroke-width="30"/>
+    <polygon points="-800,0 -750,-50 -750,50" fill="#000000" stroke-width="0"/>
+    <polygon points="800,0 750,-50 750,50" fill="#000000" stroke-width="0"/>
+
+    <line x1="0" y1="-450" x2="0" y2="450" stroke-width="30"/>
+    <polygon points="0,-450 -50,-400 50,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="0,450 -50,400 50,400" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="8.0rem" font-weight="bold" dominant-baseline="hanging">
+    <text x="-825" y="475" text-anchor="end">min = (-8.0, -4.5)</text>
+    <text x="825" y="-600" text-anchor="left">max = (8.0, 4.5)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="-400" y="-50" >(Width=16.0)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="left" dominant-baseline="auto">
+    <text x="25" y="-200" >(Height=9.0)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_example3.svg
+++ b/docs/_static/spatial_coords_example3.svg
@@ -1,0 +1,63 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region 1 -->
+    <rect x="-800" y="-450" width="1600" height="900" fill="#BBBBBB"/>
+
+    <!-- Bounds Region 2 -->
+    <rect x="-450" y="-450" width="900" height="900" />
+    <circle cx="-450" cy="450" r="30" />
+    <circle cx="450" cy="-450" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="-450" y1="0" x2="450" y2="0" stroke-width="30"/>
+    <polygon points="-450,0 -400,-50 -400,50" fill="#000000" stroke-width="0"/>
+    <polygon points="450,0 400,-50 400,50" fill="#000000" stroke-width="0"/>
+
+    <line x1="0" y1="-450" x2="0" y2="450" stroke-width="30"/>
+    <polygon points="0,-450 -50,-400 50,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="0,450 -50,400 50,400" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="8.0rem" font-weight="bold" dominant-baseline="hanging">
+    <text x="-425" y="500" text-anchor="end">min = (-4.5, -4.5)</text>
+    <text x="425" y="-600" text-anchor="left">max = (4.5, 4.5)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="-250" y="-50" >(Width=9.0)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="left" dominant-baseline="auto">
+    <text x="25" y="-200" >(Height=9.0)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_example4.svg
+++ b/docs/_static/spatial_coords_example4.svg
@@ -1,0 +1,66 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region 1 -->
+    <rect x="-800" y="-450" width="1600" height="900" fill="#BBBBBB"/>
+
+    <!-- Bounds Region 2 -->
+    <rect x="-450" y="-450" width="900" height="900" fill="#BBBBBB"/>
+
+    <!-- Bounds Region 3 -->
+    <rect x="400" y="-450" width="400" height="225" />
+    <circle cx="400" cy="-225" r="30" />
+    <circle cx="800" cy="-450" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="400" y1="-337" x2="800" y2="-337" stroke-width="10"/>
+    <polygon points="400,-337 450,-357 450,-317" fill="#000000" stroke-width="0"/>
+    <polygon points="800,-337 750,-357 750,-317" fill="#000000" stroke-width="0"/>
+
+    <line x1="600" y1="-225" x2="600" y2="-450" stroke-width="10"/>
+    <polygon points="600,-450 580,-400 620,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="600,-225 580,-275 620,-275" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="6.0rem" font-weight="bold" dominant-baseline="hanging">
+    <text x="400" y="-180" text-anchor="end">min = (4.0, 2.25)</text>
+    <text x="825" y="-600" text-anchor="left">max = (8.0, 4.5)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="600" y="-480" >(Width=4.0)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="left" dominant-baseline="middle">
+    <text x="820" y="-337" >(Height=2.25)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_system.svg
+++ b/docs/_static/spatial_coords_system.svg
@@ -1,0 +1,22 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+</svg>

--- a/docs/tutorials/spatial-coordinates.md
+++ b/docs/tutorials/spatial-coordinates.md
@@ -1,0 +1,86 @@
+# OTIO Spatial Coordinate System
+This document describes a proposed coordinate system for OpenTimelineIO. It focuses mainly on the Bounds object, which is a rectangular area represented through a 2D box within that coordinate system.  
+
+## Coordinate System
+The proposed spatial coordinate system is unit-less.  
+It allows decoupling clip layouts from pixel density.  
+It has a single origin (X=0.0, Y=0.0) and is used as a unique canvas across the whole Timeline.  
+Y-Axis-Up convention is used.  
+
+![Coordinate System](../_static/spatial_coords_system.svg)
+## Bounds
+
+A Bounds object is a 2D box that defines a spatial area in the unit-less coordinate system.  
+Here is an example of Bounds defining a first-quadrant-snapped rectangle with a width of 16 and a height of 9.  
+Note that, since Bounds are serializable object, they have a metadata member.  
+```
+"bounds": {
+  "OTIO_SCHEMA": "Bounds.1",
+  "box": {
+    "OTIO_SCHEMA": "Box2d.1",
+    "min": {
+      "OTIO_SCHEMA":"V2d.1",
+      "x": 0.0,
+      "y": 0.0
+    },
+    "max": {
+      "OTIO_SCHEMA":"V2d.1",
+      "x": 16.0,
+      "y": 9.0
+    }
+  },
+  "metadata": {}
+}
+```
+
+![Example 1](../_static/spatial_coords_example1.svg)  
+
+Here is another example of Bounds defining an origin-centered rectangle with a width of 16 and a height of 9.  
+```
+"bounds": {
+  "OTIO_SCHEMA": "Bounds.1",
+  "box": {
+    "OTIO_SCHEMA": "Box2d.1",
+    "min": {
+      "OTIO_SCHEMA":"V2d.1",
+      "x": -8.0,
+      "y": -4.5
+    },
+    "max": {
+      "OTIO_SCHEMA":"V2d.1",
+      "x": 8.0,
+      "y": 4.5
+    }
+  }
+}
+```
+
+![Example 2](../_static/spatial_coords_example2.svg)
+
+When multiple clips are being rendered, either through a transition or through the presence of a multi-tracks timeline, all clips share the same coordinate system.  
+
+For instance, if we add an origin-centered square clip on top of the previous one, here is what we get.  
+
+![Example 3](../_static/spatial_coords_example3.svg)  
+
+Since each clip has its own bounds properties, clips can be arranged into complex layouts.  
+
+This can be used in several contexts, for instance:  
+
+-   Side-by-side comparison
+-   Picture-In-Picture
+-   Complex spatial layouts for notes (collage)
+
+Example of a Picture-In-Picture layout added on top of the previous 2-clips layout:  
+![Example 4](../_static/spatial_coords_example4.svg)  
+## Bounds and Clips
+Currently, we use the Bounds object at the ***Clip.media_reference.bounds*** level. This allows support for different bounds when changing the media-representation of a given Clip. For instance, a Clip could have 2 media-representations (a set of High-Res 16:9 OpenEXR files and a Low-Res 4:3 MP4 file). Those 2 media-representations might not cover the same spatial area, therefore it makes sense for them to have their individual Bounds region.  
+## Non-Bounds representations
+The coordinate system can also be used to describe non-rectangular coordinates. For instance, effects that have spatial-based parameters that need to be expressed in a resolution-independent way could use the same system.  
+
+Examples of potential usage for this coordinate system:  
+
+-   Blur amount
+-   Annotation position
+-   Wipe bar position (angular mask)
+

--- a/docs/tutorials/spatial-coordinates.md
+++ b/docs/tutorials/spatial-coordinates.md
@@ -7,6 +7,10 @@ It allows decoupling clip layouts from pixel density.
 It has a single origin (X=0.0, Y=0.0) and is used as a unique canvas across the whole Timeline.  
 Y-Axis-Up convention is used.  
 
+We propose in the OTIO spatial coordinate system that we use planes that are unique in the continuous domain in order to make it analogous to the existing temporal implementation.  Currently in a Composition of Items a RationalTime's value (usually a frame) index is seen as belonging to the Item that appears later in time.  For example, if we have two Items ranging from value 1 to value 2 and from value 2 to value 3, value 2 will belong to the second Item.  Or in other words, we are using exclusive temporal bounds such that the temporal spans are [1,2) and [2,3).
+
+In order to preserve the same logic in the spatial domain we require a plane that is unique in the continuous domain.  To use a similar example given a 2 dimensional bound from (0, 1), and another from (1, 2), we require that a sample at the value 1 falls strictly into one bound or the other, in particular, it should fall into the higher value bound (1,2) and not into (0, 1).
+
 ![Coordinate System](../_static/spatial_coords_system.svg)
 ## Bounds
 


### PR DESCRIPTION
Fixes #1011

**Summary**

This PR contains a draft version of the documentation written for the
Coordinate System proposal for OpenTimelineIO.

The following PR contains the actual implementation : https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/998

I used markdown for the whole documentation and SVG for graphics. I originally had built the graphics using draw.io but I thought having them as stand-alone SVGs would be more useful and lightweight.

I tried using recursive SVGs (ie.: invoke an SVG file from another SVG file through an `image` tag) to avoid code duplication, but apparently when an SVG is used as image, it must be complete in a single file. If anyone has a simple solution to this, let me know.

**Files Changed**

docs/tutorials/spatial-coordinates.md

-The actual markdown documentation

docs/_static/spatial_coords_example1.svg
docs/_static/spatial_coords_example2.svg
docs/_static/spatial_coords_example3.svg
docs/_static/spatial_coords_example4.svg
docs/_static/spatial_coords_system.svg

-SVG images referenced by the documentation.