### PR TITLE
Support Python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [2.7, 3.7, 3.8]
+        python-version: [2.7, 3.7, 3.8, 3.9]
 
     env:
       OTIO_CXX_COVERAGE_BUILD: ON
@@ -71,7 +71,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-build: [cp27*, cp37*, cp38*]
+        python-build: [cp27*, cp37*, cp38*, cp39*]
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenTimelineIO
 ==============
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2016--2020-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.7%2C%203.8-blue.svg)
+![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.7%2C%203.8%2C%203.9-blue)
 [![Build Status](https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO/branch/master/graph/badge.svg)](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
@@ -108,7 +108,7 @@ You can install development dependencies with `pip install .[dev]`
 
 You can also install the PySide2 dependency with `pip install .[view]`
 
-Currently the code base is written against python2.7, python3.7 and python3.8,
+Currently the code base is written against python 2.7, 3.7, 3.8 and 3.9,
 in keeping with the pep8 style.  We ask that before developers submit pull
 request, they:
 

--- a/setup.py
+++ b/setup.py
@@ -32,19 +32,6 @@ PLAT_TO_CMAKE = {
     "win-amd64": "x64",
 }
 
-INSTALL_REQUIRES = [
-    'pyaaf2~=1.4.0',
-]
-# python2 dependencies
-if sys.version_info[0] < 3:
-    INSTALL_REQUIRES.extend(
-        [
-            "backports.tempfile",
-            'future',  # enables the builtins module in the XGES adapter
-            "pathlib2"  # used in the otioz adapter to conform to unix paths
-        ]
-    )
-
 
 def _debugInstance(x):
     for a in sorted(dir(x)):
@@ -295,6 +282,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: OS Independent',
         'Natural Language :: English',
     ],
@@ -329,7 +317,17 @@ setup(
         'opentimelineview': 'src/opentimelineview',
     },
 
-    install_requires=INSTALL_REQUIRES,
+    # Disallow 3.9.0 because of https://github.com/python/cpython/pull/22670
+    python_requires='>2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, !=3.6.*, !=3.9.0',  # noqa: E501
+
+    install_requires=[
+        'pyaaf2~=1.4.0',
+        'backports.tempfile; python_version<"3.0"',
+        # Enables the builtins module in the XGES adapter
+        'future; python_version<"3.0"',
+        # Used in the otioz adapter to conform to unix paths
+        'pathlib2; python_version<"3.0"'
+    ],
     entry_points={
         'console_scripts': [
             'otioview = opentimelineview.console:main',


### PR DESCRIPTION
Fixes #828.

Add support for Python 3.9.

I also took the occasion to set the `python_requires` to explicitly set the supported Python versions and prohibit Python 3.9.0. Additionally I removed the logic around the install requires for Python < 3 to use a more modern and static method.