### PR TITLE
Support available_image_bounds in the "Example OTIO Reader" RV plugin

### DIFF
--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -33,6 +33,19 @@ from rv import commands
 from rv import extra_commands
 
 import opentimelineio as otio
+from contextlib import contextmanager
+
+
+@contextmanager
+def set_context(context, **kwargs):
+    old_context = context.copy()
+    context.update(**kwargs)
+
+    try:
+        yield
+    finally:
+        context.clear()
+        context.update(old_context)
 
 
 class NoMappingForOtioTypeError(otio.exceptions.OTIOError):
@@ -52,7 +65,7 @@ def read_otio_file(otio_file):
     return create_rv_node_from_otio(input_otio)
 
 
-def create_rv_node_from_otio(otio_obj, track_kind=None):
+def create_rv_node_from_otio(otio_obj, context=None):
     WRITE_TYPE_MAP = {
         otio.schema.Timeline: _create_timeline,
         otio.schema.Stack: _create_stack,
@@ -64,14 +77,14 @@ def create_rv_node_from_otio(otio_obj, track_kind=None):
     }
 
     if type(otio_obj) in WRITE_TYPE_MAP:
-        return WRITE_TYPE_MAP[type(otio_obj)](otio_obj, track_kind)
+        return WRITE_TYPE_MAP[type(otio_obj)](otio_obj, context)
 
     raise NoMappingForOtioTypeError(
         str(type(otio_obj)) + " on object: {}".format(otio_obj)
     )
 
 
-def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
+def _create_dissolve(pre_item, in_dissolve, post_item, context=None):
     rv_trx = commands.newNode("CrossDissolve", in_dissolve.name or "dissolve")
     extra_commands.setUIName(rv_trx, str(in_dissolve.name or "dissolve"))
 
@@ -89,9 +102,9 @@ def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
                               [float(pre_item.trimmed_range().duration.rate)],
                               True)
 
-    pre_item_rv = create_rv_node_from_otio(pre_item, track_kind)
+    pre_item_rv = create_rv_node_from_otio(pre_item, context)
 
-    post_item_rv = create_rv_node_from_otio(post_item, track_kind)
+    post_item_rv = create_rv_node_from_otio(post_item, context)
 
     node_to_insert = post_item_rv
 
@@ -113,7 +126,7 @@ def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
             pre_item.media_reference.available_range.start_time.rate
         )
 
-        post_item_rv = create_rv_node_from_otio(post_item, track_kind)
+        post_item_rv = create_rv_node_from_otio(post_item, context)
 
         rt_node.addInput(post_item_rv)
         node_to_insert = rt_node
@@ -123,7 +136,7 @@ def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
     return rv_trx
 
 
-def _create_transition(pre_item, in_trx, post_item, track_kind=None):
+def _create_transition(pre_item, in_trx, post_item, context=None):
     trx_map = {
         otio.schema.TransitionTypes.SMPTE_Dissolve: _create_dissolve,
     }
@@ -135,17 +148,17 @@ def _create_transition(pre_item, in_trx, post_item, track_kind=None):
         pre_item,
         in_trx,
         post_item,
-        track_kind
+        context
     )
 
 
-def _create_stack(in_stack, track_kind=None):
+def _create_stack(in_stack, context=None):
     new_stack = commands.newNode("RVStackGroup", in_stack.name or "tracks")
     extra_commands.setUIName(new_stack, str(in_stack.name or "tracks"))
 
     new_inputs = []
     for seq in in_stack:
-        result = create_rv_node_from_otio(seq, track_kind)
+        result = create_rv_node_from_otio(seq, context)
         if result:
             new_inputs.append(result)
 
@@ -154,7 +167,9 @@ def _create_stack(in_stack, track_kind=None):
     return new_stack
 
 
-def _create_track(in_seq, _=None):
+def _create_track(in_seq, context=None):
+    context = context or {}
+
     new_seq = commands.newNode("RVSequenceGroup", str(in_seq.name or "track"))
     extra_commands.setUIName(new_seq, str(in_seq.name or "track"))
 
@@ -162,33 +177,69 @@ def _create_track(in_seq, _=None):
         in_seq
     )
 
