### PR TITLE
Make target for building wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ FLAKE8_PROG := $(shell command -v flake8 2> /dev/null)
 CHECK_MANIFEST_PROG := $(shell command -v check-manifest 2> /dev/null)
 
 WHEEL_MODULE_PROG := $(shell command -v wheel 2> /dev/null)
+WHEEL_BUILD_FOLDERS = build dist OpenTimelineIO.egg-info
 
 # AUTOPEP8_PROG := $(shell command -v autopep8 2> /dev/null)
 TEST_ARGS=
@@ -114,6 +115,11 @@ test_first_fail: python-version
 clean:
 ifdef COV_PROG
 	@${COV_PROG} erase
+endif
+ifdef WHEEL_MODULE_PROG
+	for dir in $(WHEEL_BUILD_FOLDERS); do \
+		rm -Rfv $$dir; \
+	done
 endif
 	@${MAKE_PROG} -C contrib/opentimelineio_contrib/adapters clean VERBOSE=$(VERBOSE)
 

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,6 @@ PYCODESTYLE_PROG := $(shell command -v pycodestyle 2> /dev/null)
 PYFLAKES_PROG := $(shell command -v pyflakes 2> /dev/null)
 FLAKE8_PROG := $(shell command -v flake8 2> /dev/null)
 CHECK_MANIFEST_PROG := $(shell command -v check-manifest 2> /dev/null)
-
-WHEEL_MODULE_PROG := $(shell command -v wheel 2> /dev/null)
-WHEEL_BUILD_FOLDERS = build dist OpenTimelineIO.egg-info
-
 # AUTOPEP8_PROG := $(shell command -v autopep8 2> /dev/null)
 TEST_ARGS=
 
@@ -116,12 +112,8 @@ clean:
 ifdef COV_PROG
 	@${COV_PROG} erase
 endif
-ifdef WHEEL_MODULE_PROG
-	for dir in $(WHEEL_BUILD_FOLDERS); do \
-		rm -Rfv $$dir; \
-	done
-endif
 	@${MAKE_PROG} -C contrib/opentimelineio_contrib/adapters clean VERBOSE=$(VERBOSE)
+	rm -vf *.whl
 
 # conform all files to pep8 -- WILL CHANGE FILES IN PLACE
 # autopep8:
@@ -152,13 +144,7 @@ endif
 
 # build python wheel package for the available python version
 wheel:
-ifndef WHEEL_MODULE_PROG
-	$(error $(newline)$(ccred)python wheel package is not installed$(newline)$(ccend)\
-	$(ccblue)	https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels$(newline)$(ccend)\
-	$(ccred)You can install this package with$(newline)$(ccend)\
-	$(ccblue)	pip install wheel$(newline)$(ccend))
-endif
-	@python setup.py bdist_wheel
+	@pip wheel . --no-deps
 
 # format all .h and .cpp files using clang-format
 format:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: coverage test test_first_fail clean autopep8 lint doc-html \
-	python-version manifest lcov
+	python-version wheel manifest lcov
 
 # Special definition to handle Make from stripping newlines
 define newline
@@ -30,6 +30,9 @@ PYCODESTYLE_PROG := $(shell command -v pycodestyle 2> /dev/null)
 PYFLAKES_PROG := $(shell command -v pyflakes 2> /dev/null)
 FLAKE8_PROG := $(shell command -v flake8 2> /dev/null)
 CHECK_MANIFEST_PROG := $(shell command -v check-manifest 2> /dev/null)
+
+WHEEL_MODULE_PROG := $(shell command -v wheel 2> /dev/null)
+
 # AUTOPEP8_PROG := $(shell command -v autopep8 2> /dev/null)
 TEST_ARGS=
 
@@ -140,6 +143,16 @@ ifndef FLAKE8_PROG
 	$(dev_deps_message))
 endif
 	@python -m flake8
+
+# build python wheel package for the available python version
+wheel:
+ifndef WHEEL_MODULE_PROG
+	$(error $(newline)$(ccred)python wheel package is not installed$(newline)$(ccend)\
+	$(ccblue)	https://packaging.python.org/guides/distributing-packages-using-setuptools/#wheels$(newline)$(ccend)\
+	$(ccred)You can install this package with$(newline)$(ccend)\
+	$(ccblue)	pip install wheel$(newline)$(ccend))
+endif
+	@python setup.py bdist_wheel
 
 # format all .h and .cpp files using clang-format
 format:


### PR DESCRIPTION
Fixes #1005

**Summary**

Adds a `wheel` target to the Makefile.

Running `make wheel` will build a `.whl` package for the available python version to the root of the project.
Running `make clean` will remove all `*.whl` files from the project root.