### PR TITLE
bounds -> available_image_bounds and remove imath inclusives

### DIFF
--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -59,8 +59,8 @@ parameters:
 ### MediaReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
-- *bounds*
 - *metadata*
 - *name*
 
@@ -149,8 +149,8 @@ parameters:
 ### ExternalReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
-- *bounds*
 - *metadata*
 - *name*
 - *target_url*
@@ -175,8 +175,8 @@ parameters:
 ### GeneratorReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
-- *bounds*
 - *generator_kind*
 - *metadata*
 - *name*
@@ -185,8 +185,8 @@ parameters:
 ### ImageSequenceReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
-- *bounds*
 - *frame_step*
 - *frame_zero_padding*
 - *metadata*
@@ -217,8 +217,8 @@ parameters:
 ### MissingReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
-- *bounds*
 - *metadata*
 - *name*
 

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -113,8 +113,8 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
-- *bounds*: 
 - *metadata*: 
 - *name*: 
 
@@ -302,8 +302,8 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
-- *bounds*: 
 - *metadata*: 
 - *name*: 
 - *target_url*: 
@@ -352,8 +352,8 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
-- *bounds*: 
 - *generator_kind*: 
 - *metadata*: 
 - *name*: 
@@ -430,8 +430,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
-- *bounds*: 
 - *frame_step*: Step between frame numbers in file names.
 - *frame_zero_padding*: Number of digits to pad zeros out to in frame numbers.
 - *metadata*: 
@@ -486,8 +486,8 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
-- *bounds*: 
 - *metadata*: 
 - *name*: 
 

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -51,20 +51,20 @@ TimeRange Clip::available_range(ErrorStatus* error_status) const {
 }
 
 optional<Imath::Box2d> 
-Clip::bounds(ErrorStatus* error_status) const {
+Clip::available_image_bounds(ErrorStatus* error_status) const {
     if (!_media_reference) {
         *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
-                                    "No bounds set on clip", this);
+                                    "No image bounds set on clip", this);
         return optional<Imath::Box2d>();
     }
 
-    if (!_media_reference.value->bounds()) {
+    if (!_media_reference.value->available_image_bounds()) {
         *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
-                                    "No bounds set on media reference on clip", this);
+                                    "No image bounds set on media reference on clip", this);
         return optional<Imath::Box2d>();
     }
 
-    return _media_reference.value->bounds();
+    return _media_reference.value->available_image_bounds();
 }
 
 } }

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -26,7 +26,7 @@ public:
     
     virtual TimeRange available_range(ErrorStatus* error_status) const;
 
-    virtual optional<Imath::Box2d> bounds(ErrorStatus* error_status) const;
+    virtual optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
 
 protected:
     virtual ~Clip();

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -51,7 +51,7 @@ RationalTime Composable::duration(ErrorStatus* error_status) const {
 }
 
 optional<Imath::Box2d> 
