### PR TITLE
update outdated python module paths in docs

### DIFF
--- a/docs/tutorials/architecture.md
+++ b/docs/tutorials/architecture.md
@@ -35,7 +35,7 @@ The in-memory OTIO representation data model is rooted at an `otio.schema.Timeli
 - `otio.schema.Track`
 - `otio.schema.Transition`
 
-The `otio.schema.Clip` objects can reference media through a `otio.media_reference.External` or indicate that they are missing a reference to real media with a `otio.media_reference.MissingReference`.  All objects have a metadata dictionary for blind data.
+The `otio.schema.Clip` objects can reference media through a `otio.schema.ExternalReference` or indicate that they are missing a reference to real media with a `otio.schema.MissingReference`.  All objects have a metadata dictionary for blind data.
 
 Schema composition objects (`otio.schema.Stack` and `otio.schema.Track`) implement the python mutable sequence API.  A simple script that prints out each shot might look like:
 
@@ -76,7 +76,7 @@ A clip must have at least one set or else its duration is not computable:
 
 ```python
 cl.duration()
-# raises: CannotComputeAvailableRangeError: No available_range set on media reference on clip: Clip("example", External("file:///example.mov"), None, {})
+# raises: opentimelineio._otio.CannotComputeAvailableRangeError: Cannot compute available range: No available_range set on media reference on clip: Clip("", ExternalReference("file:///example.mov"), None, {})
 ```
 
 You may query the `available_range` and `trimmed_range` via accessors on the `Clip()` itself, for example:

--- a/docs/tutorials/write-a-media-linker.md
+++ b/docs/tutorials/write-a-media-linker.md
@@ -47,7 +47,7 @@ For example:
     def link_media_reference(in_clip, media_linker_argument_map):
         d.update(media_linker_argument_map)
         # you'll probably want to set it to something other than a missing reference
-        in_clip.media_reference = otio.media_reference.MissingReference(
+        in_clip.media_reference = otio.schema.MissingReference(
             name=in_clip.name + "_tweaked",
             metadata=d
         )

--- a/docs/tutorials/write-an-adapter.md
+++ b/docs/tutorials/write-an-adapter.md
@@ -165,7 +165,7 @@ Note that all metadata should be nested inside a sub-dictionary (in this example
 
 Clip media (if known) should be linked like this:
 ```python
-clip.media_reference = otio.media_reference.External(
+clip.media_reference = otio.schema.ExternalReference(
     target_url="file://example/movie.mov"
 )
 ```
@@ -186,7 +186,7 @@ Note that the source_range of the clip is not necessarily the same as the availa
 
 If you know the range of media available at that Media Reference's URL, then you can specify it like this:
 ```python
-clip.media_reference = otio.media_reference.External(
+clip.media_reference = otio.schema.ExternalReference(
   target_url="file://example/movie.mov",
   available_range=otio.opentime.TimeRange(
       start_time=otio.opentime.RationalTime(100, 24), # frame 100 @ 24fps


### PR DESCRIPTION
- otio.media_reference -> otio.schema
- updated the text of an exception to match the current text