### PR TITLE
Use const references when catching exceptions

### DIFF
--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -107,7 +107,7 @@ RationalTime::from_timecode(std::string const& timecode, double rate, ErrorStatu
         minutes = std::stoi(fields[1]);
         seconds = std::stoi(fields[2]);
         frames  = std::stoi(fields[3]);
-    } catch(std::exception e) {
+    } catch(std::exception const& e) {
         *error_status = ErrorStatus(ErrorStatus::INVALID_TIMECODE_STRING,
                                     string_printf("Input timecode '%s' is an invalid timecode",
                                                   timecode.c_str()));
@@ -175,7 +175,7 @@ RationalTime::from_time_string(std::string const& time_string, double rate, Erro
         hours   = std::stod(fields[0]);
         minutes = std::stod(fields[1]);
         seconds = std::stod(fields[2]);
-    } catch(std::exception e) {
+    } catch(std::exception const& e) {
         *error_status = ErrorStatus(ErrorStatus::INVALID_TIME_STRING,
                                     string_printf("Input time string '%s' is an invalid time string",
                                                   time_string.c_str()));


### PR DESCRIPTION
```Fixes #1033```

This PR fixes a couple warnings from gcc 10.3:
```
warning: catching polymorphic type ‘class std::exception’ by value [-Wcatch-value=]
```