-Composable::bounds(ErrorStatus* error_status) const {
+Composable::available_image_bounds(ErrorStatus* error_status) const {
     *error_status = ErrorStatus::NOT_IMPLEMENTED;
     return optional<Imath::Box2d>();
 }

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -30,7 +30,7 @@ public:
     
     virtual RationalTime duration(ErrorStatus* error_status) const;
 
-    virtual optional<Imath::Box2d> bounds(ErrorStatus* error_status) const;
+    virtual optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
 
 protected:
     bool _set_parent(Composition*);

--- a/src/opentimelineio/errorStatus.cpp
+++ b/src/opentimelineio/errorStatus.cpp
@@ -53,7 +53,7 @@ std::string ErrorStatus::outcome_to_string(Outcome o) {
     case CANNOT_TRIM_TRANSITION:
         return "cannot trim transition";
     case CANNOT_COMPUTE_BOUNDS:
-        return "cannot compute bounds";
+        return "cannot compute image bounds";
     default:
         return "unknown/illegal ErrorStatus::Outcome code";
     };

--- a/src/opentimelineio/externalReference.cpp
+++ b/src/opentimelineio/externalReference.cpp
@@ -5,8 +5,8 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 ExternalReference::ExternalReference(std::string const& target_url,
                                      optional<TimeRange> const& available_range,
                                      AnyDictionary const& metadata, 
-                                     optional<Imath::Box2d> const& bounds)
-    : Parent(std::string(), available_range, metadata, bounds ),
+                                     optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(std::string(), available_range, metadata, available_image_bounds ),
       _target_url(target_url) {
 }
 

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -17,7 +17,7 @@ public:
     ExternalReference(std::string const& target_url = std::string(),
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary(),
-                      optional<Imath::Box2d> const& bounds = nullopt);
+                      optional<Imath::Box2d> const& available_image_bounds = nullopt);
         
     std::string const& target_url() const {
         return _target_url;

--- a/src/opentimelineio/generatorReference.cpp
+++ b/src/opentimelineio/generatorReference.cpp
@@ -7,8 +7,8 @@ GeneratorReference::GeneratorReference(std::string const& name,
                                        optional<TimeRange> const& available_range,
                                        AnyDictionary const& parameters,
                                        AnyDictionary const& metadata,
-                                       optional<Imath::Box2d> const& bounds)
-    : Parent(name, available_range, metadata, bounds),
+                                       optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(name, available_range, metadata, available_image_bounds),
       _generator_kind(generator_kind),
       _parameters(parameters) {
 }

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -19,7 +19,7 @@ public:
                        optional<TimeRange> const& available_range = nullopt,
                        AnyDictionary const& parameters = AnyDictionary(),
                        AnyDictionary const& metadata = AnyDictionary(),
-                       optional<Imath::Box2d> const& bounds = nullopt);
+                       optional<Imath::Box2d> const& available_image_bounds = nullopt);
         
     std::string const& generator_kind() const {
         return _generator_kind;

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -12,8 +12,8 @@ ImageSequenceReference::ImageSequenceReference(std::string const& target_url_bas
                       MissingFramePolicy const missing_frame_policy,
                       optional<TimeRange> const& available_range,
                       AnyDictionary const& metadata,
-                      optional<Imath::Box2d> const& bounds)
-    : Parent(std::string(), available_range, metadata, bounds),
+                      optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(std::string(), available_range, metadata, available_image_bounds),
     _target_url_base(target_url_base),
     _name_prefix(name_prefix),
     _name_suffix(name_suffix),

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -30,7 +30,7 @@ public:
                       MissingFramePolicy const missing_frame_policy = MissingFramePolicy::error,
                       optional<TimeRange> const& available_range = nullopt,
                       AnyDictionary const& metadata = AnyDictionary(), 
-                      optional<Imath::Box2d> const& bounds = nullopt);
+                      optional<Imath::Box2d> const& available_image_bounds = nullopt);
         
     std::string const& target_url_base() const {
         return _target_url_base;

--- a/src/opentimelineio/mediaReference.cpp
+++ b/src/opentimelineio/mediaReference.cpp
@@ -5,10 +5,10 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 MediaReference::MediaReference(std::string const& name,
                                optional<TimeRange> const& available_range,
                                AnyDictionary const& metadata,
-                               optional<Imath::Box2d> const& bounds)
+                               optional<Imath::Box2d> const& available_image_bounds)
     : Parent(name, metadata),
       _available_range(available_range),
