### PR TITLE
Error fixes

### DIFF
--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -141,13 +141,14 @@ inline std::vector<SerializableObject::Retainer<T>> Composition::children_if(
     optional<TimeRange> search_range,
     bool shallow_search) const
 {
+    std::vector<Retainer<T>> out;
     std::vector<Retainer<Composable>> children;
     if (search_range)
     {
         // limit the search to children who are in the search_range
         children = children_in_range(*search_range, error_status);
-        if (!error_status) {
-            *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
+        if (*error_status) {
+            return out;
         }
     }
     else
@@ -155,7 +156,6 @@ inline std::vector<SerializableObject::Retainer<T>> Composition::children_if(
         // otherwise search all the children
         children = _children;
     }
-    std::vector<Retainer<T>> out;
     for (const auto& child : children)
     {
         if (auto valid_child = dynamic_cast<T*>(child.value)) {
@@ -171,14 +171,14 @@ inline std::vector<SerializableObject::Retainer<T>> Composition::children_if(
                 if (search_range)
                 {
                     search_range = transformed_time_range(*search_range, composition, error_status);
-                    if (!error_status) {
-                        *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
+                    if (*error_status) {
+                        return out;
                     }
                 }
 
                 const auto valid_children = composition->children_if<T>(error_status, search_range, shallow_search);
-                if (!error_status) {
-                    *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
+                if (*error_status) {
+                    return out;
                 }
                 for (const auto& valid_child : valid_children) {
                     out.push_back(valid_child);

--- a/src/opentimelineio/serializableCollection.h
+++ b/src/opentimelineio/serializableCollection.h
@@ -93,8 +93,8 @@ inline std::vector<SerializableObject::Retainer<T>> SerializableCollection::chil
             if (auto collection = dynamic_cast<SerializableCollection*>(child.value))
             {
                 const auto valid_children = collection->children_if<T>(error_status, search_range);
-                if (!error_status) {
-                    *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
+                if (*error_status) {
+                    return out;
                 }
                 for (const auto& valid_child : valid_children) {
                     out.push_back(valid_child);
@@ -103,8 +103,8 @@ inline std::vector<SerializableObject::Retainer<T>> SerializableCollection::chil
             else if (auto composition = dynamic_cast<Composition*>(child.value))
             {
                 const auto valid_children = composition->children_if<T>(error_status, search_range);
-                if (!error_status) {
-                    *error_status = ErrorStatus(ErrorStatus::INTERNAL_ERROR, "one or more invalid children encountered");
+                if (*error_status) {
+                    return out;
                 }
                 for (const auto& valid_child : valid_children) {
                     out.push_back(valid_child);


### PR DESCRIPTION
Fixes #1060

These changes fix the error handling in ```Composition::child_at_time()```, ```Composition::children_in_range()```, ```Composition::children_if()```, and ```SerializableCollection::children_if()``` to properly check the error_status and return from the function.

I also added an additional Python test for the various options to ```children_if()/each_child()```, though it might not be necessary if it doesn't increase test coverage. I was hoping to test the various error conditions that were fixed, though it's not obvious how to trigger them since error_status is passed down to so many different functions.