### PR TITLE
Publish wheels and sdist in PyPI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,6 +12,7 @@ env:
 on:
   push:
     branches: [ master ]
+    tags: [ '*' ]
   pull_request:
     branches: [ master ]
 
@@ -21,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [2.7, 3.7, 3.8, 3.9]
+        python-version: ['2.7', '3.7', '3.8', '3.9']
 
     env:
       OTIO_CXX_COVERAGE_BUILD: ON
@@ -102,3 +103,33 @@ jobs:
         with:
           name: wheels
           path: ./wheelhouse/*.whl
+
+  pypi_publish:
+    needs: package_wheels
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Python
+        uses: actions/setup-python@v2.2.2
+
+      - name: Install pypa/build
+        run: python -m pip install build --user
+
+      - name: Generate sdist
+        run: python -m build --sdist --outdir dist .
+
+      - name: Download wheels
+        uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Publish wheels and sdist (source code only) in PyPI.

Fixes #988 .

The method I used is simple. I added a job in the `python-package` workflow that will only run when the GitHub Action is triggered by tag pushed in the repo.

That's the simplest option. But it has one major downside. The artifacts will be regenerated for the release. This is a problem because there could be some amount of time between the last PR is merged and the tag creation and during this time some things might have changed (transitive dependencies, GitHub Actions environment, etc). On Linux it isn't much a problem as wheels are generated in docker images, but on macOS and Windows it's another story.

A safer approach would be to have the publish job be in its own workflow. This workflow would fetch the wheels from the last successful build (or a specific build if we make the workflow that can be manually triggered with custom inputs). This is the approach the the [Java bindings](https://github.com/OpenTimelineIO/OpenTimelineIO-Java-Bindings) is using, with the difference that the publish workflow is triggered by a release creation, not a tag pushed.

I will be happy to go with later (safer) approach if TSC prefers that.

# Notes

* For this to work, you will need to add a secret named `PYPI_API_TOKEN` to the repository. The value needs to be a PyPI token created from the user interface (see https://pypi.org/help/#apitoken for instructions). You will need to specify a name when creating the token. I suggest choosing a name that clearly states that it's going to be used by GitHub actions .
* I left out GPG signing for now, but I'll be more than happy to add that if requested.