-      _bounds(bounds) {
+      _available_image_bounds(available_image_bounds) {
 }
 
 MediaReference::~MediaReference() {
@@ -21,14 +21,14 @@ bool MediaReference::is_missing_reference() const {
 
 bool MediaReference::read_from(Reader& reader) {
     return reader.read_if_present("available_range", &_available_range) &&
-        reader.read_if_present("bounds", &_bounds) &&
+        reader.read_if_present("available_image_bounds", &_available_image_bounds) &&
         Parent::read_from(reader);
 }
 
 void MediaReference::write_to(Writer& writer) const {
     Parent::write_to(writer);
     writer.write("available_range", _available_range);
-    writer.write("bounds", _bounds);
+    writer.write("available_image_bounds", _available_image_bounds);
 }
 
 } }

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -21,7 +21,7 @@ public:
     MediaReference(std::string const& name = std::string(),
                    optional<TimeRange> const& available_range = nullopt,
                    AnyDictionary const& metadata = AnyDictionary(),
-                   optional<Imath::Box2d> const& bounds = nullopt);
+                   optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
     optional<TimeRange> const& available_range () const {
         return _available_range;
@@ -33,12 +33,12 @@ public:
 
     virtual bool is_missing_reference() const;
    
-    optional<Imath::Box2d> bounds() const {
-        return _bounds;
+    optional<Imath::Box2d> available_image_bounds() const {
+        return _available_image_bounds;
     }
 
-    void set_bounds(optional<Imath::Box2d> const& bounds) {
-        _bounds = bounds;
+    void set_available_image_bounds(optional<Imath::Box2d> const& available_image_bounds) {
+        _available_image_bounds = available_image_bounds;
     } 
 
 protected:
@@ -49,7 +49,7 @@ protected:
 
 private:
     optional<TimeRange> _available_range;
-    optional<Imath::Box2d> _bounds;
+    optional<Imath::Box2d> _available_image_bounds;
 };
 
 } }

--- a/src/opentimelineio/missingReference.cpp
+++ b/src/opentimelineio/missingReference.cpp
@@ -5,8 +5,8 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
 MissingReference::MissingReference(std::string const& name,
                                    optional<TimeRange> const& available_range,
                                    AnyDictionary const& metadata,
-                                   optional<Imath::Box2d> const& bounds)
-    : Parent(name, available_range, metadata, bounds) {
+                                   optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(name, available_range, metadata, available_image_bounds) {
 }
 
 MissingReference::~MissingReference() {

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -17,7 +17,7 @@ public:
     MissingReference(std::string const& name = std::string(),
                      optional<TimeRange> const& available_range = nullopt,
                      AnyDictionary const& metadata = AnyDictionary(),
-                     optional<Imath::Box2d> const& bounds = nullopt);
+                     optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
     virtual bool is_missing_reference() const;
 

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -94,13 +94,13 @@ std::vector<SerializableObject::Retainer<Clip>> Stack::clip_if(
 }
 
 optional<Imath::Box2d> 
-Stack::bounds(ErrorStatus* error_status) const {
+Stack::available_image_bounds(ErrorStatus* error_status) const {
     optional<Imath::Box2d> box;
     bool found_first_child = false;
     for (auto clip : children_if<Clip>(error_status))
     {
         optional<Imath::Box2d> child_box;
-        if (auto clip_box = clip->bounds(error_status)) {
+        if (auto clip_box = clip->available_image_bounds(error_status)) {
             child_box = clip_box;
         }
         if (*error_status) {

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -29,7 +29,7 @@ public:
 
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 
-    optional<Imath::Box2d> bounds(ErrorStatus* error_status) const;
+    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
 
     // Return a vector of clips.
     //

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -72,8 +72,8 @@ public:
         optional<TimeRange> search_range = nullopt,
         bool shallow_search = false) const;
     
-    optional<Imath::Box2d> bounds(ErrorStatus* error_status) const {
-        return _tracks.value->bounds(error_status);
+    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const {
+        return _tracks.value->available_image_bounds(error_status);
     }
 
 protected:

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -220,12 +220,12 @@ std::vector<SerializableObject::Retainer<Clip>> Track::clip_if(
 }
 
 optional<Imath::Box2d> 
-Track::bounds(ErrorStatus* error_status) const {
+Track::available_image_bounds(ErrorStatus* error_status) const {
     optional<Imath::Box2d> box;
     bool found_first_clip = false;
     for (auto child: children()) {
         if (auto clip = dynamic_cast<Clip*>(child.value)) {
-            if (auto clip_box = clip->bounds(error_status)) {
+            if (auto clip_box = clip->available_image_bounds(error_status)) {
                 if (clip_box) {
                     if (found_first_clip) {
                         box->extendBy(*clip_box);

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -51,7 +51,7 @@ public:
 
     virtual std::map<Composable*, TimeRange> range_of_all_children(ErrorStatus* error_status) const;
 
-    optional<Imath::Box2d> bounds(ErrorStatus* error_status) const;
+    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
 
     // Return a vector of clips.
     //

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
@@ -106,12 +106,6 @@ static void define_imath_2d(py::module m) {
         .def("__ne__", [](Imath::Box2d lhs, py::object const& rhs) {
             return lhs != _type_checked<Imath::Box2d>(rhs, "!=");
         })
-        .def("makeEmpty", &Imath::Box2d::makeEmpty)
-        .def("makeInfinite", &Imath::Box2d::makeInfinite)
-        .def("isEmpty", &Imath::Box2d::isEmpty)
-        .def("isInfinite", &Imath::Box2d::isInfinite)
-        .def("hasVolume", &Imath::Box2d::hasVolume)
-        .def("size", &Imath::Box2d::size)
         .def("center", &Imath::Box2d::center)
         .def("extendBy", [](Imath::Box2d* box, Imath::V2d const& point ) {
             return box->extendBy(point); 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -342,8 +342,8 @@ static void define_items_and_compositions(py::module m) {
         .def("transformed_time_range", [](Item* item, TimeRange time_range, Item* to_item) {
             return item->transformed_time_range(time_range, to_item, ErrorStatusHandler());
             }, "time_range"_a, "to_item"_a)
-        .def_property_readonly("bounds", [](Item* item) {
-            return item->bounds(ErrorStatusHandler());
+        .def_property_readonly("available_image_bounds", [](Item* item) {
+            return item->available_image_bounds(ErrorStatusHandler());
             });
 
     auto transition_class =
@@ -651,14 +651,14 @@ static void define_media_references(py::module m) {
         .def(py::init([](std::string name,
                          optional<TimeRange> available_range,
                          py::object metadata,
-                         optional<Imath::Box2d> const& bounds) {
-                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata), bounds); }),
+                         optional<Imath::Box2d> const& available_image_bounds) {
+                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata), available_image_bounds); }),
              name_arg,
              "available_range"_a = nullopt,
              metadata_arg,
-             "bounds"_a = nullopt)
+             "available_image_bounds"_a = nullopt)
         .def_property("available_range", &MediaReference::available_range, &MediaReference::set_available_range)
-        .def_property("bounds", &MediaReference::bounds, &MediaReference::set_bounds) 
+        .def_property("available_image_bounds", &MediaReference::available_image_bounds, &MediaReference::set_available_image_bounds) 
         .def_property_readonly("is_missing_reference", &MediaReference::is_missing_reference);
 
     py::class_<GeneratorReference, MediaReference,
@@ -666,18 +666,18 @@ static void define_media_references(py::module m) {
         .def(py::init([](std::string name, std::string generator_kind,
                          optional<TimeRange> const& available_range,
                          py::object parameters, py::object metadata,
-                         optional<Imath::Box2d> const& bounds) {
+                         optional<Imath::Box2d> const& available_image_bounds) {
                           return new GeneratorReference(name, generator_kind,
                                                         available_range,
                                                         py_to_any_dictionary(parameters),
                                                         py_to_any_dictionary(metadata),
-                                                        bounds); }),
+                                                        available_image_bounds); }),
              name_arg,
              "generator_kind"_a = std::string(),
              "available_range"_a = nullopt,
              "parameters"_a = py::none(),
              metadata_arg,
-             "bounds"_a = nullopt)
+             "available_image_bounds"_a = nullopt)
         .def_property("generator_kind", &GeneratorReference::generator_kind, &GeneratorReference::set_generator_kind)
         .def_property_readonly("parameters", [](GeneratorReference* g) {
                 auto ptr = g->parameters().get_or_create_mutation_stamp();
@@ -690,17 +690,17 @@ static void define_media_references(py::module m) {
                         py::object name,
                         optional<TimeRange> available_range,
                         py::object metadata,
-                        optional<Imath::Box2d> const& bounds) {
+                        optional<Imath::Box2d> const& available_image_bounds) {
                     return new MissingReference(
                                   string_or_none_converter(name),
                                   available_range,
                                   py_to_any_dictionary(metadata),
-                                  bounds); 
+                                  available_image_bounds); 
                     }),
              name_arg,
              "available_range"_a = nullopt,
              metadata_arg,
-             "bounds"_a = nullopt);
+             "available_image_bounds"_a = nullopt);
 
 
     py::class_<ExternalReference, MediaReference,
@@ -708,15 +708,15 @@ static void define_media_references(py::module m) {
         .def(py::init([](std::string target_url,
                          optional<TimeRange> const& available_range,
                          py::object metadata,
-                         optional<Imath::Box2d> const& bounds) {
+                         optional<Imath::Box2d> const& available_image_bounds) {
                           return new ExternalReference(target_url,
                                                         available_range,
                                                         py_to_any_dictionary(metadata),
-                                                        bounds); }),
+                                                        available_image_bounds); }),
              "target_url"_a = std::string(),
              "available_range"_a = nullopt,
              metadata_arg,
-             "bounds"_a = nullopt)
+             "available_image_bounds"_a = nullopt)
         .def_property("target_url", &ExternalReference::target_url, &ExternalReference::set_target_url);
 
     auto imagesequencereference_class = py:: class_<ImageSequenceReference, MediaReference,
@@ -798,7 +798,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                          ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
                          py::object metadata,
-                         optional<Imath::Box2d> const& bounds) {
+                         optional<Imath::Box2d> const& available_image_bounds) {
                           return new ImageSequenceReference(target_url_base,
                                                             name_prefix,
                                                             name_suffix,
@@ -809,7 +809,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                                                             missing_frame_policy,
                                                             available_range,
                                                             py_to_any_dictionary(metadata),
-                                                            bounds); }),
+                                                            available_image_bounds); }),
                         "target_url_base"_a = std::string(),
                         "name_prefix"_a = std::string(),
                         "name_suffix"_a = std::string(),
@@ -820,7 +820,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                         "missing_frame_policy"_a = ImageSequenceReference::MissingFramePolicy::error,
                         "available_range"_a = nullopt,
                         metadata_arg,
-                        "bounds"_a = nullopt)
+                        "available_image_bounds"_a = nullopt)
         .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base, "Everything leading up to the file name in the ``target_url``.")
         .def_property("name_prefix", &ImageSequenceReference::name_prefix, &ImageSequenceReference::set_name_prefix, "Everything in the file name leading up to the frame number.")
         .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix, "Everything after the frame number in the file name.")

