### PR TITLE
CI: switch platform versions back to -latest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -124,7 +124,7 @@ jobs:
 
   package_sdist:
     needs: py_build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
Before a release, we freeze the CI platforms.  This unfreezes them back to using the -latest images.