### PR TITLE
Add ALE adapter round-trip CDL values

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/ale.py
+++ b/contrib/opentimelineio_contrib/adapters/ale.py
@@ -134,12 +134,29 @@ def _parse_data_line(line, columns, fps):
 
             if cdl:
                 del metadata['ASC_SOP']
+                asc_sop = cdl.get('asc_sop')
+                if asc_sop:
+                    line.append(
+                        "*ASC_SOP ({} {} {}) ({} {} {}) ({} {} {})".format(
+                            asc_sop['slope'][0],
+                            asc_sop['slope'][1],
+                            asc_sop['slope'][2],
+                            asc_sop['offset'][0],
+                            asc_sop['offset'][1],
+                            asc_sop['offset'][2],
+                            asc_sop['power'][0],
+                            asc_sop['power'][1],
+                            asc_sop['power'][2],
+                         ))
 
         if metadata.get('ASC_SAT'):
             try:
                 asc_sat_value = float(metadata['ASC_SAT'])
                 cdl.update(asc_sat=asc_sat_value)
                 del metadata['ASC_SAT']
+                asc_sat = cdl.get('asc_sat')
+                if asc_sat:
+                    line.append("*ASC_SAT {}".format(asc_sat))
             except ValueError:
                 pass
 


### PR DESCRIPTION
```Fixes #1050```

**Summary**
Appended ASC_SOP and ASC_SAT values for the round-trip of data.

To provide a similar behavior as EDL adapter.