-    track_kind = in_seq.kind
+    with set_context(context, track_kind=in_seq.kind):
+        new_inputs = []
+        for thing in items_to_serialize:
+            if isinstance(thing, tuple):
+                result = _create_transition(*thing, context=context)
+            elif thing.duration().value == 0:
+                continue
+            else:
+                result = create_rv_node_from_otio(thing, context)
 
-    new_inputs = []
-    for thing in items_to_serialize:
-        if isinstance(thing, tuple):
-            result = _create_transition(*thing, track_kind=track_kind)
-        elif thing.duration().value == 0:
-            continue
-        else:
-            result = create_rv_node_from_otio(thing, track_kind)
+            if result:
+                new_inputs.append(result)
 
-        if result:
-            new_inputs.append(result)
+        commands.setNodeInputs(new_seq, new_inputs)
+        _add_metadata_to_node(in_seq, new_seq)
 
-    commands.setNodeInputs(new_seq, new_inputs)
-    _add_metadata_to_node(in_seq, new_seq)
     return new_seq
 
 
-def _create_timeline(tl, _=None):
-    return create_rv_node_from_otio(tl.tracks)
+def _get_global_transform(tl):
+    # since there's no global scale in otio, use the first source with
+    # bounds as the global bounds
+    def find_display_bounds(tl):
+        for clip in tl.clip_if():
+            if hasattr(clip, "media_reference") and clip.media_reference:
+                if hasattr(clip.media_reference, "available_image_bounds"):
+                    bounds = clip.media_reference.available_image_bounds
+                    if bounds:
+                        return bounds
+        return None
+
+    bounds = find_display_bounds(tl)
+    if not bounds:
+        return {}
+
+    translate = bounds.center()
+    scale = bounds.max - bounds.min
+
+    # RV's global coordinate system has a width and height of 1 where the
+    # width will be scaled to the image aspect ratio.  So scale globally by
+    # height. The source width will later be scaled to aspect ratio.
+    global_scale = otio.schema.V2d(1.0 / scale.y, 1.0 / scale.y)
+
+    return {
+        'global_scale': global_scale,
+        'global_translate': translate * global_scale,
+    }
 
 
-def _create_collection(collection, track_kind=None):
+def _create_timeline(tl, context=None):
+    context = context or {}
+
+    with set_context(
+        context,
+        **_get_global_transform(tl)
+    ):
+        return create_rv_node_from_otio(tl.tracks, context)
+
+
+def _create_collection(collection, context=None):
     results = []
     for item in collection:
-        result = create_rv_node_from_otio(item, track_kind)
+        result = create_rv_node_from_otio(item, context)
         if result:
             results.append(result)
 
@@ -196,11 +247,12 @@ def _create_collection(collection, track_kind=None):
         return results[0]
 
 
-def _create_media_reference(item, track_kind=None):
+def _create_media_reference(item, context=None):
+    context = context or {}
     if hasattr(item, "media_reference") and item.media_reference:
         if isinstance(item.media_reference, otio.schema.ExternalReference):
             media = [str(item.media_reference.target_url)]
-            if track_kind == otio.schema.TrackKind.Audio:
+            if context.get('track_kind') == otio.schema.TrackKind.Audio:
                 # Create blank video media to accompany audio for valid source
                 blank = _create_movieproc(item.available_range())
                 # Appending blank to media promotes name of audio file in RV
@@ -226,7 +278,8 @@ def _create_media_reference(item, track_kind=None):
     return None
 
 
-def _create_item(it, track_kind=None):
+def _create_item(it, context=None):
+    context = context or {}
     range_to_read = it.trimmed_range()
 
     if not range_to_read:
@@ -236,7 +289,7 @@ def _create_item(it, track_kind=None):
             )
         )
 
-    new_media = _create_media_reference(it, track_kind)
+    new_media = _create_media_reference(it, context)
     if not new_media:
         kind = "smptebars"
         if isinstance(it, otio.schema.Gap):
@@ -269,6 +322,8 @@ def _create_item(it, track_kind=None):
                     range_to_read
                 )
 
+        _add_source_bounds(it.media_reference, src, context)
+
     if not in_frame and not out_frame:
         # because OTIO has no global concept of FPS, the rate of the duration
         # is used as the rate for the range of the source.
@@ -298,6 +353,64 @@ def _create_movieproc(time_range, kind="blank"):
         time_range.duration.rate
     )
     return movieproc
