### PR TITLE
Fix CMP0010 CMake warning caused by back slashes on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ if(OTIO_PYTHON_INSTALL)
             set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${OTIO_PYTHON_INSTALL_DIR}/opentimelineio")
         endif()
     endif()
+
+    if (win32)
+        string(REPLACE "\\" "/" OTIO_RESOLVED_PYTHON_INSTALL_DIR ${OTIO_RESOLVED_PYTHON_INSTALL_DIR})
+    endif()
+
 else()
     set(OTIO_RESOLVED_CXX_DYLIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib")
     message(STATUS "OTIO C++ installing to ${CMAKE_INSTALL_PREFIX}")


### PR DESCRIPTION
Small fix to remove an annoying CMake warning in build logs. See https://github.com/PixarAnimationStudios/OpenTimelineIO/runs/3642334378?check_suite_focus=true#step:8:523 for the wanring in context.

The warning in question is:
```
    CMake Warning (dev) at src/py-opentimelineio/opentimelineio-bindings/cmake_install.cmake:80 (list):
      Syntax error in cmake code at

        D:/a/OpenTimelineIO/OpenTimelineIO/build/src/py-opentimelineio/opentimelineio-bindings/cmake_install.cmake:81

      when parsing string

        C:\Users\RUNNER~1\AppData\Local\Temp\pip-req-build-3xa3dntx\build\lib.win-amd64-3.7\/bin/

      Invalid escape sequence \U

      Policy CMP0010 is not set: Bad variable reference syntax is an error.  Run
      "cmake --help-policy CMP0010" for policy details.  Use the cmake_policy
      command to set the policy and suppress this warning.
    Call Stack (most recent call first):
      src/py-opentimelineio/cmake_install.cmake:42 (include)
      cmake_install.cmake:52 (include)
    This warning is for project developers.  Use -Wno-dev to suppress it.
```