### PR TITLE
Create wheels on Windows

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,30 +66,66 @@ jobs:
         fail_ci_if_error: true
 
   package_wheels:
-    name: Package wheels on ${{ matrix.os }}
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-build: [cp27*, cp37*, cp38*]
+        exclude:
+          # Python 2.7 on Windows requires a workaround for C++11 support,
+          # built separately below
+          - os: windows-latest
+            python-build: cp27*
 
     steps:
       - uses: actions/checkout@v2
 
-      # Used to host cibuildwheel
-      - uses: actions/setup-python@v2
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.10.0
-
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        # TODO: Solve for the 32-bit errors in windows python 2.7:
-        #   https://github.com/pybind/cmake_example/blob/master/.github/workflows/wheels.yml#L66
+        uses: pypa/cibuildwheel@v1.12.0
+        with:
+          output-dir: wheelhouse
         env:
-          CIBW_SKIP: cp27-win*
           CIBW_BUILD: ${{ matrix.python-build }}
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl
+
+  # Windows 2.7 (requires workaround for MSVC 2008 replacement)
+  package_wheels_win:
+    needs: build
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest]
+        python-build: [cp27*]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build 64-bit wheel
+        uses: pypa/cibuildwheel@v1.12.0
+        with:
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: cp27-win_amd64
+          DISTUTILS_USE_SDK: 1
+          MSSdk: 1
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+
+      - name: Build 32-bit wheel
+        uses: pypa/cibuildwheel@v1.12.0
+        env:
+          CIBW_BUILD: cp27-win32
+          DISTUTILS_USE_SDK: 1
+          MSSdk: 1
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -72,14 +72,24 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-build: [cp27*, cp37*, cp38*]
-        exclude:
-          # Python 2.7 on Windows requires a workaround for C++11 support,
-          # built separately below
-          - os: windows-latest
-            python-build: cp27*
-
     steps:
       - uses: actions/checkout@v2
