### PR TITLE
fix kdenlive read if global_feed=1 is missing

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/kdenlive.py
+++ b/contrib/opentimelineio_contrib/adapters/kdenlive.py
@@ -92,6 +92,16 @@ def read_from_string(input_str):
         name=mlt.get('name', 'Kdenlive imported timeline'))
 
     maintractor = mlt.find("tractor[@global_feed='1']")
+    if maintractor is None:
+        # global_feed is no longer set in newer kdenlive versions,
+        # but the last tractor in the xml is apparently still the main tractor
+        # so lets take that one and check if it includes all the other ones, like it should
+        alltractors = mlt.findall("tractor")
+        maintractor = alltractors[-1]
+        if not all((maintractor.find("track[@producer='%s']" % tractor.attrib['id']) is not None)
+                   for tractor in alltractors[:-1]):
+            raise RuntimeError("Can't find main tractor")
+            
     for maintrack in maintractor.findall('track'):
         if maintrack.get('producer') == 'black_track':
             continue

--- a/contrib/opentimelineio_contrib/adapters/kdenlive.py
+++ b/contrib/opentimelineio_contrib/adapters/kdenlive.py
@@ -95,7 +95,7 @@ def read_from_string(input_str):
     if maintractor is None:
         # global_feed is no longer set in newer kdenlive versions,
         # but the last tractor in the xml is apparently still the main tractor
-        # so lets take that one and check if it includes all the other ones, like it should
+        # so let's take that one and check if it includes all the other ones, like it should
         alltractors = mlt.findall("tractor")
         maintractor = alltractors[-1]
         if not all((maintractor.find("track[@producer='%s']" % tractor.attrib['id']) is not None)


### PR DESCRIPTION
In newer versions of kdenlive, the global_feed=1 attribute isn't set in the "main" tractor.
However, it looks like the last tractor in the xml is still the main tractor.
This change uses the last tractor as the main tractor if it can't be found using global_feed=1 and, just to be safe, checks if all other tractors are included by it.

This fixes #1159 as well as the following bugs in the KDE bugtracker:
https://bugs.kde.org/show_bug.cgi?id=426942
https://bugs.kde.org/show_bug.cgi?id=445214

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/PixarAnimationStudios/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