--- a/src/py-opentimelineio/opentimelineio/core/mediaReference.py
+++ b/src/py-opentimelineio/opentimelineio/core/mediaReference.py
@@ -8,7 +8,7 @@ def __str__(self):
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
-        repr(self.bounds),
+        repr(self.available_image_bounds),
         repr(self.metadata)
     )
 
@@ -19,7 +19,7 @@ def __repr__(self):
         "otio.{}.{}("
         "name={},"
         " available_range={},"
-        " bounds={},"
+        " available_image_bounds={},"
         " metadata={}"
         ")"
     ).format(
@@ -27,6 +27,6 @@ def __repr__(self):
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
-        repr(self.bounds),
+        repr(self.available_image_bounds),
         repr(self.metadata)
     )

--- a/src/py-opentimelineio/opentimelineio/schema/generator_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/generator_reference.py
@@ -8,7 +8,7 @@ def __str__(self):
         self.name,
         self.generator_kind,
         self.parameters,
-        self.bounds,
+        self.available_image_bounds,
         self.metadata
     )
 
@@ -20,13 +20,13 @@ def __repr__(self):
         'name={}, '
         'generator_kind={}, '
         'parameters={}, '
-        'bounds={}, '
+        'available_image_bounds={}, '
         'metadata={}'
         ')'.format(
             repr(self.name),
             repr(self.generator_kind),
             repr(self.parameters),
-            repr(self.bounds),
+            repr(self.available_image_bounds),
             repr(self.metadata),
         )
     )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -16,7 +16,7 @@ def __str__(self):
             self.frame_zero_padding,
             self.missing_frame_policy,
             self.available_range,
