### PR TITLE
Replace deprecated Pybind11 get_type() usages by py::type::of()

### DIFF
--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -50,7 +50,7 @@ RationalTime _type_checked(py::object const& rhs, char const* op) {
         return py::cast<RationalTime>(rhs);
     }
     catch (...) {
-        std::string rhs_type = py::cast<std::string>(rhs.get_type().attr("__name__"));
+        std::string rhs_type = py::cast<std::string>(py::type::of(rhs).attr("__name__"));
         throw py::type_error(string_printf("unsupported operand type(s) for %s: "
                                            "RationalTime and %s", op, rhs_type.c_str()));
     }


### PR DESCRIPTION
**Summarize your change.**

I noticed while working on the docs for the Python bindings that the code base had a reference to a deprecated Pybind11 method, `get_type`. As stated in https://pybind11.readthedocs.io/en/stable/upgrade.html#v2-6, the replacement is `py::type::of`.

Quote from the doc:
> The undocumented h.get_type() method has been deprecated and replaced by py::type::of(h).

This PR replaces the `get_type` call with `py::type::of`.