+
+
+def _add_source_bounds(media_ref, src, context):
+    if not hasattr(media_ref, "available_image_bounds"):
+        return
+
+    global_scale = context.get('global_scale')
+    global_translate = context.get('global_translate')
+    if not global_scale or not global_translate:
+        return
+
+    bounds = media_ref.available_image_bounds
+    if not bounds:
+        return
+
+    # A width of 1.0 in RV means draw to the aspect ratio, so scale the
+    # width by the inverse of the aspect ratio
+    #
+    media_info = commands.sourceMediaInfo(src)
+    height = media_info['height']
+    aspect_ratio = 1.0 if height == 0 else media_info['width'] / height
+
+    translate = bounds.center() * global_scale - global_translate
+    scale = (bounds.max - bounds.min) * global_scale
+
+    transform_node = extra_commands.associatedNode('RVTransform2D', src)
+
+    commands.setFloatProperty(
+        "{}.transform.scale".format(transform_node),
+        [scale.x / aspect_ratio, scale.y]
+    )
+    commands.setFloatProperty(
+        "{}.transform.translate".format(transform_node),
+        [translate.x, translate.y]
+    )
+
+    # write the bounds global_scale and global_translate to the node so we can
+    # preserve the original values if we round-trip
+    commands.newProperty(
+        "{}.otio.global_scale".format(transform_node),
+        commands.FloatType,
+        2
+    )
+    commands.newProperty(
+        "{}.otio.global_translate".format(transform_node),
+        commands.FloatType,
+        2
+    )
+    commands.setFloatProperty(
+        "{}.otio.global_scale".format(transform_node),
+        [global_scale.x, global_scale.y],
+        True
+    )
+    commands.setFloatProperty(
+        "{}.otio.global_translate".format(transform_node),
+        [global_translate.x, global_translate.y],
+        True
+    )
 
 
 def _add_metadata_to_node(item, rv_node):

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -202,9 +202,9 @@ def _get_global_transform(tl):
     def find_display_bounds(tl):
         for clip in tl.clip_if():
             try:
-               bounds = clip.media_reference.available_image_bounds
-               if bounds:
-                   return bounds
+                bounds = clip.media_reference.available_image_bounds
+                if bounds:
+                    return bounds
             except AttributeError:
                 continue
         return None
@@ -357,16 +357,13 @@ def _create_movieproc(time_range, kind="blank"):
 
 
 def _add_source_bounds(media_ref, src, context):
-    if media_ref.available_image_bounds is None:
+    bounds = media_ref.available_image_bounds
+    if not bounds:
         return
 
     global_scale = context.get('global_scale')
     global_translate = context.get('global_translate')
     if global_scale is None or global_translate is None:
-        return
-
-    bounds = media_ref.available_image_bounds
-    if not bounds:
         return
 
     # A width of 1.0 in RV means draw to the aspect ratio, so scale the

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -209,7 +209,7 @@ def _get_global_transform(tl):
         return None
 
     bounds = find_display_bounds(tl)
-    if not bounds:
+    if bounds is None:
         return {}
 
     translate = bounds.center()

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -361,7 +361,7 @@ def _add_source_bounds(media_ref, src, context):
 
     global_scale = context.get('global_scale')
     global_translate = context.get('global_translate')
-    if not global_scale or not global_translate:
+    if global_scale is None or global_translate is None:
         return
 
     bounds = media_ref.available_image_bounds

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -357,7 +357,7 @@ def _create_movieproc(time_range, kind="blank"):
 
 
 def _add_source_bounds(media_ref, src, context):
-    if not hasattr(media_ref, "available_image_bounds"):
+    if media_ref.available_image_bounds is None:
         return
 
     global_scale = context.get('global_scale')

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -201,11 +201,12 @@ def _get_global_transform(tl):
     # bounds as the global bounds
     def find_display_bounds(tl):
         for clip in tl.clip_if():
-            if hasattr(clip, "media_reference") and clip.media_reference:
-                if hasattr(clip.media_reference, "available_image_bounds"):
-                    bounds = clip.media_reference.available_image_bounds
-                    if bounds:
-                        return bounds
+            try:
+               bounds = clip.media_reference.available_image_bounds
+               if bounds:
+                   return bounds
+            except AttributeError:
+                continue
         return None
 
     bounds = find_display_bounds(tl)

--- a/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
@@ -38,7 +38,6 @@ import shutil
 import shlex
 import time
 import imp