-            self.bounds,
+            self.available_image_bounds,
             self.metadata,
         )
     )
@@ -35,7 +35,7 @@ def __repr__(self):
         'frame_zero_padding={}, '
         'missing_frame_policy={}, '
         'available_range={}, '
-        'bounds={}, '
+        'available_image_bounds={}, '
         'metadata={}'
         ')' .format(
             repr(self.target_url_base),
@@ -47,7 +47,7 @@ def __repr__(self):
             repr(self.frame_zero_padding),
             repr(self.missing_frame_policy),
             repr(self.available_range),
-            repr(self.bounds),
+            repr(self.available_image_bounds),
             repr(self.metadata),
         )
     )

--- a/tests/baselines/empty_external_reference.json
+++ b/tests/baselines/empty_external_reference.json
@@ -1,7 +1,7 @@
 {
     "OTIO_SCHEMA" : "ExternalReference.1",
     "available_range" : null,
-    "bounds" : null,
+    "available_image_bounds" : null,
     "metadata" : {},
     "name" : "",
     "target_url" : "foo.bar"

--- a/tests/baselines/empty_generator_reference.json
+++ b/tests/baselines/empty_generator_reference.json
@@ -1,7 +1,7 @@
 {
     "OTIO_SCHEMA" : "GeneratorReference.1",
     "available_range" : null,
-    "bounds" : null,
+    "available_image_bounds" : null,
     "generator_kind" : "",
     "metadata" : {},
     "parameters" : {},

--- a/tests/baselines/empty_missingreference.json
+++ b/tests/baselines/empty_missingreference.json
@@ -1,7 +1,7 @@
 {
     "OTIO_SCHEMA" : "MissingReference.1",
     "available_range" : null,
-    "bounds" : null,
+    "available_image_bounds" : null,
     "metadata" : {},
     "name" : ""
 }

--- a/tests/sample_data/clip_example.otio
+++ b/tests/sample_data/clip_example.otio
@@ -48,7 +48,7 @@
                 }
               },
               "metadata": {},
