### PR TITLE
Update AAF Documentation Link

### DIFF
--- a/docs/tutorials/adapters.md
+++ b/docs/tutorials/adapters.md
@@ -15,7 +15,7 @@ Final Cut Pro X XML Format:
 
 ### Adobe Premiere Project ###
 
-- Based on guidance from Adobe, we support interchange with Adobe Premiere via 
+- Based on guidance from Adobe, we support interchange with Adobe Premiere via
     the FCP 7 XML format (see above).
 
 ### CMX3600 EDL ###
@@ -31,8 +31,8 @@ Final Cut Pro X XML Format:
 - Status: Reads and writes AAF compositions
   - includes clip, gaps, transitions but not markers or effects
   - This adapter is still in progress, see the ongoing work here: <a href="https://github.com/PixarAnimationStudios/OpenTimelineIO/projects/1" target="_blank">AAF Project</a>
-- <a href="http://www.amwa.tv/downloads/specifications/aafobjectspec-v1.1.pdf" target="_blank">Spec</a>
-- <a href="http://www.amwa.tv/downloads/specifications/aafeditprotocol.pdf" target="_blank">Protocol</a>
+- <a href="https://static.amwa.tv/ms-01-aaf-object-spec.pdf" target="_blank">Spec</a>
+- <a href="https://static.amwa.tv/as-01-aaf-edit-protocol-spec.pdf" target="_blank">Protocol</a>
 
 - Depends on the <a href="https://github.com/markreidvfx/pyaaf2" target="_blank">`PyAAF2`</a> module, so either:
     - `pip install pyaaf2`
@@ -41,24 +41,24 @@ Final Cut Pro X XML Format:
 Contrib Adapters
 ----------------
 
-The contrib area hosts adapters which come from the community (_not_ supported 
+The contrib area hosts adapters which come from the community (_not_ supported
     by the core-otio team) and may require extra dependencies.
 
 ### RV Session File ###
 
 - Status: write-only adapter supported via the `rv_session` adapter.
-- need to set environment variables to locate `py-interp` and `rvSession.py` 
+- need to set environment variables to locate `py-interp` and `rvSession.py`
     from within the RV distribution
-- set `${OTIO_RV_PYTHON_BIN}` to point at `py-interp` from within rv, for 
+- set `${OTIO_RV_PYTHON_BIN}` to point at `py-interp` from within rv, for
     example:
     `setenv OTIO_RV_PYTHON_BIN /Applications/RV64.app/Contents/MacOS/py-interp`
 - set `${OTIO_RV_PYTHON_LIB}` to point at the parent directory of `rvSession.py`:
     `setenv OTIO_RV_PYTHON_LIB /Applications/RV64.app/Contents/src/python`
-    
+
 ### Maya Sequencer ###
 
 - Status: supported via the `maya_sequencer` adapter.
-- set `${OTIO_MAYA_PYTHON_BIN}` to point the location of `mayapy` within the maya 
+- set `${OTIO_MAYA_PYTHON_BIN}` to point the location of `mayapy` within the maya
     installation.
 
 ### HLS Playlist ###
@@ -82,4 +82,3 @@ Uses FFmpeg to burn text overlays into video media.
 ### Kdenlive Adapter ###
 
 - Status: supported via the kdenlive adapter
-


### PR DESCRIPTION
Fixes #1201 

Updated URLs of the PDFs to the new location on static.amwa.tv
