### PR TITLE
Remove duplicate error code NON_DROPFRAME_RATE.

### DIFF
--- a/docs/cxx/cxx.rst
+++ b/docs/cxx/cxx.rst
@@ -578,7 +578,6 @@ raise, and what their semantic meaning is.
     
     OK, n/a, No Error
     INVALID_TIMECODE_RATE, ``ValueError``, "Timecode rate isn't a valid SMPTE rate"
-    NON_DROPFRAME_RATE,  ``ValueError``, "Timecode rate isn't valid for SMPTE Drop-Frame Timecode"
     INVALID_TIMECODE_STRING,  ``ValueError``, "String is not properly formatted SMPTE timecode string"
     TIMECODE_RATE_MISMATCH,  ``ValueError``, " Timecode string has a frame number higher than the frame rate"
     INVALID_TIME_STRING,  ``ValueError``,

--- a/src/opentime/errorStatus.cpp
+++ b/src/opentime/errorStatus.cpp
@@ -8,8 +8,6 @@ std::string ErrorStatus::outcome_to_string(Outcome o) {
         return std::string();
     case INVALID_TIMECODE_RATE:
         return "invalid timecode rate";
-    case NON_DROPFRAME_RATE:
-        return "rate is not a dropframe rate";
     case INVALID_TIMECODE_STRING:
         return "string is not a valid timecode string";
     case TIMECODE_RATE_MISMATCH:

--- a/src/opentime/errorStatus.h
+++ b/src/opentime/errorStatus.h
@@ -9,7 +9,6 @@ struct ErrorStatus {
     enum Outcome {
         OK = 0,
         INVALID_TIMECODE_RATE,
-        NON_DROPFRAME_RATE,
         INVALID_TIMECODE_STRING,
         INVALID_TIME_STRING,
         TIMECODE_RATE_MISMATCH,

--- a/src/opentime/rationalTime.cpp
+++ b/src/opentime/rationalTime.cpp
@@ -84,10 +84,10 @@ RationalTime::from_timecode(std::string const& timecode, double rate, ErrorStatu
     if (timecode.find(';') != std::string::npos) {
         if (!rate_is_dropframe) {
             if (error_status) {
-                *error_status = ErrorStatus(ErrorStatus::NON_DROPFRAME_RATE,
+                *error_status = ErrorStatus(ErrorStatus::INVALID_RATE_FOR_DROP_FRAME_TIMECODE,
                                             string_printf("Timecode '%s' indicates drop frame rate due "
                                                           "to the ';' frame divider. "
-                                                          "Passed in rate %g is of non-drop-frame-rate.",
+                                                          "Passed in rate %g is not a valid drop frame rate.",
                                                           timecode.c_str(), rate));
             }
             return RationalTime::_invalid_time;

--- a/tests/test_opentime.py
+++ b/tests/test_opentime.py
@@ -380,7 +380,8 @@ class TestTime(unittest.TestCase):
 
         This is what we're testing here. When using 24 fps for the
         drop-frame timecode 01:00:13;23 we should get a ValueError
-        mapping internally to the ErrorStatus 'NON_DROPFRAME_RATE'.
+        mapping internally to the ErrorStatus
+        'INVALID_RATE_FOR_DROP_FRAME_TIMECODE'.
         """
         with self.assertRaises(ValueError):
             otio.opentime.from_timecode('01:00:13;23', 24)


### PR DESCRIPTION
Closes #625 

RationalTime had a duplicate error code in it that was only used in one
place.