-              "bounds": {
+              "available_image_bounds": {
                 "OTIO_SCHEMA": "Box2d.1",
                 "min": {
                   "OTIO_SCHEMA":"V2d.1",

--- a/tests/test_box2d.py
+++ b/tests/test_box2d.py
@@ -54,29 +54,14 @@ class Box2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             ')'
         )
 
-    def test_limits(self):
+    def test_center(self):
         v1 = otio.schema.V2d(1.0, 2.0)
         v2 = otio.schema.V2d(3.0, 4.0)
-        box = otio.schema.Box2d(v1, v2)
+        box1 = otio.schema.Box2d(v1, v2)
 
-        v_lowest = otio.schema.V2d(v1.baseTypeLowest(), v1.baseTypeLowest())
-        v_max = otio.schema.V2d(v1.baseTypeMax(), v1.baseTypeMax())
-
-        empty = otio.schema.Box2d(v_max, v_lowest)
-        inf = otio.schema.Box2d(v_lowest, v_max)
-
-        box.makeEmpty()
-        self.assertEqual(box, empty)
-        self.assertTrue(box.isEmpty())
-        self.assertFalse(box.hasVolume())
-        self.assertEqual(box.center(), otio.schema.V2d(0.0, 0.0))
-        self.assertEqual(box.size(), otio.schema.V2d(0.0, 0.0))
-
-        box.makeInfinite()
-        self.assertEqual(box, inf)
-        self.assertTrue(box.isInfinite())
-        self.assertTrue(box.hasVolume())
-        self.assertEqual(box.center(), otio.schema.V2d(0.0, 0.0))
+        self.assertEqual(box1.center(),
+                         otio.schema.V2d(2.0, 3.0)
+                         )
 
     def test_extend(self):
         v1 = otio.schema.V2d(1.0, 2.0)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -135,29 +135,29 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(cl.trimmed_range(), cl.source_range)
         self.assertIsNot(cl.trimmed_range(), cl.source_range)
 
-    def test_bounds(self):
-        bounds = otio.schema.Box2d(
+    def test_available_image_bounds(self):
+        available_image_bounds = otio.schema.Box2d(
             otio.schema.V2d(0.0, 0.0),
             otio.schema.V2d(16.0, 9.0)
         )
 
         media_reference = otio.schema.ExternalReference(
             "/var/tmp/foo.mov",
-            bounds=bounds
+            available_image_bounds=available_image_bounds
         )
 
         cl = otio.schema.Clip(
-            name="test_bounds",
+            name="test_available_image_bounds",
             media_reference=media_reference
         )
 
-        self.assertEqual(bounds, cl.bounds)
-        self.assertEqual(cl.bounds, media_reference.bounds)
+        self.assertEqual(available_image_bounds, cl.available_image_bounds)
+        self.assertEqual(cl.available_image_bounds, media_reference.available_image_bounds)
 
-        self.assertEqual(0.0, cl.bounds.min.x)
-        self.assertEqual(0.0, cl.bounds.min.y)
-        self.assertEqual(16.0, cl.bounds.max.x)
-        self.assertEqual(9.0, cl.bounds.max.y)
+        self.assertEqual(0.0, cl.available_image_bounds.min.x)
+        self.assertEqual(0.0, cl.available_image_bounds.min.y)
+        self.assertEqual(16.0, cl.available_image_bounds.max.x)
+        self.assertEqual(9.0, cl.available_image_bounds.max.y)
 
     def test_ref_default(self):
         cl = otio.schema.Clip()

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -696,17 +696,17 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.opentime.RationalTime(50, 24)
         )
 
-    def test_bounds_single_clip(self):
+    def test_available_image_bounds_single_clip(self):
         st = otio.schema.Stack(name="foo", children=[
             otio.schema.Gap(name="GAP1")
         ])
 
-        # There's noting valid, we should have no bounds
-        self.assertEqual(st.bounds, None)
+        # There's noting valid, we should have no available_image_bounds
+        self.assertEqual(st.available_image_bounds, None)
 
         clip = otio.schema.Clip(
             media_reference=otio.schema.ExternalReference(
-                bounds=otio.schema.Box2d(
+                available_image_bounds=otio.schema.Box2d(
                     otio.schema.V2d(1, 1),
                     otio.schema.V2d(2, 2)
                 ),
@@ -715,16 +715,16 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             name="clip1"
         )
 
-        # The Stack bounds should be equal to the single clip that's in it
+        # The Stack available_image_bounds should be equal to the single clip that's in it
         st.append(clip)
-        self.assertEqual(st.bounds, clip.bounds)
+        self.assertEqual(st.available_image_bounds, clip.available_image_bounds)
 
-    def test_bounds_multi_clip(self):
+    def test_available_image_bounds_multi_clip(self):
         st = otio.schema.Stack(name="foo", children=[
             otio.schema.Gap(name="GAP1"),
             otio.schema.Clip(
                 media_reference=otio.schema.ExternalReference(
-                    bounds=otio.schema.Box2d(
+                    available_image_bounds=otio.schema.Box2d(
                         otio.schema.V2d(1, 1),
                         otio.schema.V2d(2, 2)
                     ),
@@ -735,7 +735,7 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.schema.Gap(name="GAP2"),
             otio.schema.Clip(
                 media_reference=otio.schema.ExternalReference(
-                    bounds=otio.schema.Box2d(
+                    available_image_bounds=otio.schema.Box2d(
                         otio.schema.V2d(2, 2),
                         otio.schema.V2d(3, 3)
                     ),
@@ -746,7 +746,7 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.schema.Gap(name="GAP3"),
             otio.schema.Clip(
                 media_reference=otio.schema.ExternalReference(
-                    bounds=otio.schema.Box2d(
+                    available_image_bounds=otio.schema.Box2d(
                         otio.schema.V2d(3, 3),
                         otio.schema.V2d(4, 4)
                     ),
@@ -757,27 +757,27 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.schema.Gap(name="GAP4")
         ])
 
-        # The Stack bounds should cover the overlapping boxes,
+        # The Stack available_image_bounds should cover the overlapping boxes,
         # the gaps should be ignored
-        self.assertEqual(st.bounds,
+        self.assertEqual(st.available_image_bounds,
                          otio.schema.Box2d(
                              otio.schema.V2d(1, 1),
                              otio.schema.V2d(4, 4)
                          )
                          )
 
-    def test_bounds_multi_layer(self):
+    def test_available_image_bounds_multi_layer(self):
         tr1 = otio.schema.Track(name="tr1", children=[
             otio.schema.Gap(name="GAP1")
         ])
         st = otio.schema.Stack(name="foo", children=[tr1])
 
-        self.assertEqual(st.bounds, tr1.bounds)
-        self.assertEqual(st.bounds, None)
+        self.assertEqual(st.available_image_bounds, tr1.available_image_bounds)
+        self.assertEqual(st.available_image_bounds, None)
 
         cl1 = otio.schema.Clip(
             media_reference=otio.schema.ExternalReference(
-                bounds=otio.schema.Box2d(
+                available_image_bounds=otio.schema.Box2d(
                     otio.schema.V2d(0, 0),
                     otio.schema.V2d(2, 2)
                 ),
@@ -787,20 +787,20 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         )
         tr1.append(cl1)
 
-        self.assertEqual(st.bounds, cl1.bounds)
-        self.assertEqual(st.bounds, tr1.bounds)
+        self.assertEqual(st.available_image_bounds, cl1.available_image_bounds)
+        self.assertEqual(st.available_image_bounds, tr1.available_image_bounds)
 
         tr2 = otio.schema.Track(name="tr2", children=[
             otio.schema.Gap(name="GAP2")
         ])
         st.append(tr2)
 
-        self.assertEqual(st.bounds, cl1.bounds)
-        self.assertEqual(st.bounds, tr1.bounds)
+        self.assertEqual(st.available_image_bounds, cl1.available_image_bounds)
+        self.assertEqual(st.available_image_bounds, tr1.available_image_bounds)
 
         cl2 = otio.schema.Clip(
             media_reference=otio.schema.ExternalReference(
-                bounds=otio.schema.Box2d(
+                available_image_bounds=otio.schema.Box2d(
                     otio.schema.V2d(1, 1),
                     otio.schema.V2d(3, 3)
                 ),
@@ -810,12 +810,12 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
         )
         tr2.append(cl2)
 
-        # Each track should have bounds equal to its single clip,
-        # but the stack bounds should use both tracks
-        self.assertEqual(tr1.bounds, cl1.bounds)
-        self.assertEqual(tr2.bounds, cl2.bounds)
+        # Each track should have available_image_bounds equal to its single clip,
+        # but the stack available_image_bounds should use both tracks
+        self.assertEqual(tr1.available_image_bounds, cl1.available_image_bounds)
+        self.assertEqual(tr2.available_image_bounds, cl2.available_image_bounds)
 
-        union = st.bounds
+        union = st.available_image_bounds
         self.assertEqual(union,
                          otio.schema.Box2d(
                              otio.schema.V2d(0, 0),
@@ -823,9 +823,9 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
                          )
                          )
 
-        # Appending a track with no bounds should do nothing
+        # Appending a track with no available_image_bounds should do nothing
         st.append(otio.schema.Track())
-        union2 = st.bounds
+        union2 = st.available_image_bounds
         self.assertEqual(union, union2)
 
 

--- a/tests/test_generator_reference.py
+++ b/tests/test_generator_reference.py
@@ -25,7 +25,7 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             metadata={
                 "foo": "bar"
             },
-            bounds=otio.schema.Box2d(
+            available_image_bounds=otio.schema.Box2d(
                 otio.schema.V2d(0.0, 0.0),
                 otio.schema.V2d(16.0, 9.0)
             )
@@ -44,7 +44,7 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             )
         )
         self.assertEqual(
-            self.gen.bounds,
+            self.gen.available_image_bounds,
             otio.schema.Box2d(
                 otio.schema.V2d(0.0, 0.0),
                 otio.schema.V2d(16.0, 9.0)
@@ -76,7 +76,7 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
                 str(self.gen.name),
                 str(self.gen.generator_kind),
                 str(self.gen.parameters),
-                str(self.gen.bounds),
+                str(self.gen.available_image_bounds),
                 str(self.gen.metadata),
             )
         )
@@ -87,13 +87,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "name={}, "
             "generator_kind={}, "
             "parameters={}, "
-            "bounds={}, "
+            "available_image_bounds={}, "
             "metadata={}"
             ")".format(
                 repr(self.gen.name),
                 repr(self.gen.generator_kind),
                 repr(self.gen.parameters),
-                repr(self.gen.bounds),
+                repr(self.gen.available_image_bounds),
                 repr(self.gen.metadata),
             )
         )

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -64,7 +64,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             metadata={"custom": {"foo": "bar"}},
-            bounds=otio.schema.Box2d(
+            available_image_bounds=otio.schema.Box2d(
                 otio.schema.V2d(0.0, 0.0),
                 otio.schema.V2d(16.0, 9.0)
             ),
@@ -100,7 +100,7 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
             ),
-            bounds=otio.schema.Box2d(
+            available_image_bounds=otio.schema.Box2d(
                 otio.schema.V2d(0.0, 0.0),
                 otio.schema.V2d(16.0, 9.0)
             ),
@@ -117,7 +117,7 @@ class ImageSequenceReferenceTests(
             'frame_zero_padding=5, '
             'missing_frame_policy=<MissingFramePolicy.error: 0>, '
             'available_range={}, '
-            'bounds=otio.schema.Box2d('
+            'available_image_bounds=otio.schema.Box2d('
             'min=otio.schema.V2d(x=0.0, y=0.0), '
             'max=otio.schema.V2d(x=16.0, y=9.0)), '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
@@ -539,7 +539,7 @@ class ImageSequenceReferenceTests(
 
         self.assertEqual(ref.frame_range_for_time_range(time_range), (13, 29))
 
-    def test_frame_range_for_time_range_out_of_bounds(self):
+    def test_frame_range_for_time_range_out_of_available_image_bounds(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
             "show_shot.",

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -56,7 +56,7 @@ class MediaReferenceTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertMultiLineEqual(
             repr(missing),
             "otio.schema.MissingReference("
-            "name='', available_range=None, bounds=None, metadata={}"
+            "name='', available_range=None, available_image_bounds=None, metadata={}"
             ")"
         )
 

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -324,7 +324,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             tl.tracks[0].range_of_child_at_index(0)
         )
 
-    def test_bounds(self):
+    def test_available_image_bounds(self):
         track = otio.schema.Track(name="test_track")
         tl = otio.schema.Timeline("test_timeline", tracks=[track])
 
@@ -332,7 +332,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         cl = otio.schema.Clip(
             name="test clip1",
             media_reference=otio.schema.ExternalReference(
-                bounds=otio.schema.Box2d(
+                available_image_bounds=otio.schema.Box2d(
                     otio.schema.V2d(0.0, 0.0),
                     otio.schema.V2d(1.0, 1.0)
                 ),
@@ -342,7 +342,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         cl2 = otio.schema.Clip(
             name="test clip2",
             media_reference=otio.schema.ExternalReference(
-                bounds=otio.schema.Box2d(
+                available_image_bounds=otio.schema.Box2d(
                     otio.schema.V2d(1.0, 1.0),
                     otio.schema.V2d(2.0, 2.0)
                 ),
@@ -352,7 +352,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         cl3 = otio.schema.Clip(
             name="test clip3",
             media_reference=otio.schema.ExternalReference(
-                bounds=otio.schema.Box2d(
+                available_image_bounds=otio.schema.Box2d(
                     otio.schema.V2d(2.0, 2.0),
                     otio.schema.V2d(3.0, 3.0)
                 ),
@@ -370,7 +370,7 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         )
 
         # union should be overlapping area, gap should be ignored
-        self.assertEqual(tl.tracks[0].bounds, union)
+        self.assertEqual(tl.tracks[0].available_image_bounds, union)
 
     def test_iterators(self):
         self.maxDiff = None


### PR DESCRIPTION
Fixes #771
MediaReference: spatial bounding box

**Summary**

This is a followup on the previous spatial bounds merge [here](https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/1022)

After our meeting, we decided to make a few changes which this branch introduces:
- Rename `bounds` to `available_image_bounds`.  The `image` is added to indicate the bounds are being applied to the visual/video/image data and `available` is added to indicate that this is the total available size (similar in concept to available range).  This allows us to later add constraints on the bounds (like `source_range`). 

-  Remove some problematic imath bindings.  Calculations in imath related to borders/edges are inclusive, which is not what we want, so we'll remove these until we can add exclusive methods in imath.

**Tests**

Since this is only renaming/removal the existing imath and bounds testings will cover this completely. 
