### PR TITLE
AAF reader supports muted clips

### DIFF
--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -768,8 +768,8 @@ def _transcribe(item, parents, edit_rate, indent=0):
         # a multi cam thing
         if alternates and len(alternates) == 1:
             # Our result is the clip itself, but marked as enabled=False (muted)
-            metadata = copy.deepcopy(alternates[0].metadata["AAF"])
             result = alternates[0]
+            metadata = copy.deepcopy(result.metadata["AAF"])
             result.enabled = False
         else:
             metadata['alternates'] = alternates
@@ -1346,24 +1346,38 @@ def _simplify(thing):
                     # TODO: We may be discarding metadata, should we merge it?
                     # TODO: Do we need to offset the markers in time?
                     thing.markers.extend(child.markers)
+
                     # Note: we don't merge effects, because we already made
                     # sure the child had no effects in the if statement above.
+
+                    # Preserve the enabled/disabled state as we merge these two.
+                    thing.enabled = thing.enabled and child.enabled
 
                     c = c + num
                 c = c - 1
 
         # skip redundant containers
         if _is_redundant_container(thing):
-            # TODO: We may be discarding metadata here, should we merge it?
+            # Merge the redundant container with the 1st (only) child object
             result = thing[0].deepcopy()
+
+            # TODO: We may be discarding metadata here, should we merge it?
+
+            # Merge the markers from both
             # TODO: Do we need to offset the markers in time?
             result.markers.extend(thing.markers)
+
+            # Merge the effects from both
             # TODO: The order of the effects is probably important...
             # should they be added to the end or the front?
             # Intuitively it seems like the child's effects should come before
             # the parent's effects. This will need to be solidified when we
             # add more effects support.
             result.effects.extend(thing.effects)
+
+            # Preserve the enabled/disabled state as we merge these two.
+            result.enabled = result.enabled and thing.enabled
+
             # Keep the parent's length, if it has one
             if thing.source_range:
                 # make sure it has a source_range first

--- a/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
+++ b/contrib/opentimelineio_contrib/adapters/advanced_authoring_format.py
@@ -767,10 +767,12 @@ def _transcribe(item, parents, edit_rate, indent=0):
         # muted case -- if there is only one item its muted, otherwise its
         # a multi cam thing
         if alternates and len(alternates) == 1:
-            metadata['muted_clip'] = True
-            result.name = str(alternates[0].name) + "_MUTED"
-
-        metadata['alternates'] = alternates
+            # Our result is the clip itself, but marked as enabled=False (muted)
+            metadata = copy.deepcopy(alternates[0].metadata["AAF"])
+            result = alternates[0]
+            result.enabled = False
+        else:
+            metadata['alternates'] = alternates
 
     # @TODO: There are a bunch of other AAF object types that we will
     # likely need to add support for. I'm leaving this code here to help

--- a/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
+++ b/contrib/opentimelineio_contrib/adapters/tests/test_aaf_adapter.py
@@ -863,13 +863,15 @@ class AAFReaderTests(unittest.TestCase):
         # do then this effect is a "Speed Bump" from 166% to 44% to 166%
 
     def test_muted_clip(self):
-        sc = otio.adapters.read_from_file(MUTED_CLIP_PATH, simplify=False)
-        gp = sc[0].tracks[8][0][0]
-
-        self.assertIsNotNone(gp)
-        self.assertTrue(gp.metadata['AAF']['muted_clip'])
-        self.assertIsInstance(gp, otio.schema.Gap)
-        self.assertEqual(gp.name, 'Frame Debugger 0h.mov_MUTED')
+        timeline = otio.adapters.read_from_file(MUTED_CLIP_PATH)
+        self.assertIsInstance(timeline, otio.schema.Timeline)
+        self.assertEqual(len(timeline.tracks), 1)
+        track = timeline.tracks[0]
+        self.assertEqual(len(track), 1)
+        clip = track[0]
+        self.assertIsInstance(clip, otio.schema.Clip)
+        self.assertEqual(clip.name, 'Frame Debugger 0h.mov')
+        self.assertEqual(clip.enabled, False)
 
     def test_essence_group(self):
         timeline = otio.adapters.read_from_file(ESSENCE_GROUP_PATH)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -298,9 +298,9 @@ class ItemTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             duration=otio.opentime.RationalTime(10, 1)
         )
         it = otio.core.Item(source_range=tr)
-        self.assertEquals(it.enabled, True)
+        self.assertEqual(it.enabled, True)
         it.enabled = False
-        self.assertEquals(it.enabled, False)
+        self.assertEqual(it.enabled, False)
         encoded = otio.adapters.otio_json.write_to_string(it)
         decoded = otio.adapters.otio_json.read_from_string(encoded)
         self.assertIsOTIOEquivalentTo(it, decoded)


### PR DESCRIPTION
```Fixes #483```

Now that #1175 has landed, this PR updates the AAF reader to use the new `enabled` boolean when it reads muted clips. This replaces the previous workaround where the AAF reader would place a Gap with the muted clip as metadata. Now each muted clip will be a normal Clip object with `enabled=False`.

I haven't tested with muted tracks yet.
