### PR TITLE
Bake OS versions in CI before release

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
     - uses: actions/checkout@v2.3.4
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         python-version: ['2.7', '3.7', '3.8', '3.9']
 
     env:
@@ -89,7 +89,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
         python-build: [cp27*, cp37*, cp38*, cp39*]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There is an annoying warning in the builds saying that the macOS version will soon change to macOS-11. For example, see the annotations section in https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/runs/1373884396.

So I thought we could just bake the OS versions before we do a release, just in case GitHub updates the latest tags right before we do the release of 0.14.0.