### PR TITLE
Added linguist override to detect .otio files for JSON highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.otio linguist-language=JSON


### PR DESCRIPTION
Adds a [linguist override](https://github.com/github/linguist/blob/master/docs/overrides.md) to syntax highlight `.otio` files as JSON.