### PR TITLE
Recursively get submodules before generating the sdist

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -124,9 +124,11 @@ jobs:
 
   package_sdist:
     needs: py_build_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v2.3.5
+      with:
+        submodules: 'recursive'
 
     - uses: actions/setup-python@v2
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,9 +11,9 @@ env:
 
 on:
   push:
-    branches: [ main ]
+    branches: [ 'main', 'v[0-9]*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ 'main', 'v[0-9]*' ]
 
 jobs:
   cpp_build:


### PR DESCRIPTION
This is a cherry-pick of #1152 for a 0.14 patch release.

See the slack discussion around [this message](https://academysoftwarefdn.slack.com/archives/CMQ9J4BQC/p1637282298263800) for more context.