### PR TITLE
Add constexpr/noexcept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 # Global language settings
 
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 14)
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/opentime/errorStatus.h
+++ b/src/opentime/errorStatus.h
@@ -6,7 +6,7 @@
 namespace opentime { namespace OPENTIME_VERSION  {
     
 struct ErrorStatus {
-    operator bool () {
+    operator bool () noexcept {
         return outcome != Outcome::OK;
     }
     

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -290,7 +290,7 @@ RationalTime::to_time_string() const {
     // result and return the string at the end with a '-'. This provides
     // compatibility with ffmpeg, which allows negative time strings.
     if (std::signbit(total_seconds)) {
-        total_seconds = std::fabs(total_seconds);
+        total_seconds = fabs(total_seconds);
         is_negative = true;
     }
 

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -3,6 +3,7 @@
 #include "opentime/version.h"
 #include "opentime/errorStatus.h"
 #include <cmath>
+#include <limits>
 #include <string>
 
 namespace opentime { namespace OPENTIME_VERSION  {
@@ -17,7 +18,7 @@ constexpr double fabs(double val) noexcept
 {
     union { double f; uint64_t i; }
     bits = { val };
-    bits.i &= -1ULL / 2;
+    bits.i &= std::numeric_limits<uint64_t>::max() / 2;
     return bits.f;
 }
 

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -22,7 +22,7 @@ public:
     constexpr RationalTime(RationalTime const&) noexcept = default;
     RationalTime& operator= (RationalTime const&) noexcept = default;
 
-    constexpr bool is_invalid_time() const noexcept {
+    bool is_invalid_time() const noexcept {
         return (std::isnan(_rate) || std::isnan(_value)) ? true : (_rate <= 0);
     }
     
@@ -50,7 +50,7 @@ public:
         return value_rescaled_to(rt._rate);
     }
 
-    constexpr bool almost_equal(RationalTime other, double delta = 0) const noexcept {
+    bool almost_equal(RationalTime other, double delta = 0) const noexcept {
         return fabs(value_rescaled_to(other._rate) - other._value) <= delta;
     }
 
@@ -171,7 +171,7 @@ private:
     static RationalTime _invalid_time;
     static constexpr double _invalid_rate = -1;
     
-    constexpr RationalTime _floor() const noexcept {
+    RationalTime _floor() const noexcept {
         return RationalTime {floor(_value), _rate};
     }
 

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -13,7 +13,14 @@ enum IsDropFrameRate : int {
     ForceYes = 1,
 };
     
-    
+constexpr double fabs(double val) noexcept
+{
+    union { double f; uint64_t i; }
+    bits = { val };
+    bits.i &= -1ULL / 2;
+    return bits.f;
+}
+
 class RationalTime {
 public:
     explicit constexpr RationalTime(double value = 0, double rate = 1) noexcept
@@ -50,7 +57,7 @@ public:
         return value_rescaled_to(rt._rate);
     }
 
-    bool almost_equal(RationalTime other, double delta = 0) const noexcept {
+    constexpr bool almost_equal(RationalTime other, double delta = 0) const noexcept {
         return fabs(value_rescaled_to(other._rate) - other._value) <= delta;
     }
 
@@ -107,7 +114,7 @@ public:
     
     std::string to_time_string() const;
 
-    RationalTime const& operator+= (RationalTime other) noexcept {
+    constexpr RationalTime const& operator+= (RationalTime other) noexcept {
         if (_rate < other._rate) {
             _value = other._value + value_rescaled_to(other._rate);
             _rate = other._rate;
@@ -118,7 +125,7 @@ public:
         return *this;
     }
 
-    RationalTime const& operator-= (RationalTime other) noexcept {
+    constexpr RationalTime const& operator-= (RationalTime other) noexcept {
         if (_rate < other._rate) {
             _value = value_rescaled_to(other._rate) - other._value;
             _rate = other._rate;

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -16,50 +16,46 @@ enum IsDropFrameRate : int {
     
 class RationalTime {
 public:
-    explicit RationalTime(double value = 0, double rate = 1)
+    explicit constexpr RationalTime(double value = 0, double rate = 1) noexcept
     : _value {value}, _rate {rate} {}
 
-    RationalTime(RationalTime const&) = default;
-    RationalTime& operator= (RationalTime const&) = default;
+    constexpr RationalTime(RationalTime const&) noexcept = default;
+    RationalTime& operator= (RationalTime const&) noexcept = default;
 
-    bool is_invalid_time() const {
-        if(std::isnan(_rate) || std::isnan(_value)) {
-            return true;
-        }
-
-        return _rate <= 0;
+    constexpr bool is_invalid_time() const noexcept {
+        return (std::isnan(_rate) || std::isnan(_value)) ? true : (_rate <= 0);
     }
     
-    double value() const {
+    constexpr double value() const noexcept {
         return _value;
     }
 
-    double rate() const {
+    constexpr double rate() const noexcept {
         return _rate;
     }
 
-    RationalTime rescaled_to(double new_rate) const {
+    constexpr RationalTime rescaled_to(double new_rate) const noexcept {
         return RationalTime {value_rescaled_to(new_rate), new_rate};
     }
 
-    RationalTime rescaled_to(RationalTime rt) const {
+    constexpr RationalTime rescaled_to(RationalTime rt) const noexcept {
         return RationalTime {value_rescaled_to(rt._rate), rt._rate};
     }
 
-    double value_rescaled_to(double new_rate) const {
+    constexpr double value_rescaled_to(double new_rate) const noexcept {
         return new_rate == _rate ? _value : (_value * new_rate) / _rate;
     }
     
-    double value_rescaled_to(RationalTime rt) const {
+    constexpr double value_rescaled_to(RationalTime rt) const noexcept {
         return value_rescaled_to(rt._rate);
     }
 
-    bool almost_equal(RationalTime other, double delta = 0) const {
+    constexpr bool almost_equal(RationalTime other, double delta = 0) const noexcept {
         return fabs(value_rescaled_to(other._rate) - other._value) <= delta;
     }
 
     static RationalTime
-    duration_from_start_end_time(RationalTime start_time, RationalTime end_time_exclusive) {
+    constexpr duration_from_start_end_time(RationalTime start_time, RationalTime end_time_exclusive) noexcept {
         return start_time._rate == end_time_exclusive._rate ?
             RationalTime {end_time_exclusive._value - start_time._value, start_time._rate} :
             RationalTime {end_time_exclusive.value_rescaled_to(start_time) - start_time._value,
@@ -67,7 +63,7 @@ public:
     }
 
     static RationalTime
-    duration_from_start_end_time_inclusive(RationalTime start_time, RationalTime end_time_inclusive) {
+    constexpr duration_from_start_end_time_inclusive(RationalTime start_time, RationalTime end_time_inclusive) noexcept {
         return start_time._rate == end_time_inclusive._rate ?
             RationalTime {end_time_inclusive._value - start_time._value + 1, start_time._rate} :
             RationalTime {end_time_inclusive.value_rescaled_to(start_time) - start_time._value + 1,
@@ -76,26 +72,26 @@ public:
 
     static bool is_valid_timecode_rate(double rate);
     
-    static RationalTime from_frames(double frame, double rate) {
+    static constexpr RationalTime from_frames(double frame, double rate) noexcept {
         return RationalTime{double(int(frame)), rate};
     }
 
-    static RationalTime from_seconds(double seconds) {
+    static constexpr RationalTime from_seconds(double seconds) noexcept {
         return RationalTime{seconds, 1};
     }
 
     static RationalTime from_timecode(std::string const& timecode, double rate, ErrorStatus *error_status);
     static RationalTime from_time_string(std::string const& time_string, double rate, ErrorStatus *error_status);
 
-    int to_frames() const {
+    constexpr int to_frames() const noexcept {
         return int(_value);
     }
 
-    int to_frames(double rate) const {
+    constexpr int to_frames(double rate) const noexcept {
         return int(value_rescaled_to(rate));
     }
 
-    double to_seconds() const {
+    constexpr double to_seconds() const noexcept {
         return value_rescaled_to(1);
     }
     
@@ -111,7 +107,7 @@ public:
     
     std::string to_time_string() const;
 
-    RationalTime const& operator+= (RationalTime other) {
+    RationalTime const& operator+= (RationalTime other) noexcept {
         if (_rate < other._rate) {
             _value = other._value + value_rescaled_to(other._rate);
             _rate = other._rate;
@@ -122,7 +118,7 @@ public:
         return *this;
     }
 
-    RationalTime const& operator-= (RationalTime other) {
+    RationalTime const& operator-= (RationalTime other) noexcept {
         if (_rate < other._rate) {
             _value = value_rescaled_to(other._rate) - other._value;
             _rate = other._rate;
@@ -133,41 +129,41 @@ public:
         return *this;
     }
 
-    friend RationalTime operator+ (RationalTime lhs, RationalTime rhs) {
+    friend constexpr RationalTime operator+ (RationalTime lhs, RationalTime rhs) noexcept {
         return (lhs._rate < rhs._rate) ? RationalTime {lhs.value_rescaled_to(rhs._rate) + rhs._value, rhs._rate} :
                                          RationalTime {rhs.value_rescaled_to(lhs._rate) + lhs._value, lhs._rate};
     }
         
-    friend RationalTime operator- (RationalTime lhs, RationalTime rhs) {
+    friend constexpr RationalTime operator- (RationalTime lhs, RationalTime rhs) noexcept {
         return (lhs._rate < rhs._rate) ? RationalTime {lhs.value_rescaled_to(rhs._rate) - rhs._value, rhs._rate} :
                                          RationalTime {lhs._value - rhs.value_rescaled_to(lhs._rate), lhs._rate};
     }
 
-    friend RationalTime operator- (RationalTime lhs) {
+    friend constexpr RationalTime operator- (RationalTime lhs) noexcept {
         return RationalTime {-lhs._value, lhs._rate};
     }
 
-    friend bool operator> (RationalTime lhs, RationalTime rhs) {
+    friend constexpr bool operator> (RationalTime lhs, RationalTime rhs) noexcept {
          return (lhs._value / lhs._rate) > (rhs._value / rhs._rate);
     }
 
-    friend bool operator>= (RationalTime lhs, RationalTime rhs) {
+    friend constexpr bool operator>= (RationalTime lhs, RationalTime rhs) noexcept {
         return (lhs._value / lhs._rate) >= (rhs._value / rhs._rate);
     }
 
-    friend bool operator< (RationalTime lhs, RationalTime rhs) {
+    friend constexpr bool operator< (RationalTime lhs, RationalTime rhs) noexcept {
         return !(lhs >= rhs);
     }
 
-    friend bool operator<= (RationalTime lhs, RationalTime rhs) {
+    friend constexpr bool operator<= (RationalTime lhs, RationalTime rhs) noexcept {
         return !(lhs > rhs);
     }
 
-    friend bool operator== (RationalTime lhs, RationalTime rhs) {
+    friend constexpr bool operator== (RationalTime lhs, RationalTime rhs) noexcept {
         return lhs.value_rescaled_to(rhs._rate) == rhs._value;
     }
 
-    friend bool operator!= (RationalTime lhs, RationalTime rhs) {
+    friend constexpr bool operator!= (RationalTime lhs, RationalTime rhs) noexcept {
         return !(lhs == rhs);
     }
 
@@ -175,7 +171,7 @@ private:
     static RationalTime _invalid_time;
     static constexpr double _invalid_rate = -1;
     
-    RationalTime _floor() const {
+    constexpr RationalTime _floor() const noexcept {
         return RationalTime {floor(_value), _rate};
     }
 

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -27,27 +27,27 @@ constexpr double DEFAULT_EPSILON_s = 1.0 / (2 * 192000.0);
 
 class TimeRange {
 public:
-    explicit TimeRange() : _start_time{}, _duration{} {}
+    explicit constexpr TimeRange() noexcept : _start_time{}, _duration{} {}
 
-    explicit TimeRange(RationalTime start_time)
+    explicit constexpr TimeRange(RationalTime start_time) noexcept
             : _start_time{start_time}, _duration{RationalTime{0, start_time.rate()}} {}
 
-    explicit TimeRange(RationalTime start_time, RationalTime duration)
+    explicit constexpr TimeRange(RationalTime start_time, RationalTime duration) noexcept
             : _start_time{start_time}, _duration{duration} {}
 
-    TimeRange(TimeRange const &) = default;
+    constexpr TimeRange(TimeRange const &) noexcept = default;
 
-    TimeRange &operator=(TimeRange const &) = default;
+    TimeRange &operator=(TimeRange const &) noexcept = default;
 
-    RationalTime const &start_time() const {
+    constexpr RationalTime const &start_time() const noexcept {
         return _start_time;
     }
 
-    RationalTime const &duration() const {
+    constexpr RationalTime const &duration() const noexcept {
         return _duration;
     }
 
-    RationalTime end_time_inclusive() const {
+    RationalTime end_time_inclusive() const noexcept {
         RationalTime et = end_time_exclusive();
 
         if ((et - _start_time.rescaled_to(_duration))._value > 1) {
@@ -58,15 +58,15 @@ public:
         }
     }
 
-    RationalTime end_time_exclusive() const {
+    constexpr RationalTime end_time_exclusive() const noexcept {
         return _duration + _start_time.rescaled_to(_duration);
     }
 
-    TimeRange duration_extended_by(RationalTime other) const {
+    constexpr TimeRange duration_extended_by(RationalTime other) const noexcept {
         return TimeRange{_start_time, _duration + other};
     }
 
-    TimeRange extended_by(TimeRange other) const {
+    TimeRange extended_by(TimeRange other) const noexcept {
         RationalTime new_start_time{std::min(_start_time, other._start_time)},
                 new_end_time{std::max(end_time_exclusive(), other.end_time_exclusive())};
 
@@ -74,11 +74,11 @@ public:
                          RationalTime::duration_from_start_end_time(new_start_time, new_end_time)};
     }
 
-    RationalTime clamped(RationalTime other) const {
+    RationalTime clamped(RationalTime other) const noexcept {
         return std::min(std::max(other, _start_time), end_time_inclusive());
     }
 
-    TimeRange clamped(TimeRange other) const {
+    TimeRange clamped(TimeRange other) const noexcept {
         TimeRange r{std::max(other._start_time, _start_time), other._duration};
         RationalTime end{std::min(r.end_time_exclusive(), end_time_exclusive())};
         return TimeRange{r._start_time, end - r._start_time};
@@ -106,7 +106,7 @@ public:
      *              [      this      ]
      * @param other
      */
-    bool contains(RationalTime other) const {
+    constexpr bool contains(RationalTime other) const noexcept {
         return _start_time <= other && other < end_time_exclusive();
     }
 
@@ -118,7 +118,7 @@ public:
      * The converse would be <em>other.contains(this)</em>
      * @param other
      */
-    bool contains(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool contains(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisStart = _start_time.to_seconds();
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
@@ -134,7 +134,7 @@ public:
      *              [    this    ]
      * @param other
      */
-    bool overlaps(RationalTime other) const {
+    bool overlaps(RationalTime other) const noexcept {
         return contains(other);
     }
 
@@ -147,7 +147,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool overlaps(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool overlaps(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisStart = _start_time.to_seconds();
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
@@ -164,7 +164,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool before(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool before(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
         return greater_than(otherStart, thisEnd, epsilon_s);
@@ -178,7 +178,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool before(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool before(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisEnd = end_time_exclusive().to_seconds();
         double otherTime = other.to_seconds();
         return lesser_than(thisEnd, otherTime, epsilon_s);
@@ -192,7 +192,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool meets(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool meets(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
         return otherStart - thisEnd <= epsilon_s && otherStart - thisEnd >= 0;
@@ -207,7 +207,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool begins(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool begins(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisStart = _start_time.to_seconds();
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
@@ -223,7 +223,7 @@ public:
      *              [ this ]
      * @param other
      */
-    bool begins(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool begins(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisStart = _start_time.to_seconds();
         double otherStart = other.to_seconds();
         return fabs(otherStart - thisStart) <= epsilon_s;
@@ -238,7 +238,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool finishes(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool finishes(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisStart = _start_time.to_seconds();
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
@@ -255,7 +255,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool finishes(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool finishes(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisEnd = end_time_exclusive().to_seconds();
         double otherEnd = other.to_seconds();
         return fabs(thisEnd - otherEnd) <= epsilon_s;
@@ -270,7 +270,7 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool intersects(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const {
+    bool intersects(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
         double thisStart = _start_time.to_seconds();
         double thisEnd = end_time_exclusive().to_seconds();
         double otherStart = other._start_time.to_seconds();
@@ -287,7 +287,7 @@ public:
      * @param lhs
      * @param rhs
      */
-    friend bool operator==(TimeRange lhs, TimeRange rhs) {
+    friend bool operator==(TimeRange lhs, TimeRange rhs) noexcept {
         RationalTime start = lhs._start_time - rhs._start_time;
         RationalTime duration = lhs._duration - rhs._duration;
         return fabs(start.to_seconds()) < DEFAULT_EPSILON_s &&
@@ -299,16 +299,16 @@ public:
      * @param lhs
      * @param rhs
      */
-    friend bool operator!=(TimeRange lhs, TimeRange rhs) {
+    friend bool operator!=(TimeRange lhs, TimeRange rhs) noexcept {
         return !(lhs == rhs);
     }
 
-    static TimeRange range_from_start_end_time(RationalTime start_time, RationalTime end_time_exclusive) {
+    static constexpr TimeRange range_from_start_end_time(RationalTime start_time, RationalTime end_time_exclusive) noexcept {
         return TimeRange{start_time,
                          RationalTime::duration_from_start_end_time(start_time, end_time_exclusive)};
     }
 
-    static TimeRange range_from_start_end_time_inclusive(RationalTime start_time, RationalTime end_time_inclusive) {
+    static constexpr TimeRange range_from_start_end_time_inclusive(RationalTime start_time, RationalTime end_time_inclusive) noexcept {
         return TimeRange{start_time,
                          RationalTime::duration_from_start_end_time_inclusive(start_time, end_time_inclusive)};
     }
@@ -317,11 +317,11 @@ private:
     RationalTime _start_time, _duration;
     friend class TimeTransform;
 
-    inline bool greater_than(double lhs, double rhs, double epsilon) const{
+    inline constexpr bool greater_than(double lhs, double rhs, double epsilon) const noexcept {
         return lhs - rhs >= epsilon;
     }
 
-    inline bool lesser_than(double lhs, double rhs, double epsilon) const{
+    inline constexpr bool lesser_than(double lhs, double rhs, double epsilon) const noexcept {
         return rhs - lhs >= epsilon;
     }
 };

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -39,11 +39,11 @@ public:
 
     TimeRange &operator=(TimeRange const &) noexcept = default;
 
-    constexpr RationalTime const &start_time() const noexcept {
+    constexpr RationalTime start_time() const noexcept {
         return _start_time;
     }
 
-    constexpr RationalTime const &duration() const noexcept {
+    constexpr RationalTime duration() const noexcept {
         return _duration;
     }
 

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -48,7 +48,7 @@ public:
     }
 
     RationalTime end_time_inclusive() const noexcept {
-        RationalTime et = end_time_exclusive();
+        const RationalTime et = end_time_exclusive();
 
         if ((et - _start_time.rescaled_to(_duration))._value > 1) {
             return _duration._value != floor(_duration._value) ? et._floor() :
@@ -66,8 +66,8 @@ public:
         return TimeRange{_start_time, _duration + other};
     }
 
-    TimeRange extended_by(TimeRange other) const noexcept {
-        RationalTime new_start_time{std::min(_start_time, other._start_time)},
+    constexpr TimeRange extended_by(TimeRange other) const noexcept {
+        const RationalTime new_start_time{std::min(_start_time, other._start_time)},
                 new_end_time{std::max(end_time_exclusive(), other.end_time_exclusive())};
 
         return TimeRange{new_start_time,
@@ -78,9 +78,9 @@ public:
         return std::min(std::max(other, _start_time), end_time_inclusive());
     }
 
-    TimeRange clamped(TimeRange other) const noexcept {
-        TimeRange r{std::max(other._start_time, _start_time), other._duration};
-        RationalTime end{std::min(r.end_time_exclusive(), end_time_exclusive())};
+    constexpr TimeRange clamped(TimeRange other) const noexcept {
+        const TimeRange r{std::max(other._start_time, _start_time), other._duration};
+        const RationalTime end{std::min(r.end_time_exclusive(), end_time_exclusive())};
         return TimeRange{r._start_time, end - r._start_time};
     }
 
@@ -118,11 +118,11 @@ public:
      * The converse would be <em>other.contains(this)</em>
      * @param other
      */
-    bool contains(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisStart = _start_time.to_seconds();
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
-        double otherEnd = other.end_time_exclusive().to_seconds();
+    constexpr bool contains(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisStart = _start_time.to_seconds();
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
+        const double otherEnd = other.end_time_exclusive().to_seconds();
         return greater_than(otherStart, thisStart, epsilon_s) && lesser_than(otherEnd, thisEnd, epsilon_s);
     }
 
@@ -134,7 +134,7 @@ public:
      *              [    this    ]
      * @param other
      */
-    bool overlaps(RationalTime other) const noexcept {
+    constexpr bool overlaps(RationalTime other) const noexcept {
         return contains(other);
     }
 
@@ -147,11 +147,11 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool overlaps(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisStart = _start_time.to_seconds();
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
-        double otherEnd = other.end_time_exclusive().to_seconds();
+    constexpr bool overlaps(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisStart = _start_time.to_seconds();
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
+        const double otherEnd = other.end_time_exclusive().to_seconds();
         return lesser_than(thisStart, otherStart, epsilon_s) &&
                 greater_than(thisEnd, otherStart, epsilon_s) &&
                 greater_than(otherEnd, thisEnd, epsilon_s);
@@ -164,9 +164,9 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool before(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
+    constexpr bool before(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
         return greater_than(otherStart, thisEnd, epsilon_s);
     }
 
@@ -178,9 +178,9 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool before(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherTime = other.to_seconds();
+    constexpr bool before(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherTime = other.to_seconds();
         return lesser_than(thisEnd, otherTime, epsilon_s);
     }
 
@@ -192,9 +192,9 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool meets(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
+    constexpr bool meets(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
         return otherStart - thisEnd <= epsilon_s && otherStart - thisEnd >= 0;
     }
 
@@ -207,11 +207,11 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool begins(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisStart = _start_time.to_seconds();
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
-        double otherEnd = other.end_time_exclusive().to_seconds();
+    constexpr bool begins(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisStart = _start_time.to_seconds();
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
+        const double otherEnd = other.end_time_exclusive().to_seconds();
         return fabs(otherStart - thisStart) <= epsilon_s && lesser_than(thisEnd, otherEnd, epsilon_s);
     }
 
@@ -223,9 +223,9 @@ public:
      *              [ this ]
      * @param other
      */
-    bool begins(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisStart = _start_time.to_seconds();
-        double otherStart = other.to_seconds();
+    constexpr bool begins(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisStart = _start_time.to_seconds();
+        const double otherStart = other.to_seconds();
         return fabs(otherStart - thisStart) <= epsilon_s;
     }
 
@@ -238,11 +238,11 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool finishes(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisStart = _start_time.to_seconds();
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
-        double otherEnd = other.end_time_exclusive().to_seconds();
+    constexpr bool finishes(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisStart = _start_time.to_seconds();
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
+        const double otherEnd = other.end_time_exclusive().to_seconds();
         return fabs(thisEnd - otherEnd) <= epsilon_s && greater_than(thisStart, otherStart, epsilon_s);
     }
 
@@ -255,9 +255,9 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool finishes(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherEnd = other.to_seconds();
+    constexpr bool finishes(RationalTime other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherEnd = other.to_seconds();
         return fabs(thisEnd - otherEnd) <= epsilon_s;
     }
 
@@ -270,11 +270,11 @@ public:
      * @param other
      * @param epsilon_s
      */
-    bool intersects(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
-        double thisStart = _start_time.to_seconds();
-        double thisEnd = end_time_exclusive().to_seconds();
-        double otherStart = other._start_time.to_seconds();
-        double otherEnd = other.end_time_exclusive().to_seconds();
+    constexpr bool intersects(TimeRange other, double epsilon_s = DEFAULT_EPSILON_s) const noexcept {
+        const double thisStart = _start_time.to_seconds();
+        const double thisEnd = end_time_exclusive().to_seconds();
+        const double otherStart = other._start_time.to_seconds();
+        const double otherEnd = other.end_time_exclusive().to_seconds();
         return lesser_than(thisStart, otherEnd, epsilon_s) && greater_than(thisEnd, otherStart, epsilon_s);
     }
 
@@ -287,9 +287,9 @@ public:
      * @param lhs
      * @param rhs
      */
-    friend bool operator==(TimeRange lhs, TimeRange rhs) noexcept {
-        RationalTime start = lhs._start_time - rhs._start_time;
-        RationalTime duration = lhs._duration - rhs._duration;
+    friend constexpr bool operator==(TimeRange lhs, TimeRange rhs) noexcept {
+        const RationalTime start = lhs._start_time - rhs._start_time;
+        const RationalTime duration = lhs._duration - rhs._duration;
         return fabs(start.to_seconds()) < DEFAULT_EPSILON_s &&
                fabs(duration.to_seconds()) < DEFAULT_EPSILON_s;
     }
@@ -299,7 +299,7 @@ public:
      * @param lhs
      * @param rhs
      */
-    friend bool operator!=(TimeRange lhs, TimeRange rhs) noexcept {
+    friend constexpr bool operator!=(TimeRange lhs, TimeRange rhs) noexcept {
         return !(lhs == rhs);
     }
 

--- a/src/opentime/timeTransform.h
+++ b/src/opentime/timeTransform.h
@@ -9,45 +9,45 @@ namespace opentime { namespace OPENTIME_VERSION {
     
 class TimeTransform {
 public:
-    explicit TimeTransform(RationalTime offset = RationalTime{}, double scale = 1, double rate = -1)
+    explicit constexpr TimeTransform(RationalTime offset = RationalTime{}, double scale = 1, double rate = -1) noexcept
     : _offset {offset}, _scale {scale}, _rate {rate} {}
 
-    RationalTime offset() const {
+    constexpr RationalTime offset() const noexcept {
         return _offset;
     }
 
-    double scale() const {
+    constexpr double scale() const noexcept {
         return _scale;
     }
 
-    double rate() const {
+    constexpr double rate() const noexcept {
         return _rate;
     }
 
-    TimeTransform(TimeTransform const&) = default;
-    TimeTransform& operator= (TimeTransform const&) = default;
+    constexpr TimeTransform(TimeTransform const&) noexcept = default;
+    TimeTransform& operator= (TimeTransform const&) noexcept = default;
 
-    TimeRange applied_to(TimeRange other) const {
+    TimeRange applied_to(TimeRange other) const noexcept {
         return TimeRange::range_from_start_end_time(applied_to(other._start_time),
                                                     applied_to(other.end_time_exclusive()));
     }
 
-    TimeTransform applied_to(TimeTransform other) const {
+    constexpr TimeTransform applied_to(TimeTransform other) const noexcept {
         return TimeTransform {_offset + other._offset, _scale * other._scale,
                               _rate > 0 ? _rate : other._rate};
     }
 
-    RationalTime applied_to(RationalTime other) const {
+    RationalTime applied_to(RationalTime other) const noexcept {
         RationalTime result { RationalTime {other._value * _scale, other._rate} + _offset };
         double target_rate = _rate > 0 ? _rate : other._rate;
         return target_rate > 0 ? result.rescaled_to(target_rate) : result;
     }
     
-    friend bool operator==(TimeTransform lhs, TimeTransform rhs) {
+    friend constexpr bool operator==(TimeTransform lhs, TimeTransform rhs) noexcept {
         return lhs._offset == rhs._offset && lhs._scale == rhs._scale && lhs._rate == rhs._rate;
     }
     
-    friend bool operator!=(TimeTransform lhs, TimeTransform rhs) {
+    friend constexpr bool operator!=(TimeTransform lhs, TimeTransform rhs) noexcept {
         return !(lhs == rhs);
     }
     

--- a/src/opentimelineio/anyDictionary.h
+++ b/src/opentimelineio/anyDictionary.h
@@ -132,7 +132,7 @@ public:
     using map::const_reverse_iterator;
     
     struct MutationStamp {
-        MutationStamp(AnyDictionary* d)
+        constexpr MutationStamp(AnyDictionary* d) noexcept
         : stamp {1}, any_dictionary {d}, owning {false} {
             assert(d);
         }
@@ -171,7 +171,7 @@ public:
 private:
     MutationStamp* _mutation_stamp = nullptr;
     
-    void mutate() {
+    void mutate() noexcept {
         if (_mutation_stamp) {
             _mutation_stamp->stamp++;
         }

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -14,7 +14,7 @@ Clip::Clip(std::string const& name,
 Clip::~Clip() {
 }
 
-MediaReference* Clip::media_reference() const {
+MediaReference* Clip::media_reference() const noexcept {
     return _media_reference;
 }
 

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -22,7 +22,7 @@ public:
 
     void set_media_reference(MediaReference* media_reference);
 
-    MediaReference* media_reference() const;
+    MediaReference* media_reference() const noexcept;
     
     virtual TimeRange available_range(ErrorStatus* error_status) const;
 

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -20,7 +20,7 @@ bool Composable::overlapping() const {
     return false;
 }
 
-bool Composable::_set_parent(Composition* new_parent) {
+bool Composable::_set_parent(Composition* new_parent) noexcept {
     if (new_parent && _parent) {
         return false;
     }
@@ -29,7 +29,7 @@ bool Composable::_set_parent(Composition* new_parent) {
     return true;
 }
 
-Composable* Composable::_highest_ancestor() {
+Composable* Composable::_highest_ancestor() noexcept {
     Composable* c = this;
     for ( ; c->_parent; c = c->_parent) {
         /* empty */

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -29,10 +29,10 @@ public:
     virtual RationalTime duration(ErrorStatus* error_status) const;
 
 protected:
-    bool _set_parent(Composition*);
-    Composable* _highest_ancestor();
+    bool _set_parent(Composition*) noexcept;
+    Composable* _highest_ancestor() noexcept;
 
-    Composable const* _highest_ancestor() const {
+    Composable const* _highest_ancestor() const noexcept {
         return const_cast<Composable*>(this)->_highest_ancestor();
     }
 

--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -19,7 +19,7 @@ Composition::~Composition() {
     clear_children();
 }
 
-std::string const& Composition::composition_kind() const {
+std::string Composition::composition_kind() const {
     static std::string kind = "Composition";
     return kind;
 }
@@ -310,7 +310,7 @@ optional<TimeRange> Composition::trim_child_range(TimeRange child_range) const {
         return child_range;
     }
     
-    TimeRange const& sr = *source_range();
+    const TimeRange sr = *source_range();
     bool past_end_time = sr.start_time() >= child_range.end_time_exclusive();
     bool before_start_time = sr.end_time_exclusive() <= child_range.start_time();
     

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -23,7 +23,7 @@ public:
 
     virtual std::string const& composition_kind() const;
 
-    std::vector<Retainer<Composable>> const& children() const {
+    std::vector<Retainer<Composable>> const& children() const noexcept {
         return _children;
     }
 

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -21,7 +21,7 @@ public:
                 std::vector<Effect*> const& effects = std::vector<Effect*>(),
                 std::vector<Marker*> const& markers = std::vector<Marker*>());
 
-    virtual std::string const& composition_kind() const;
+    virtual std::string composition_kind() const;
 
     std::vector<Retainer<Composable>> const& children() const noexcept {
         return _children;

--- a/src/opentimelineio/effect.h
+++ b/src/opentimelineio/effect.h
@@ -18,7 +18,7 @@ public:
            std::string const& effect_name = std::string(),
            AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& effect_name() const noexcept {
+    std::string effect_name() const noexcept {
         return _effect_name;
     }
     

--- a/src/opentimelineio/effect.h
+++ b/src/opentimelineio/effect.h
@@ -18,7 +18,7 @@ public:
            std::string const& effect_name = std::string(),
            AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& effect_name() const {
+    std::string const& effect_name() const noexcept {
         return _effect_name;
     }
     

--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -8,7 +8,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 class SerializableObject;
 
 struct ErrorStatus {
-    operator bool () {
+    operator bool () noexcept {
         return outcome != Outcome::OK;
     }
     

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -18,7 +18,7 @@ public:
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
         
-    std::string const& target_url() const {
+    std::string const& target_url() const noexcept {
         return _target_url;
     }
     

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -18,7 +18,7 @@ public:
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
         
-    std::string const& target_url() const noexcept {
+    std::string target_url() const noexcept {
         return _target_url;
     }
     

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -20,7 +20,7 @@ public:
                        AnyDictionary const& parameters = AnyDictionary(),
                        AnyDictionary const& metadata = AnyDictionary());
         
-    std::string const& generator_kind() const noexcept {
+    std::string generator_kind() const noexcept {
         return _generator_kind;
     }
     

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -20,7 +20,7 @@ public:
                        AnyDictionary const& parameters = AnyDictionary(),
                        AnyDictionary const& metadata = AnyDictionary());
         
-    std::string const& generator_kind() const {
+    std::string const& generator_kind() const noexcept {
         return _generator_kind;
     }
     
@@ -28,11 +28,11 @@ public:
         _generator_kind = generator_kind;
     }
 
-    AnyDictionary& parameters() {
+    AnyDictionary& parameters() noexcept {
         return _parameters;
     }
 
-    AnyDictionary const& parameters() const {
+    AnyDictionary const& parameters() const noexcept {
         return _parameters;
     }
 

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -32,7 +32,7 @@ public:
         return _parameters;
     }
 
-    AnyDictionary const& parameters() const noexcept {
+    AnyDictionary parameters() const noexcept {
         return _parameters;
     }
 

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -7,7 +7,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
                       std::string const& name_suffix,
                       int start_frame,
                       int frame_step,
-                      double const rate,
+                      double rate,
                       int frame_zero_padding,
                       MissingFramePolicy const missing_frame_policy,
                       optional<TimeRange> const& available_range,
@@ -52,7 +52,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
         return num_frames;
     }
 
-    int ImageSequenceReference::frame_for_time(RationalTime const time, ErrorStatus* error_status) const {
+    int ImageSequenceReference::frame_for_time(RationalTime const& time, ErrorStatus* error_status) const {
         if (!this->available_range().has_value() || !this->available_range().value().contains(time)) {
             *error_status = ErrorStatus(ErrorStatus::INVALID_TIME_RANGE);
             return 0;
@@ -68,7 +68,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
     }
 
     std::string
-    ImageSequenceReference::target_url_for_image_number(int const image_number, ErrorStatus* error_status) const {
+    ImageSequenceReference::target_url_for_image_number(int image_number, ErrorStatus* error_status) const {
         if (_rate == 0) {
             *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX, "Zero rate sequence has no frames.");
             return std::string();
@@ -109,7 +109,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
     }
 
     RationalTime
-    ImageSequenceReference::presentation_time_for_image_number(int const image_number, ErrorStatus* error_status) const {
+    ImageSequenceReference::presentation_time_for_image_number(int image_number, ErrorStatus* error_status) const {
         if (image_number >= this->number_of_images_in_sequence()) {
             *error_status = ErrorStatus(ErrorStatus::ILLEGAL_INDEX);
             return RationalTime();

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -27,7 +27,7 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
     }
 
     RationalTime
-    ImageSequenceReference::frame_duration() const {
+    ImageSequenceReference::frame_duration() const noexcept {
         return RationalTime((double)_frame_step, _rate);
     }
 

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -31,7 +31,7 @@ public:
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
         
-    std::string const& target_url_base() const noexcept {
+    std::string target_url_base() const noexcept {
         return _target_url_base;
     }
     

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -39,7 +39,7 @@ public:
         _target_url_base = target_url_base;
     }
         
-    std::string const& name_prefix() const noexcept {
+    std::string name_prefix() const noexcept {
         return _name_prefix;
     }
     

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -25,7 +25,7 @@ public:
                       std::string const& name_suffix = std::string(),
                       int start_frame = 1,
                       int frame_step = 1,
-                      double const rate = 1,
+                      double rate = 1,
                       int frame_zero_padding = 0,
                       MissingFramePolicy const missing_frame_policy = MissingFramePolicy::error,
                       optional<TimeRange> const& available_range = nullopt,
@@ -47,7 +47,7 @@ public:
         _name_prefix = target_url_base;
     }
 
-    std::string const& name_suffix() const noexcept {
+    std::string name_suffix() const noexcept {
         return _name_suffix;
     }
     
@@ -59,7 +59,7 @@ public:
         return _start_frame;
     }
 
-    void set_start_frame(int const start_frame) noexcept {
+    void set_start_frame(int start_frame) noexcept {
         _start_frame = start_frame;
     }
 
@@ -67,15 +67,15 @@ public:
         return _frame_step;
     }
 
-    void set_frame_step(int const frame_step) noexcept {
+    void set_frame_step(int frame_step) noexcept {
         _frame_step = frame_step;
     }
 
-    double const& rate() const noexcept {
+    double rate() const noexcept {
         return _rate;
     }
 
-    void set_rate(double const rate) noexcept {
+    void set_rate(double rate) noexcept {
         _rate = rate;
     }
 
@@ -83,11 +83,11 @@ public:
         return _frame_zero_padding;
     }
 
-    void set_frame_zero_padding(int const frame_zero_padding) noexcept {
+    void set_frame_zero_padding(int frame_zero_padding) noexcept {
         _frame_zero_padding = frame_zero_padding;
     }
 
-    void set_missing_frame_policy(MissingFramePolicy const missing_frame_policy) noexcept {
+    void set_missing_frame_policy(MissingFramePolicy missing_frame_policy) noexcept {
         _missing_frame_policy = missing_frame_policy;
     }
 
@@ -97,13 +97,13 @@ public:
 
     int end_frame() const;
     int number_of_images_in_sequence() const;
-    int frame_for_time(RationalTime const time, ErrorStatus* error_status) const;
+    int frame_for_time(RationalTime const& time, ErrorStatus* error_status) const;
 
     std::string
-    target_url_for_image_number(int const image_number, ErrorStatus* error_status) const;
+    target_url_for_image_number(int image_number, ErrorStatus* error_status) const;
 
     RationalTime
-    presentation_time_for_image_number(int const image_number, ErrorStatus* error_status) const;
+    presentation_time_for_image_number(int image_number, ErrorStatus* error_status) const;
 
 protected:
     virtual ~ImageSequenceReference();

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -31,7 +31,7 @@ public:
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary());
         
-    std::string const& target_url_base() const {
+    std::string const& target_url_base() const noexcept {
         return _target_url_base;
     }
     
@@ -39,7 +39,7 @@ public:
         _target_url_base = target_url_base;
     }
         
-    std::string const& name_prefix() const {
+    std::string const& name_prefix() const noexcept {
         return _name_prefix;
     }
     
@@ -47,7 +47,7 @@ public:
         _name_prefix = target_url_base;
     }
 
-    std::string const& name_suffix() const {
+    std::string const& name_suffix() const noexcept {
         return _name_suffix;
     }
     
@@ -55,43 +55,43 @@ public:
         _name_suffix = target_url_base;
     }
 
-    int start_frame() const {
+    int start_frame() const noexcept {
         return _start_frame;
     }
 
-    void set_start_frame(int const start_frame) {
+    void set_start_frame(int const start_frame) noexcept {
         _start_frame = start_frame;
     }
 
-    int frame_step() const {
+    int frame_step() const noexcept {
         return _frame_step;
     }
 
-    void set_frame_step(int const frame_step) {
+    void set_frame_step(int const frame_step) noexcept {
         _frame_step = frame_step;
     }
 
-    double const& rate() const {
+    double const& rate() const noexcept {
         return _rate;
     }
 
-    void set_rate(double const rate) {
+    void set_rate(double const rate) noexcept {
         _rate = rate;
     }
 
-    int frame_zero_padding() const {
+    int frame_zero_padding() const noexcept {
         return _frame_zero_padding;
     }
 
-    void set_frame_zero_padding(int const frame_zero_padding) {
+    void set_frame_zero_padding(int const frame_zero_padding) noexcept {
         _frame_zero_padding = frame_zero_padding;
     }
 
-    void set_missing_frame_policy(MissingFramePolicy const missing_frame_policy) {
+    void set_missing_frame_policy(MissingFramePolicy const missing_frame_policy) noexcept {
         _missing_frame_policy = missing_frame_policy;
     }
 
-    MissingFramePolicy missing_frame_policy() const {
+    MissingFramePolicy missing_frame_policy() const noexcept {
         return _missing_frame_policy;
     }
 
@@ -121,7 +121,7 @@ private:
     int _frame_zero_padding;
     MissingFramePolicy _missing_frame_policy;
     
-    RationalTime frame_duration() const;
+    RationalTime frame_duration() const noexcept;
 };
 
 } }

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -29,7 +29,7 @@ public:
     virtual bool visible() const;
     virtual bool overlapping() const;
 
-    optional<TimeRange> const& source_range () const {
+    optional<TimeRange> const& source_range () const noexcept {
         return _source_range;
     }
 
@@ -37,19 +37,19 @@ public:
         _source_range = source_range;
     }
 
-    std::vector<Retainer<Effect>>& effects() {
+    std::vector<Retainer<Effect>>& effects() noexcept {
         return _effects;
     }
 
-    std::vector<Retainer<Effect>> const& effects() const {
+    std::vector<Retainer<Effect>> const& effects() const noexcept {
         return _effects;
     }
 
-    std::vector<Retainer<Marker>>& markers() {
+    std::vector<Retainer<Marker>>& markers() noexcept {
         return _markers;
     }
 
-    std::vector<Retainer<Marker>> const& markers() const {
+    std::vector<Retainer<Marker>> const& markers() const noexcept {
         return _markers;
     }
 

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -29,7 +29,7 @@ public:
     virtual bool visible() const;
     virtual bool overlapping() const;
 
-    optional<TimeRange> const& source_range () const noexcept {
+    optional<TimeRange> source_range () const noexcept {
         return _source_range;
     }
 

--- a/src/opentimelineio/linearTimeWarp.h
+++ b/src/opentimelineio/linearTimeWarp.h
@@ -19,11 +19,11 @@ public:
                    double time_scalar = 1,
                    AnyDictionary const& metadata = AnyDictionary());
 
-    double time_scalar() const {
+    double time_scalar() const noexcept {
         return _time_scalar;
     }
 
-    void set_time_scalar(double time_scalar) {
+    void set_time_scalar(double time_scalar) noexcept {
         _time_scalar = time_scalar;
     }
 

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -33,7 +33,7 @@ public:
            std::string const& color = Color::green,
            AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& color() const {
+    std::string const& color() const noexcept {
         return _color;
     }
     
@@ -41,11 +41,11 @@ public:
         _color = color;
     }
 
-    TimeRange const& marked_range() const {
+    TimeRange const& marked_range() const noexcept {
         return _marked_range;
     }
 
-    void set_marked_range(TimeRange const& marked_range) {
+    void set_marked_range(TimeRange const& marked_range) noexcept {
         _marked_range = marked_range;
     }
 

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -33,7 +33,7 @@ public:
            std::string const& color = Color::green,
            AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& color() const noexcept {
+    std::string color() const noexcept {
         return _color;
     }
     

--- a/src/opentimelineio/marker.h
+++ b/src/opentimelineio/marker.h
@@ -41,7 +41,7 @@ public:
         _color = color;
     }
 
-    TimeRange const& marked_range() const noexcept {
+    TimeRange marked_range() const noexcept {
         return _marked_range;
     }
 

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -20,7 +20,7 @@ public:
                    optional<TimeRange> const& available_range = nullopt,
                    AnyDictionary const& metadata = AnyDictionary());
 
-    optional<TimeRange> const& available_range () const noexcept {
+    optional<TimeRange> available_range () const noexcept {
         return _available_range;
     }
 

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -20,7 +20,7 @@ public:
                    optional<TimeRange> const& available_range = nullopt,
                    AnyDictionary const& metadata = AnyDictionary());
 
-    optional<TimeRange> const& available_range () const {
+    optional<TimeRange> const& available_range () const noexcept {
         return _available_range;
     }
 

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -21,11 +21,11 @@ public:
                            std::vector<SerializableObject*> children = std::vector<SerializableObject*>(),
                            AnyDictionary const& metadata = AnyDictionary());
 
-    std::vector<Retainer<SerializableObject>> const& children() const {
+    std::vector<Retainer<SerializableObject>> const& children() const noexcept {
         return _children;
     }
 
-    std::vector<Retainer<SerializableObject>>& children() {
+    std::vector<Retainer<SerializableObject>>& children() noexcept {
         return _children;
     }
 

--- a/src/opentimelineio/serializableObject.cpp
+++ b/src/opentimelineio/serializableObject.cpp
@@ -113,7 +113,7 @@ SerializableObject* SerializableObject::from_json_file(std::string const& file_n
     return any_cast<Retainer<>&>(dest).take_value();
 }
 
-std::string const& SerializableObject::_schema_name_for_reference() const {
+std::string SerializableObject::_schema_name_for_reference() const {
     return schema_name();
 }
 

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -442,7 +442,7 @@ public:
 
     virtual bool is_unknown_schema() const;
     
-    std::string const& schema_name() const {
+    std::string schema_name() const {
         return _type_record()->schema_name;
     }
 
@@ -512,7 +512,7 @@ private:
     SerializableObject& operator=(SerializableObject const&) = delete;
     template <typename T> friend struct Retainer;
     
-    virtual std::string const& _schema_name_for_reference() const;
+    virtual std::string _schema_name_for_reference() const;
             
     void _managed_retain();
     void _managed_release();

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -452,15 +452,15 @@ public:
     
     template <typename T>
     struct Retainer {
-        operator T* () const {
+        operator T* () const noexcept {
             return value;
         }
 
-        T* operator -> () const {
+        T* operator -> () const noexcept {
             return value;
         }
         
-        operator bool () const {
+        operator bool () const noexcept {
             return value != nullptr;
         }
         

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -17,7 +17,7 @@ public:
     SerializableObjectWithMetadata(std::string const& name = std::string(),
                                    AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& name() const noexcept {
+    std::string name() const noexcept {
         return _name;
     }
 

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -17,7 +17,7 @@ public:
     SerializableObjectWithMetadata(std::string const& name = std::string(),
                                    AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& name() const {
+    std::string const& name() const noexcept {
         return _name;
     }
 
@@ -25,11 +25,11 @@ public:
         _name = name;
     }
 
-    AnyDictionary& metadata() {
+    AnyDictionary& metadata() noexcept {
         return _metadata;
     }
 
-    AnyDictionary const& metadata() const {
+    AnyDictionary const& metadata() const noexcept {
         return _metadata;
     }
 

--- a/src/opentimelineio/serializableObjectWithMetadata.h
+++ b/src/opentimelineio/serializableObjectWithMetadata.h
@@ -29,7 +29,7 @@ public:
         return _metadata;
     }
 
-    AnyDictionary const& metadata() const noexcept {
+    AnyDictionary metadata() const noexcept {
         return _metadata;
     }
 

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -16,7 +16,7 @@ Stack::Stack(
 Stack::~Stack() {
 }
 
-std::string const& Stack::composition_kind() const {
+std::string Stack::composition_kind() const {
     static std::string kind = "Stack";
     return kind;
 }
@@ -67,7 +67,7 @@ TimeRange Stack::trimmed_range_of_child_at_index(int index, ErrorStatus* error_s
         return range;
     }
     
-    TimeRange const& sr = *source_range();
+    const TimeRange sr = *source_range();
     return TimeRange(sr.start_time(),
                      std::min(range.duration(), sr.duration()));
 }

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -40,7 +40,7 @@ public:
 protected:
     virtual ~Stack();
 
-    virtual std::string const& composition_kind() const;
+    virtual std::string composition_kind() const;
 
     virtual bool read_from(Reader&);
     virtual void write_to(Writer&) const;

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -22,7 +22,7 @@ public:
              optional<RationalTime> global_start_time = nullopt,
              AnyDictionary const& metadata = AnyDictionary());
 
-    Stack* tracks() const {
+    Stack* tracks() const noexcept {
         return _tracks;
     }
 
@@ -34,7 +34,7 @@ public:
 
     void set_tracks(Stack* stack);
     
-    optional<RationalTime> const& global_start_time() const {
+    optional<RationalTime> const& global_start_time() const noexcept {
         return _global_start_time;
     }
     

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -34,7 +34,7 @@ public:
 
     void set_tracks(Stack* stack);
     
-    optional<RationalTime> const& global_start_time() const noexcept {
+    optional<RationalTime> global_start_time() const noexcept {
         return _global_start_time;
     }
     

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -17,7 +17,7 @@ Track::Track(std::string const& name,
 Track::~Track() {
 }
 
-std::string const& Track::composition_kind() const {
+std::string Track::composition_kind() const {
     static std::string kind = "Track";
     return kind;
 }

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -31,7 +31,7 @@ public:
           std::string const& = Kind::video,
           AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& kind() const noexcept {
+    std::string kind() const noexcept {
         return _kind;
     }
     

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -31,7 +31,7 @@ public:
           std::string const& = Kind::video,
           AnyDictionary const& metadata = AnyDictionary());
 
-    std::string const& kind() const {
+    std::string const& kind() const noexcept {
         return _kind;
     }
     

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -63,7 +63,7 @@ public:
 
 protected:
     virtual ~Track();
-    virtual std::string const& composition_kind() const;
+    virtual std::string composition_kind() const;
 
     virtual bool read_from(Reader&);
     virtual void write_to(Writer&) const;

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -39,7 +39,7 @@ public:
         return _in_offset;
     }
     
-    void set_in_offset(RationalTime in_offset) noexcept {
+    void set_in_offset(RationalTime const& in_offset) noexcept {
         _in_offset = in_offset;
     }
 
@@ -47,7 +47,7 @@ public:
         return _out_offset;
     }
     
-    void set_out_offset(RationalTime out_offset) noexcept {
+    void set_out_offset(RationalTime const& out_offset) noexcept {
         _out_offset = out_offset;
     }
 

--- a/src/opentimelineio/transition.h
+++ b/src/opentimelineio/transition.h
@@ -27,7 +27,7 @@ public:
 
     virtual bool overlapping() const;
 
-    std::string transition_type() const {
+    std::string transition_type() const noexcept {
         return _transition_type;
     }
     
@@ -35,19 +35,19 @@ public:
         _transition_type = transition_type;
     }
 
-    RationalTime in_offset() const {
+    RationalTime in_offset() const noexcept {
         return _in_offset;
     }
     
-    void set_in_offset(RationalTime in_offset) {
+    void set_in_offset(RationalTime in_offset) noexcept {
         _in_offset = in_offset;
     }
 
-    RationalTime out_offset() const {
+    RationalTime out_offset() const noexcept {
         return _out_offset;
     }
     
-    void set_out_offset(RationalTime out_offset) {
+    void set_out_offset(RationalTime out_offset) noexcept {
         _out_offset = out_offset;
     }
 

--- a/src/opentimelineio/unknownSchema.cpp
+++ b/src/opentimelineio/unknownSchema.cpp
@@ -22,7 +22,7 @@ void UnknownSchema::write_to(Writer& writer) const {
     }
 }
 
-std::string const& UnknownSchema::_schema_name_for_reference() const {
+std::string UnknownSchema::_schema_name_for_reference() const {
     return _original_schema_name;
 }
 

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -14,11 +14,11 @@ public:
 
     UnknownSchema(std::string const& original_schema_name, int original_schema_version);
 
-    std::string const& original_schema_name() const {
+    std::string const& original_schema_name() const noexcept {
         return _original_schema_name;
     }
     
-    int original_schema_version() const {
+    int original_schema_version() const noexcept {
         return _original_schema_version;
     }
 

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -14,7 +14,7 @@ public:
 
     UnknownSchema(std::string const& original_schema_name, int original_schema_version);
 
-    std::string const& original_schema_name() const noexcept {
+    std::string original_schema_name() const noexcept {
         return _original_schema_name;
     }
     

--- a/src/opentimelineio/unknownSchema.h
+++ b/src/opentimelineio/unknownSchema.h
@@ -30,7 +30,7 @@ public:
 private:
     virtual ~UnknownSchema();
 
-    virtual std::string const& _schema_name_for_reference() const;
+    virtual std::string _schema_name_for_reference() const;
 
     std::string _original_schema_name;
     int _original_schema_version;

--- a/src/opentimelineio/vectorIndexing.h
+++ b/src/opentimelineio/vectorIndexing.h
@@ -5,7 +5,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
     
 template <typename V>
-inline int adjusted_vector_index(int index, V const& vec) {
+constexpr int adjusted_vector_index(int index, V const& vec) noexcept {
     return index < 0 ? int(vec.size()) + index : index;
 }
     


### PR DESCRIPTION
```Fixes #999```

I tried adding constexpr/noexcept decorators to OpenTime, if this looks reasonable I can also do a pass over OpenTimelineIO. I haven't used constexpr/noexcept much so hopefully I didn't go overboard, it certainly makes the headers look more busy.