+
+      # cibuildwheel 1.12.0 gates Python 2.7 wheels builds
+      # by using two environment variables, DISTUTILS_USE_SDK and MSSdk.
+      # https://cibuildwheel.readthedocs.io/en/1.x/cpp_standards/#windows-and-python-27
+      # Note that normally these are used by setuptools/distutils, but in our case
+      # they are really just used for cibuildwheel as we don't use any of the
+      # setuptools/distutils build tools. Our builds are entirely handled
+      # by CMake. CMake is able to find the right toolchain, thanks to
+      # the -A argument that we specify in the setup.py to set the
+      # target platform (x86, x64, etc).
+      - name: Set Windows Python 2.7 environment variables
+        if: matrix.python-build == 'cp27*' && runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "DISTUTILS_USE_SDK=1" >> $GITHUB_ENV
+          echo "MSSdk=1" >> $GITHUB_ENV
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v1.12.0
@@ -87,45 +97,6 @@ jobs:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: ${{ matrix.python-build }}
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./wheelhouse/*.whl
-
-  # Windows 2.7 (requires workaround for MSVC 2008 replacement)
-  package_wheels_win:
-    needs: build
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        os: [windows-latest]
-        python-build: [cp27*]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: ilammy/msvc-dev-cmd@v1
-
-      - name: Build 64-bit wheel
-        uses: pypa/cibuildwheel@v1.12.0
-        with:
-          output-dir: wheelhouse
-        env:
-          CIBW_BUILD: cp27-win_amd64
-          DISTUTILS_USE_SDK: 1
-          MSSdk: 1
-
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x86
-
-      - name: Build 32-bit wheel
-        uses: pypa/cibuildwheel@v1.12.0
-        env:
-          CIBW_BUILD: cp27-win32
-          DISTUTILS_USE_SDK: 1
-          MSSdk: 1
 
       - uses: actions/upload-artifact@v2
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,22 @@ if(OTIO_SHARED_LIBS)
 else()
     message(STATUS "Building static libs")
     set(OTIO_SHARED_OR_STATIC_LIB "STATIC")
-    if (OTIO_PYTHON_INSTALL AND NOT MSVC)
-        # If we're compiling for pybind, we can hide all our symbols, they'll only be called from pybind
-        set(CMAKE_CXX_VISIBILITY_PRESET hidden) 
-        set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+    if (OTIO_PYTHON_INSTALL)
+        if(MSVC AND Python_VERSION_MAJOR VERSION_LESS 3)
+            # Statically link run-time library (vcruntime and msvcp)
+            # See https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-160
+            # This allows us to compile OTIO bindings with a newer MSVC version
+            # than the one used by the interpreter where OTIO will be installed.
+            # This is only required for Python < 3 because only these are
+            # compiled with an older compiler (9.0). CPython 3.5+ uses at least
+            # Visual C++ 14.X.
+            # See https://wiki.python.org/moin/WindowsCompilers#Which_Microsoft_Visual_C.2B-.2B-_compiler_to_use_with_a_specific_Python_version_.3F
+            add_compile_options(/MT)
+        else()
+            # If we're compiling for pybind, we can hide all our symbols, they'll only be called from pybind
+            set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+            set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,11 @@ else()
     message(STATUS "Building static libs")
     set(OTIO_SHARED_OR_STATIC_LIB "STATIC")
     if (OTIO_PYTHON_INSTALL)
+        # If we're compiling for pybind, we can hide all our symbols, they'll only be called from pybind
+        # Note that this has no effect on Windows.
+        set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+        set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+
         if(MSVC AND Python_VERSION_MAJOR VERSION_LESS 3)
             # Statically link run-time library (vcruntime and msvcp)
             # See https://docs.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-160
@@ -109,10 +114,6 @@ else()
             # Visual C++ 14.X.
             # See https://wiki.python.org/moin/WindowsCompilers#Which_Microsoft_Visual_C.2B-.2B-_compiler_to_use_with_a_specific_Python_version_.3F
             add_compile_options(/MT)
-        else()
-            # If we're compiling for pybind, we can hide all our symbols, they'll only be called from pybind
-            set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-            set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
         endif()
     endif()
 endif()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,10 @@ import setuptools.command.build_py
 
 SOURCE_DIR = os.path.abspath(os.path.dirname(__file__))
 
+PLAT_TO_CMAKE = {
+    "win32": "Win32",
+    "win-amd64": "x64",
+}
 
 INSTALL_REQUIRES = [
     'pyaaf2~=1.4.0',
@@ -103,8 +107,7 @@ class OTIO_build_ext(setuptools.command.build_ext.build_ext):
         ]
 
         if platform.system() == "Windows":
-            if sys.maxsize > 2**32:
-                cmake_args += ['-A', 'x64']
+            cmake_args += ["-A", PLAT_TO_CMAKE[self.plat_name]]
 
         cxx_coverage = bool(os.environ.get("OTIO_CXX_COVERAGE_BUILD"))
         if cxx_coverage and not os.environ.get("OTIO_CXX_BUILD_TMP_DIR"):


### PR DESCRIPTION
Fixes #667 .

**Summary**

This PR makes it possible to build wheels on Windows in GitHub Actions.

I also updated cibuildwheel from 1.10.0 to 1.12.0 (the last version compatible with Python 2.7) and I'm now using the GitHub Action `pypa/cibuildwheel@v1.12.0` instead of installing cibuildwheel manually.

# Notes to testers
Wheels have been uploaded to test.pypi.org and can be installed using:
```
python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple opentimelineio==0.14.0dev1
```
where `python` is the interpreter you want to install the package into.

We would be extremely happy if we can get some people to test them, specially the Blender community woking on Windows. You can comment in this PR if you find any issues and you can even comment if it works :) Thanks a lot in advance to everyne that will test them!