### PR TITLE
Fix code coverage report uploads

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,7 +6,7 @@ name: OpenTimelineIO
 # for configuring which build will be a C++ coverage build / coverage report
 env:
   GH_COV_PY: 3.7
-  GH_COV_OS: ubuntu-20.04
+  GH_COV_OS: ubuntu-latest
   GH_DEPENDABOT: dependabot
 
 on:


### PR DESCRIPTION
I recently noticed that the code coverage report uploads were no more running. The cause was that we forgot to un-bake the `GH_COV_OS` in the workflow after we release 0.14.0.