-import platform
 from subprocess import call, Popen, PIPE
 
 import opentimelineio as otio
@@ -47,10 +46,7 @@ RV_OTIO_READER_NAME = 'Example OTIO Reader'
 RV_OTIO_READER_VERSION = '1.0'
 
 RV_ROOT_DIR = os.getenv('OTIO_RV_ROOT_DIR', '')
-RV_BIN_DIR = os.path.join(
-    RV_ROOT_DIR,
-    'MacOS' if platform.system() == 'Darwin' else 'bin'
-)
+RV_BIN_DIR = os.path.join(RV_ROOT_DIR, 'bin')
 
 RV_OTIO_READER_DIR = os.path.join(
     '..',
@@ -166,7 +162,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             'I L - {version} "{package_name}" {pkg_path}'.format(
                 version=RV_OTIO_READER_VERSION,
                 package_name=RV_OTIO_READER_NAME,
-                pkg_path=os.path.realpath(installed_package_path)
+                pkg_path=installed_package_path
             )
 
         self.assertIn(desired_result, stdout.split('\n'))
@@ -191,7 +187,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             delete=False
         )
         otio.adapters.write_to_file(sample_timeline, sample_file.name)
-        run_cmd = '{root}/{exe} ' \
+        run_cmd = '{root}/rv ' \
                   '-nc ' \
                   '-network ' \
                   '-networkHost localhost ' \
@@ -199,7 +195,6 @@ class RVSessionAdapterReadTest(unittest.TestCase):
                   '{sample_file}' \
                   .format(
                       root=RV_BIN_DIR,
-                      exe='RV' if platform.system() == 'Darwin' else 'rv',
                       port=9876,
                       sample_file=sample_file.name
                   )
@@ -217,15 +212,10 @@ class RVSessionAdapterReadTest(unittest.TestCase):
                 if not rvc.connected:
                     time.sleep(.5)
 
-                if attempts == 20:
+                if attempts == 10:
                     raise socket.error(
                         "Unable to connect to RV!"
                     )
-
-            # some time can pass between the RV connection
-            # and the complete startup of RV
-            print("Waiting for RV startup to complete")
-            time.sleep(10)
 
             # Check clips at positions
             clip1 = rv_media_name_at_frame(rvc, 1)

--- a/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
@@ -38,6 +38,7 @@ import shutil
 import shlex
 import time
 import imp
+import platform
 from subprocess import call, Popen, PIPE
 
 import opentimelineio as otio
@@ -46,7 +47,10 @@ RV_OTIO_READER_NAME = 'Example OTIO Reader'
 RV_OTIO_READER_VERSION = '1.0'
 
 RV_ROOT_DIR = os.getenv('OTIO_RV_ROOT_DIR', '')
-RV_BIN_DIR = os.path.join(RV_ROOT_DIR, 'bin')
+RV_BIN_DIR = os.path.join(
+    RV_ROOT_DIR,
+    'MacOS' if platform.system() == 'Darwin' else 'bin'
+)
 
 RV_OTIO_READER_DIR = os.path.join(
     '..',
@@ -70,7 +74,22 @@ sample_timeline = otio.schema.Timeline(
     global_start_time=otio.opentime.RationalTime(1, 24)
 )
 track = otio.schema.Track('v1')
-for clipnum in range(1, 4):
+bounds = [
+    otio.schema.Box2d(
+        otio.schema.V2d(0.0, 0.0),
+        otio.schema.V2d(16.0, 9.0)
+    ),  # sets viewing area
+    otio.schema.Box2d(
+        otio.schema.V2d(8.0, 0),
+        otio.schema.V2d(24.0, 9.0)
+    ),  # shifted right by half the viewing area
+    otio.schema.Box2d(
+        otio.schema.V2d(0.0, 0.0),
+        otio.schema.V2d(8.0, 4.5)
+    )  # scale to 1/4 of viewing area (lower left)
+]
+
+for clipnum, box in zip(range(1, 4), bounds):
     clip_name = 'clip{n}'.format(n=clipnum)
     track.append(
         otio.schema.Clip(
@@ -80,11 +99,12 @@ for clipnum in range(1, 4):
                 available_range=otio.opentime.TimeRange(
                     otio.opentime.RationalTime(1, 24),
                     otio.opentime.RationalTime(50, 24)
-                )
+                ),
+                available_image_bounds=box
             ),
             source_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(11, 24),
-                otio.opentime.RationalTime(30, 24)
+                otio.opentime.RationalTime(3, 24)
             )
         )
     )
