### PR TITLE
Update sdist to include submodules

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -127,6 +127,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2.3.5
+      with:
+        submodules: 'recursive'
 
     - uses: actions/setup-python@v2
 


### PR DESCRIPTION
This PR fixes the sdist that is uploaded to PyPI.

The problem was reported in https://app.slack.com/client/TKA297NS0/CMQ9J4BQC.

The issue was simply that I forgot to tell GHA to recursively clone and checkout the submodules.

I tested locally by downloading the GHA artifact from my fork and installed the sdist.