### PR TITLE
Fix RV plugin test timing

### DIFF
--- a/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
@@ -84,7 +84,7 @@ for clipnum in range(1, 4):
             ),
             source_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(11, 24),
-                otio.opentime.RationalTime(30, 24)
+                otio.opentime.RationalTime(3, 24)
             )
         )
     )
@@ -205,10 +205,10 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             clip1 = rv_media_name_at_frame(rvc, 1)
             self.assertEqual(clip1, 'clip1.mov')
 
-            clip2 = rv_media_name_at_frame(rvc, 20)
+            clip2 = rv_media_name_at_frame(rvc, 4)
             self.assertEqual(clip2, 'clip2.mov')
 
-            clip3 = rv_media_name_at_frame(rvc, 40)
+            clip3 = rv_media_name_at_frame(rvc, 7)
             self.assertEqual(clip3, 'clip3.mov')
 
             rvc.disconnect()


### PR DESCRIPTION
Fixes #1146 

**Summarize your change.**

The tests for the RV plugin will always fail when they are run.  This is because the setup creates three clips with a duration of RationalTime(30,24) and the test is expecting new clips at RV global frames 1, 20, and 40.  

To fix the issue, I just lowered the duration to RationalTime(3,24) and check for clips at RV global frames 1, 4 and 7. 

**Reference associated tests.**

Only the modified test: test_rv_reader.py