@@ -146,7 +166,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             'I L - {version} "{package_name}" {pkg_path}'.format(
                 version=RV_OTIO_READER_VERSION,
                 package_name=RV_OTIO_READER_NAME,
-                pkg_path=installed_package_path
+                pkg_path=os.path.realpath(installed_package_path)
             )
 
         self.assertIn(desired_result, stdout.split('\n'))
@@ -171,7 +191,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             delete=False
         )
         otio.adapters.write_to_file(sample_timeline, sample_file.name)
-        run_cmd = '{root}/rv ' \
+        run_cmd = '{root}/{exe} ' \
                   '-nc ' \
                   '-network ' \
                   '-networkHost localhost ' \
@@ -179,6 +199,7 @@ class RVSessionAdapterReadTest(unittest.TestCase):
                   '{sample_file}' \
                   .format(
                       root=RV_BIN_DIR,
+                      exe='RV' if platform.system() == 'Darwin' else 'rv',
                       port=9876,
                       sample_file=sample_file.name
                   )
@@ -196,20 +217,44 @@ class RVSessionAdapterReadTest(unittest.TestCase):
                 if not rvc.connected:
                     time.sleep(.5)
 
-                if attempts == 10:
+                if attempts == 20:
                     raise socket.error(
                         "Unable to connect to RV!"
                     )
+
+            # some time can pass between the RV connection
+            # and the complete startup of RV
+            print("Waiting for RV startup to complete")
+            time.sleep(10)
 
             # Check clips at positions
             clip1 = rv_media_name_at_frame(rvc, 1)
             self.assertEqual(clip1, 'clip1.mov')
 
-            clip2 = rv_media_name_at_frame(rvc, 20)
+            # note RV has a default res of 1280,720 when the media doesn't exist
+            aspect_ratio = 1280.0 / 720.0
+
+            clip1_scale, clip1_translate = rv_transform_at_frame(rvc, 1)
+            self.assertEqual(clip1_scale, [1.0, 1.0])
+            self.assertEqual(clip1_translate, [0.0, 0.0])
+
+            clip2 = rv_media_name_at_frame(rvc, 4)
             self.assertEqual(clip2, 'clip2.mov')
 
-            clip3 = rv_media_name_at_frame(rvc, 40)
+            clip2_scale, clip2_translate = rv_transform_at_frame(rvc, 4)
+            self.assertEqual(clip2_scale, [1.0, 1.0])
+
+            self.assertAlmostEqual(clip2_translate[0], 0.5 * aspect_ratio)
+            self.assertEqual(clip2_translate[1], 0)
+
+            clip3 = rv_media_name_at_frame(rvc, 7)
             self.assertEqual(clip3, 'clip3.mov')
+
+            clip3_scale, clip3_translate = rv_transform_at_frame(rvc, 7)
+            self.assertEqual(clip3_scale, [0.5, 0.5])
+
+            self.assertAlmostEqual(clip3_translate[0], -0.25 * aspect_ratio)
+            self.assertEqual(clip3_translate[1], -0.25)
 
             rvc.disconnect()
 
@@ -245,17 +290,54 @@ def install_package(source_package_path):
     return rc
 
 
+def _exec_command(rvc, command, literal=True):
+    response = rvc.sendEventAndReturn("remote-pyeval", command)
+    return ast.literal_eval(response) if literal else response
+
+
+def _source_at_frame(rvc, frame):
+    return _exec_command(
+        rvc,
+        "rv.commands.sourcesAtFrame({0})".format(frame)
+    )[0]
+
+
 def rv_media_name_at_frame(rvc, frame):
-    command = "rv.commands.sourcesAtFrame({0})".format(frame)
-    source = rvc.sendEventAndReturn("remote-pyeval", command)
-    source_list = ast.literal_eval(source)
-    source_name = source_list[0]
+    source_name = _source_at_frame(rvc, frame)
+    return _exec_command(
+        rvc,
+        "rv.commands.sourceMedia('{0}')".format(source_name)
+    )[0]
 
