### PR TITLE
AAF Parser - Simplify no longer removes track of all muted clips

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -1147,7 +1147,9 @@ def _contains_something_valuable(thing):
 
     if isinstance(thing, otio.schema.Gap):
         # TODO: Are there other valuable things we should look for on a Gap?
-        return False
+        gap_metadata = thing.metadata.get('AAF')
+        if gap_metadata is not None and 'alternates' not in gap_metadata:
+            return False
 
     # anything else is presumed to be valuable
     return True


### PR DESCRIPTION
A bug that recently came to my attention, so figured I'd submit a PR to match the change we've put in to our branch for use in Matchbox. 

Looks to be an oversight in how the Gap objects are actually being used, as there is absolutely something valuable in that object when it's a muted clip and contains all the information on the clip that is muted. 