### PR TITLE
Remove extra useless parameter from RationalTime.__copy__ method

### DIFF
--- a/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
+++ b/src/py-opentimelineio/opentime-bindings/opentime_rationalTime.cpp
@@ -71,9 +71,9 @@ void opentime_rationalTime_bindings(py::module m) {
         .def("value_rescaled_to", (double (RationalTime::*)(RationalTime) const) &RationalTime::value_rescaled_to,
              "other"_a, R"docstring(Returns the time value for self converted to new_rate.)docstring")
         .def("almost_equal", &RationalTime::almost_equal, "other"_a, "delta"_a = 0)
-        .def("__copy__", [](RationalTime rt, py::object) {
+        .def("__copy__", [](RationalTime rt) {
                 return rt;
-            }, "copier"_a = py::none())
+            })
         .def("__deepcopy__", [](RationalTime rt, py::object) {
                 return rt;
             }, "copier"_a = py::none())


### PR DESCRIPTION
I noticed that the `RationalTime.__copy__` method had an argument that is not used. The `__copy__` special method is not supposed to accept arguments.

From https://docs.python.org/3/library/copy.html:

> In order for a class to define its own copy implementation, it can define special methods \_\_copy\_\_() and \_\_deepcopy\_\_(). __The former is called to implement the shallow copy operation; no additional arguments are passed__. The latter is called to implement the deep copy operation; it is passed one argument, the memo dictionary.