-    command = "rv.commands.sourceMedia('{0}')".format(source_name)
-    media_string = rvc.sendEventAndReturn("remote-pyeval", command)
-    media = ast.literal_eval(media_string)[0]
 
-    return media
+def rv_transform_at_frame(rvc, frame):
+    source = _source_at_frame(rvc, frame)
+
+    source_group = _exec_command(
+        rvc,
+        """rv.commands.nodeGroup('{0}')""".format(source),
+        literal=False
+    )
+
+    transform = _exec_command(
+        rvc,
+        """rv.extra_commands.nodesInGroupOfType(
+            '{0}', 'RVTransform2D')""".format(source_group)
+    )[0]
+
+    scale = _exec_command(
+        rvc,
+        """rv.commands.getFloatProperty(
+            '{0}.transform.scale')""".format(transform)
+    )
+
+    translate = _exec_command(
+        rvc,
+        """rv.commands.getFloatProperty(
+            '{0}.transform.translate')""".format(transform)
+    )
+
+    return scale, translate
 
 
 if __name__ == '__main__':

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -152,7 +152,10 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         )
 
         self.assertEqual(available_image_bounds, cl.available_image_bounds)
-        self.assertEqual(cl.available_image_bounds, media_reference.available_image_bounds)
+        self.assertEqual(
+            cl.available_image_bounds,
+            media_reference.available_image_bounds
+        )
 
         self.assertEqual(0.0, cl.available_image_bounds.min.x)
         self.assertEqual(0.0, cl.available_image_bounds.min.y)

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -715,7 +715,8 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             name="clip1"
         )
 
-        # The Stack available_image_bounds should be equal to the single clip that's in it
+        # The Stack available_image_bounds should be equal to
+        # the single clip that's in it
         st.append(clip)
         self.assertEqual(st.available_image_bounds, clip.available_image_bounds)
 


### PR DESCRIPTION
Fixes #1089 

**Summarize your change.**

This branch adds support for reading the `available_image_bounds` in the RV OTIO import plugin. 

This works by creating a `RvTransform2D` node for each media_reference we find that has `available_image_bounds` set.  RV uses scale/translate properties on its 2D transforms, we use the difference between the max and the min vectors of the box (ie the size) to set the scale and the center of the box to set the translate.  The x-scale is scaled by the inverse aspect ratio since in RV a scale of 1.0 means the media will be drawn according to the aspect ratio.

Since RV uses a coordinate system equivalent to an OTIO `Box2d(min=(-0.5, -0.5), max=(0.5, 0.5))` and the incoming OTIO may be in a different coordinate system we calculate a global normalization values for scale and translate properties by dividing all values by the height and finding the different between the center points of the two coordinate systems.  This is then applied to each 2D transform we apply on a source.  These normalization values are preserved so if we round trip, we can do the inverse operation to return to the original coordinate system. 

In order to have access to the display bounds at the clip level, it was necessary to pass them down through the various otio parsing methods, similarly to what is done with `track_kind`.  Instead of adding another parameters for this I created a context dictionary where the parameters can be mapped and more can be easily added in the future, adding `track_kind` and `display_bounds` into it.  I also added a context manager that will remove these parameters once they fall out of scope, ensuring that once we go back up the hierarchy, any parameters added by the children will get removed.

**Reference associated tests.**

The existing test_rv_reader.py was modified to also test for the image bounds. Note that I had to change the source range as the existing values were not working (even prior to any modification).  A duration value of 30 was set and the test expected the sources to be 20 frames apart.  I simply lowered the duration to 3 to fix.

I also did some minor refactoring of the way commands to rvNetwork were being issued, since its quite tedious to send/process the commands and their almost all done identically.

Some screen shots using the 3 bounds from the unit test 

<img width="947" alt="Screen Shot 2021-11-05 at 13 02 12" src="https://user-images.githubusercontent.com/8494931/140550020-93a429a9-a224-47c2-a8ac-0e2d5fe27ed5.png">
<img width="948" alt="Screen Shot 2021-11-05 at 13 02 43" src="https://user-images.githubusercontent.com/8494931/140550029-cc0c5e80-1868-491a-b519-cf89d339c76a.png">
<img width="953" alt="Screen Shot 2021-11-05 at 13 02 54" src="https://user-images.githubusercontent.com/8494931/140550047-4d94b1f2-503d-44a6-96f7-ca000ad91273.png">