### PR TITLE
Use platform specific command to find path

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -84,7 +84,7 @@ class ConsoleTester(otio_test_utils.OTIOAssertions):
             try:
                 subprocess.check_call(
                     [
-                        "which", sys.argv[0]
+                        "where" if os.name == "nt" else "which", sys.argv[0]
                     ],
                     stdout=subprocess.PIPE
                 )

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -83,7 +83,6 @@ class ConsoleTester(otio_test_utils.OTIOAssertions):
     def run_test(self):
         if self.SHELL_OUT:
             # make sure its on the path
-            
             console_script = os.path.join(sysconfig.get_path('scripts'), sys.argv[0])
             if platform.system() == 'Windows':
                 console_script += '.exe'

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -29,7 +29,6 @@ import sys
 import os
 import subprocess
 import sysconfig
-import fnmatch
 import platform
 
 try:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -30,6 +30,7 @@ import os
 import subprocess
 import sysconfig
 import fnmatch
+import platform
 
 try:
     # python2
@@ -85,14 +86,15 @@ class ConsoleTester(otio_test_utils.OTIOAssertions):
             # make sure its on the path
             
             console_script = os.path.join(sysconfig.get_path('scripts'), sys.argv[0])
+            if platform.system() == 'Windows':
+                console_script += '.exe'
+
             if not os.path.exists(console_script):
-                # We might be on Windows
-                if not os.path.exists(console_script + ".exe"):
-                    self.fail(
+                self.fail(
                     "Could not find '{}'.  Tests that explicitly shell"
                     " out can be disabled by setting the environment variable "
                     "OTIO_DISABLE_SHELLOUT_TESTS.".format(console_script)
-                    )
+                )
 
             # actually run the test (sys.argv is already populated correctly)
             proc = subprocess.Popen(

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -28,6 +28,8 @@ import unittest
 import sys
 import os
 import subprocess
+import sysconfig
+import fnmatch
 
 try:
     # python2
@@ -81,19 +83,16 @@ class ConsoleTester(otio_test_utils.OTIOAssertions):
     def run_test(self):
         if self.SHELL_OUT:
             # make sure its on the path
-            try:
-                subprocess.check_call(
-                    [
-                        "where" if os.name == "nt" else "which", sys.argv[0]
-                    ],
-                    stdout=subprocess.PIPE
-                )
-            except subprocess.CalledProcessError:
-                self.fail(
-                    "Could not find '{}' on $PATH.  Tests that explicitly shell"
+            
+            console_script = os.path.join(sysconfig.get_path('scripts'), sys.argv[0])
+            if not os.path.exists(console_script):
+                # We might be on Windows
+                if not os.path.exists(console_script + ".exe"):
+                    self.fail(
+                    "Could not find '{}'.  Tests that explicitly shell"
                     " out can be disabled by setting the environment variable "
-                    "OTIO_DISABLE_SHELLOUT_TESTS.".format(sys.argv[0])
-                )
+                    "OTIO_DISABLE_SHELLOUT_TESTS.".format(console_script)
+                    )
 
             # actually run the test (sys.argv is already populated correctly)
             proc = subprocess.Popen(


### PR DESCRIPTION
**Summarize your change.**

Tests on Windows were failing as the test code uses the Unix command `which`. Here we change that to use a platform specific command (`where`) when running on Windows. `shutil.which()` cannot be used as it's Python3.3+ only.

I should also say I don't have a Linux machine to test on so this has only been tested on Windows.
