### PR TITLE
publish to release Pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,5 +38,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Switch the publish target repo to use the main pypi instead of the test one.

Co-authored-by: Jean-Christophe Morin <jean_christophe_morin@hotmail.com>