### PR TITLE
Add target make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,14 @@ ifndef FLAKE8_PROG
 endif
 	@python -m flake8
 
+# format all .h and .cpp files using clang-format
+format:
+    opentimeFiles = src/opentime/*.h src/opentime/*.cpp
+    opentimelineioFiles = src/opentimelineio/*.h src/opentimelineio/*.cpp
+    pyopentimelineio-opentimeFiles = src/py-opentimelineio/opentime-bindings/*.h src/py-opentimelineio/opentime-bindings/*.cpp
+    pyopentimelineio-opentimelineioFiles = src/py-opentimelineio/opentimelineio-bindings/*.h src/py-opentimelineio/opentimelineio-bindings/*.cpp
+    $(shell clang-format -i -style=file ${opentimeFiles} ${opentimelineioFiles} ${pyopentimelineio-opentimeFiles} ${pyopentimelineio-opentimelineioFiles})
+
 manifest:
 ifndef CHECK_MANIFEST_PROG
 	$(error $(newline)$(ccred)check-manifest is not available on $$PATH please see:$(newline)$(ccend)\


### PR DESCRIPTION
Closes #1021 

The `make format` target applies the clang format to the C++ code.