### PR TITLE
Replaced @pixar email addresses with @aswf email addresses.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at otio-tsc-private@lists.aswf.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at opentimelineio-tsc@aswf.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at opentimelineio-admin@pixar.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at otio-tsc-private@lists.aswf.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Before contributing code to OpenTimelineIO, we ask that you sign a Contributor L
 * [OTIO_CLA_Corporate.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
 * [OTIO_CLA_Individual.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
 
-Once your CLA is signed, send it to `otio-tsc-private@lists.aswf.io` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
+Once your CLA is signed, send it to `opentimelineio-tsc@aswf.io` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
 
 ## Coding Conventions
 Please follow the coding convention and style in each file and in each library when adding new files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Before contributing code to OpenTimelineIO, we ask that you sign a Contributor L
 * [OTIO_CLA_Corporate.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
 * [OTIO_CLA_Individual.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
 
-Once your CLA is signed, send it to `opentimelineio-cla@pixar.com` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
+Once your CLA is signed, send it to `otio-tsc-private@lists.aswf.io` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
 
 ## Coding Conventions
 Please follow the coding convention and style in each file and in each library when adding new files.

--- a/docs/tutorials/contributing.md
+++ b/docs/tutorials/contributing.md
@@ -10,7 +10,7 @@ Before contributing code to OpenTimelineIO, we ask that you sign a Contributor L
 * [OTIO_CLA_Corporate.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
 * [OTIO_CLA_Individual.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
 
-Once your CLA is signed, send it to `opentimelineio-cla@pixar.com` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
+Once your CLA is signed, send it to `otio-tsc-private@lists.aswf.io` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
 
 ## Coding Conventions
 Please follow the coding convention and style in each file and in each library when adding new files.

--- a/docs/tutorials/contributing.md
+++ b/docs/tutorials/contributing.md
@@ -10,7 +10,7 @@ Before contributing code to OpenTimelineIO, we ask that you sign a Contributor L
 * [OTIO_CLA_Corporate.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Corporate.pdf): please sign this one for corporate use
 * [OTIO_CLA_Individual.pdf](https://github.com/PixarAnimationStudios/OpenTimelineIO/raw/main/OTIO_CLA_Individual.pdf): please sign this one if you're an individual contributor
 
-Once your CLA is signed, send it to `otio-tsc-private@lists.aswf.io` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
+Once your CLA is signed, send it to `opentimelineio-tsc@aswf.io` (please make sure to include your github username) and wait for confirmation that we've received it.  After that, you can submit pull requests.
 
 ## Coding Conventions
 Please follow the coding convention and style in each file and in each library when adding new files.


### PR DESCRIPTION
In preparation for transfer of OpenTimelineIO from Pixar to ASWF, we are changing the contact email addresses to the OTIO TSC private mailing list.