### PR TITLE
Merge spatial_coordinates to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "src/deps/any"]
 	path = src/deps/any
 	url = https://github.com/thelink2012/any.git
+[submodule "src/deps/Imath"]
+	path = src/deps/Imath
+	url = https://github.com/AcademySoftwareFoundation/Imath

--- a/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/rv/example_otio_reader/otio_reader.py
@@ -33,6 +33,19 @@ from rv import commands
 from rv import extra_commands
 
 import opentimelineio as otio
+from contextlib import contextmanager
+
+
+@contextmanager
+def set_context(context, **kwargs):
+    old_context = context.copy()
+    context.update(**kwargs)
+
+    try:
+        yield
+    finally:
+        context.clear()
+        context.update(old_context)
 
 
 class NoMappingForOtioTypeError(otio.exceptions.OTIOError):
@@ -52,7 +65,7 @@ def read_otio_file(otio_file):
     return create_rv_node_from_otio(input_otio)
 
 
-def create_rv_node_from_otio(otio_obj, track_kind=None):
+def create_rv_node_from_otio(otio_obj, context=None):
     WRITE_TYPE_MAP = {
         otio.schema.Timeline: _create_timeline,
         otio.schema.Stack: _create_stack,
@@ -64,14 +77,14 @@ def create_rv_node_from_otio(otio_obj, track_kind=None):
     }
 
     if type(otio_obj) in WRITE_TYPE_MAP:
-        return WRITE_TYPE_MAP[type(otio_obj)](otio_obj, track_kind)
+        return WRITE_TYPE_MAP[type(otio_obj)](otio_obj, context)
 
     raise NoMappingForOtioTypeError(
         str(type(otio_obj)) + " on object: {}".format(otio_obj)
     )
 
 
-def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
+def _create_dissolve(pre_item, in_dissolve, post_item, context=None):
     rv_trx = commands.newNode("CrossDissolve", in_dissolve.name or "dissolve")
     extra_commands.setUIName(rv_trx, str(in_dissolve.name or "dissolve"))
 
@@ -89,9 +102,9 @@ def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
                               [float(pre_item.trimmed_range().duration.rate)],
                               True)
 
-    pre_item_rv = create_rv_node_from_otio(pre_item, track_kind)
+    pre_item_rv = create_rv_node_from_otio(pre_item, context)
 
-    post_item_rv = create_rv_node_from_otio(post_item, track_kind)
+    post_item_rv = create_rv_node_from_otio(post_item, context)
 
     node_to_insert = post_item_rv
 
@@ -113,7 +126,7 @@ def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
             pre_item.media_reference.available_range.start_time.rate
         )
 
-        post_item_rv = create_rv_node_from_otio(post_item, track_kind)
+        post_item_rv = create_rv_node_from_otio(post_item, context)
 
         rt_node.addInput(post_item_rv)
         node_to_insert = rt_node
@@ -123,7 +136,7 @@ def _create_dissolve(pre_item, in_dissolve, post_item, track_kind=None):
     return rv_trx
 
 
-def _create_transition(pre_item, in_trx, post_item, track_kind=None):
+def _create_transition(pre_item, in_trx, post_item, context=None):
     trx_map = {
         otio.schema.TransitionTypes.SMPTE_Dissolve: _create_dissolve,
     }
@@ -135,17 +148,17 @@ def _create_transition(pre_item, in_trx, post_item, track_kind=None):
         pre_item,
         in_trx,
         post_item,
-        track_kind
+        context
     )
 
 
-def _create_stack(in_stack, track_kind=None):
+def _create_stack(in_stack, context=None):
     new_stack = commands.newNode("RVStackGroup", in_stack.name or "tracks")
     extra_commands.setUIName(new_stack, str(in_stack.name or "tracks"))
 
     new_inputs = []
     for seq in in_stack:
-        result = create_rv_node_from_otio(seq, track_kind)
+        result = create_rv_node_from_otio(seq, context)
         if result:
             new_inputs.append(result)
 
@@ -154,7 +167,9 @@ def _create_stack(in_stack, track_kind=None):
     return new_stack
 
 
-def _create_track(in_seq, _=None):
+def _create_track(in_seq, context=None):
+    context = context or {}
+
     new_seq = commands.newNode("RVSequenceGroup", str(in_seq.name or "track"))
     extra_commands.setUIName(new_seq, str(in_seq.name or "track"))
 
@@ -162,33 +177,70 @@ def _create_track(in_seq, _=None):
         in_seq
     )
 
-    track_kind = in_seq.kind
+    with set_context(context, track_kind=in_seq.kind):
+        new_inputs = []
+        for thing in items_to_serialize:
+            if isinstance(thing, tuple):
+                result = _create_transition(*thing, context=context)
+            elif thing.duration().value == 0:
+                continue
+            else:
+                result = create_rv_node_from_otio(thing, context)
 
-    new_inputs = []
-    for thing in items_to_serialize:
-        if isinstance(thing, tuple):
-            result = _create_transition(*thing, track_kind=track_kind)
-        elif thing.duration().value == 0:
-            continue
-        else:
-            result = create_rv_node_from_otio(thing, track_kind)
+            if result:
+                new_inputs.append(result)
 
-        if result:
-            new_inputs.append(result)
+        commands.setNodeInputs(new_seq, new_inputs)
+        _add_metadata_to_node(in_seq, new_seq)
 
-    commands.setNodeInputs(new_seq, new_inputs)
-    _add_metadata_to_node(in_seq, new_seq)
     return new_seq
 
 
-def _create_timeline(tl, _=None):
-    return create_rv_node_from_otio(tl.tracks)
+def _get_global_transform(tl):
+    # since there's no global scale in otio, use the first source with
+    # bounds as the global bounds
+    def find_display_bounds(tl):
+        for clip in tl.clip_if():
+            try:
+                bounds = clip.media_reference.available_image_bounds
+                if bounds:
+                    return bounds
+            except AttributeError:
+                continue
+        return None
+
+    bounds = find_display_bounds(tl)
+    if bounds is None:
+        return {}
+
+    translate = bounds.center()
+    scale = bounds.max - bounds.min
+
+    # RV's global coordinate system has a width and height of 1 where the
+    # width will be scaled to the image aspect ratio.  So scale globally by
+    # height. The source width will later be scaled to aspect ratio.
+    global_scale = otio.schema.V2d(1.0 / scale.y, 1.0 / scale.y)
+
+    return {
+        'global_scale': global_scale,
+        'global_translate': translate * global_scale,
+    }
 
 
-def _create_collection(collection, track_kind=None):
+def _create_timeline(tl, context=None):
+    context = context or {}
+
+    with set_context(
+        context,
+        **_get_global_transform(tl)
+    ):
+        return create_rv_node_from_otio(tl.tracks, context)
+
+
+def _create_collection(collection, context=None):
     results = []
     for item in collection:
-        result = create_rv_node_from_otio(item, track_kind)
+        result = create_rv_node_from_otio(item, context)
         if result:
             results.append(result)
 
@@ -196,11 +248,12 @@ def _create_collection(collection, track_kind=None):
         return results[0]
 
 
-def _create_media_reference(item, track_kind=None):
+def _create_media_reference(item, context=None):
+    context = context or {}
     if hasattr(item, "media_reference") and item.media_reference:
         if isinstance(item.media_reference, otio.schema.ExternalReference):
             media = [str(item.media_reference.target_url)]
-            if track_kind == otio.schema.TrackKind.Audio:
+            if context.get('track_kind') == otio.schema.TrackKind.Audio:
                 # Create blank video media to accompany audio for valid source
                 blank = _create_movieproc(item.available_range())
                 # Appending blank to media promotes name of audio file in RV
@@ -226,7 +279,8 @@ def _create_media_reference(item, track_kind=None):
     return None
 
 
-def _create_item(it, track_kind=None):
+def _create_item(it, context=None):
+    context = context or {}
     range_to_read = it.trimmed_range()
 
     if not range_to_read:
@@ -236,7 +290,7 @@ def _create_item(it, track_kind=None):
             )
         )
 
-    new_media = _create_media_reference(it, track_kind)
+    new_media = _create_media_reference(it, context)
     if not new_media:
         kind = "smptebars"
         if isinstance(it, otio.schema.Gap):
@@ -269,6 +323,8 @@ def _create_item(it, track_kind=None):
                     range_to_read
                 )
 
+        _add_source_bounds(it.media_reference, src, context)
+
     if not in_frame and not out_frame:
         # because OTIO has no global concept of FPS, the rate of the duration
         # is used as the rate for the range of the source.
@@ -298,6 +354,61 @@ def _create_movieproc(time_range, kind="blank"):
         time_range.duration.rate
     )
     return movieproc
+
+
+def _add_source_bounds(media_ref, src, context):
+    bounds = media_ref.available_image_bounds
+    if not bounds:
+        return
+
+    global_scale = context.get('global_scale')
+    global_translate = context.get('global_translate')
+    if global_scale is None or global_translate is None:
+        return
+
+    # A width of 1.0 in RV means draw to the aspect ratio, so scale the
+    # width by the inverse of the aspect ratio
+    #
+    media_info = commands.sourceMediaInfo(src)
+    height = media_info['height']
+    aspect_ratio = 1.0 if height == 0 else media_info['width'] / height
+
+    translate = bounds.center() * global_scale - global_translate
+    scale = (bounds.max - bounds.min) * global_scale
+
+    transform_node = extra_commands.associatedNode('RVTransform2D', src)
+
+    commands.setFloatProperty(
+        "{}.transform.scale".format(transform_node),
+        [scale.x / aspect_ratio, scale.y]
+    )
+    commands.setFloatProperty(
+        "{}.transform.translate".format(transform_node),
+        [translate.x, translate.y]
+    )
+
+    # write the bounds global_scale and global_translate to the node so we can
+    # preserve the original values if we round-trip
+    commands.newProperty(
+        "{}.otio.global_scale".format(transform_node),
+        commands.FloatType,
+        2
+    )
+    commands.newProperty(
+        "{}.otio.global_translate".format(transform_node),
+        commands.FloatType,
+        2
+    )
+    commands.setFloatProperty(
+        "{}.otio.global_scale".format(transform_node),
+        [global_scale.x, global_scale.y],
+        True
+    )
+    commands.setFloatProperty(
+        "{}.otio.global_translate".format(transform_node),
+        [global_translate.x, global_translate.y],
+        True
+    )
 
 
 def _add_metadata_to_node(item, rv_node):

--- a/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
+++ b/contrib/opentimelineio_contrib/application_plugins/tests/test_rv_reader.py
@@ -74,7 +74,22 @@ sample_timeline = otio.schema.Timeline(
     global_start_time=otio.opentime.RationalTime(1, 24)
 )
 track = otio.schema.Track('v1')
-for clipnum in range(1, 4):
+bounds = [
+    otio.schema.Box2d(
+        otio.schema.V2d(0.0, 0.0),
+        otio.schema.V2d(16.0, 9.0)
+    ),  # sets viewing area
+    otio.schema.Box2d(
+        otio.schema.V2d(8.0, 0),
+        otio.schema.V2d(24.0, 9.0)
+    ),  # shifted right by half the viewing area
+    otio.schema.Box2d(
+        otio.schema.V2d(0.0, 0.0),
+        otio.schema.V2d(8.0, 4.5)
+    )  # scale to 1/4 of viewing area (lower left)
+]
+
+for clipnum, box in zip(range(1, 4), bounds):
     clip_name = 'clip{n}'.format(n=clipnum)
     track.append(
         otio.schema.Clip(
@@ -84,7 +99,8 @@ for clipnum in range(1, 4):
                 available_range=otio.opentime.TimeRange(
                     otio.opentime.RationalTime(1, 24),
                     otio.opentime.RationalTime(50, 24)
-                )
+                ),
+                available_image_bounds=box
             ),
             source_range=otio.opentime.TimeRange(
                 otio.opentime.RationalTime(11, 24),
@@ -215,11 +231,30 @@ class RVSessionAdapterReadTest(unittest.TestCase):
             clip1 = rv_media_name_at_frame(rvc, 1)
             self.assertEqual(clip1, 'clip1.mov')
 
+            # note RV has a default res of 1280,720 when the media doesn't exist
+            aspect_ratio = 1280.0 / 720.0
+
+            clip1_scale, clip1_translate = rv_transform_at_frame(rvc, 1)
+            self.assertEqual(clip1_scale, [1.0, 1.0])
+            self.assertEqual(clip1_translate, [0.0, 0.0])
+
             clip2 = rv_media_name_at_frame(rvc, 4)
             self.assertEqual(clip2, 'clip2.mov')
 
+            clip2_scale, clip2_translate = rv_transform_at_frame(rvc, 4)
+            self.assertEqual(clip2_scale, [1.0, 1.0])
+
+            self.assertAlmostEqual(clip2_translate[0], 0.5 * aspect_ratio)
+            self.assertEqual(clip2_translate[1], 0)
+
             clip3 = rv_media_name_at_frame(rvc, 7)
             self.assertEqual(clip3, 'clip3.mov')
+
+            clip3_scale, clip3_translate = rv_transform_at_frame(rvc, 7)
+            self.assertEqual(clip3_scale, [0.5, 0.5])
+
+            self.assertAlmostEqual(clip3_translate[0], -0.25 * aspect_ratio)
+            self.assertEqual(clip3_translate[1], -0.25)
 
             rvc.disconnect()
 
@@ -255,17 +290,54 @@ def install_package(source_package_path):
     return rc
 
 
+def _exec_command(rvc, command, literal=True):
+    response = rvc.sendEventAndReturn("remote-pyeval", command)
+    return ast.literal_eval(response) if literal else response
+
+
+def _source_at_frame(rvc, frame):
+    return _exec_command(
+        rvc,
+        "rv.commands.sourcesAtFrame({0})".format(frame)
+    )[0]
+
+
 def rv_media_name_at_frame(rvc, frame):
-    command = "rv.commands.sourcesAtFrame({0})".format(frame)
-    source = rvc.sendEventAndReturn("remote-pyeval", command)
-    source_list = ast.literal_eval(source)
-    source_name = source_list[0]
+    source_name = _source_at_frame(rvc, frame)
+    return _exec_command(
+        rvc,
+        "rv.commands.sourceMedia('{0}')".format(source_name)
+    )[0]
 
-    command = "rv.commands.sourceMedia('{0}')".format(source_name)
-    media_string = rvc.sendEventAndReturn("remote-pyeval", command)
-    media = ast.literal_eval(media_string)[0]
 
-    return media
+def rv_transform_at_frame(rvc, frame):
+    source = _source_at_frame(rvc, frame)
+
+    source_group = _exec_command(
+        rvc,
+        """rv.commands.nodeGroup('{0}')""".format(source),
+        literal=False
+    )
+
+    transform = _exec_command(
+        rvc,
+        """rv.extra_commands.nodesInGroupOfType(
+            '{0}', 'RVTransform2D')""".format(source_group)
+    )[0]
+
+    scale = _exec_command(
+        rvc,
+        """rv.commands.getFloatProperty(
+            '{0}.transform.scale')""".format(transform)
+    )
+
+    translate = _exec_command(
+        rvc,
+        """rv.commands.getFloatProperty(
+            '{0}.transform.translate')""".format(transform)
+    )
+
+    return scale, translate
 
 
 if __name__ == '__main__':

--- a/docs/_static/spatial_coords_example1.svg
+++ b/docs/_static/spatial_coords_example1.svg
@@ -1,0 +1,60 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region -->
+    <rect x="0" y="-900" width="1600" height="900" />
+    <circle cx="0" cy="0" r="30" />
+    <circle cx="1600" cy="-900" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="0" y1="-450" x2="1600" y2="-450" stroke-width="30"/>
+    <polygon points="0,-450 50,-500 50,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="1600,-450 1550,-500 1550,-400" fill="#000000" stroke-width="0"/>
+
+    <line x1="800" y1="0" x2="800" y2="-900" stroke-width="30"/>
+    <polygon points="800,-900 750,-850 850,-850" fill="#000000" stroke-width="0"/>
+    <polygon points="800,0 750,-50 850,-50" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="8.0rem" font-weight="bold" text-anchor="end" dominant-baseline="hanging">
+    <text x="-25" y="25" >min = (0.0, 0.0)</text>
+    <text x="1675" y="-1100" >max = (16.0, 9.0)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="400" y="-500" >(Width=16.0)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="left" dominant-baseline="auto">
+    <text x="825" y="-650" >(Height=9.0)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_example2.svg
+++ b/docs/_static/spatial_coords_example2.svg
@@ -1,0 +1,60 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region -->
+    <rect x="-800" y="-450" width="1600" height="900" />
+    <circle cx="-800" cy="450" r="30" />
+    <circle cx="800" cy="-450" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="-800" y1="0" x2="800" y2="0" stroke-width="30"/>
+    <polygon points="-800,0 -750,-50 -750,50" fill="#000000" stroke-width="0"/>
+    <polygon points="800,0 750,-50 750,50" fill="#000000" stroke-width="0"/>
+
+    <line x1="0" y1="-450" x2="0" y2="450" stroke-width="30"/>
+    <polygon points="0,-450 -50,-400 50,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="0,450 -50,400 50,400" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="8.0rem" font-weight="bold" dominant-baseline="hanging">
+    <text x="-825" y="475" text-anchor="end">min = (-8.0, -4.5)</text>
+    <text x="825" y="-600" text-anchor="left">max = (8.0, 4.5)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="-400" y="-50" >(Width=16.0)</text>
+  </g>
+
+  <g font-size="6.0rem" font-weight="bold" text-anchor="left" dominant-baseline="auto">
+    <text x="25" y="-200" >(Height=9.0)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_example3.svg
+++ b/docs/_static/spatial_coords_example3.svg
@@ -1,0 +1,63 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region 1 -->
+    <rect x="-800" y="-450" width="1600" height="900" fill="#BBBBBB"/>
+
+    <!-- Bounds Region 2 -->
+    <rect x="-450" y="-450" width="900" height="900" />
+    <circle cx="-450" cy="450" r="30" />
+    <circle cx="450" cy="-450" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="-450" y1="0" x2="450" y2="0" stroke-width="30"/>
+    <polygon points="-450,0 -400,-50 -400,50" fill="#000000" stroke-width="0"/>
+    <polygon points="450,0 400,-50 400,50" fill="#000000" stroke-width="0"/>
+
+    <line x1="0" y1="-450" x2="0" y2="450" stroke-width="30"/>
+    <polygon points="0,-450 -50,-400 50,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="0,450 -50,400 50,400" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="8.0rem" font-weight="bold" dominant-baseline="hanging">
+    <text x="-425" y="500" text-anchor="end">min = (-4.5, -4.5)</text>
+    <text x="425" y="-600" text-anchor="left">max = (4.5, 4.5)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="-250" y="-50" >(Width=9.0)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="left" dominant-baseline="auto">
+    <text x="25" y="-200" >(Height=9.0)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_example4.svg
+++ b/docs/_static/spatial_coords_example4.svg
@@ -1,0 +1,66 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- DO-NOT-EDIT THIS SECTION, IT IS A COPY-PASTE FROM
+    spatial_coords_system.svg. SVG does not safely support svg recursion.
+  -->
+
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+
+  <!-- END OF DO-NOT-EDIT SECTION -->
+
+  <g fill="#AAFFAA" stroke="#000000" stroke-width="10">
+
+    <!-- Bounds Region 1 -->
+    <rect x="-800" y="-450" width="1600" height="900" fill="#BBBBBB"/>
+
+    <!-- Bounds Region 2 -->
+    <rect x="-450" y="-450" width="900" height="900" fill="#BBBBBB"/>
+
+    <!-- Bounds Region 3 -->
+    <rect x="400" y="-450" width="400" height="225" />
+    <circle cx="400" cy="-225" r="30" />
+    <circle cx="800" cy="-450" r="30" />
+
+    <!-- bounds width & height arrows -->
+    <line x1="400" y1="-337" x2="800" y2="-337" stroke-width="10"/>
+    <polygon points="400,-337 450,-357 450,-317" fill="#000000" stroke-width="0"/>
+    <polygon points="800,-337 750,-357 750,-317" fill="#000000" stroke-width="0"/>
+
+    <line x1="600" y1="-225" x2="600" y2="-450" stroke-width="10"/>
+    <polygon points="600,-450 580,-400 620,-400" fill="#000000" stroke-width="0"/>
+    <polygon points="600,-225 580,-275 620,-275" fill="#000000" stroke-width="0"/>
+
+  </g>
+  <g font-size="6.0rem" font-weight="bold" dominant-baseline="hanging">
+    <text x="400" y="-180" text-anchor="end">min = (4.0, 2.25)</text>
+    <text x="825" y="-600" text-anchor="left">max = (8.0, 4.5)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="middle" dominant-baseline="auto">
+    <text x="600" y="-480" >(Width=4.0)</text>
+  </g>
+
+  <g font-size="4.0rem" font-weight="bold" text-anchor="left" dominant-baseline="middle">
+    <text x="820" y="-337" >(Height=2.25)</text>
+  </g>
+
+</svg>

--- a/docs/_static/spatial_coords_system.svg
+++ b/docs/_static/spatial_coords_system.svg
@@ -1,0 +1,22 @@
+<svg width="1000" height="1000" viewBox="-2000 -2000 4000 4000" xmlns="http://www.w3.org/2000/svg">
+  <g fill="#DDDDDD">
+    <!-- grey background -->
+    <rect x="-2000" y="-2000" width="4000" height="4000" />
+  </g>
+  <g stroke="#000000" stroke-width="8">
+    <!-- x-axis -->
+    <line x1="-2000" y1="0" x2="2000" y2="0"/>
+    <polygon points="2000,0 1950,50 1950,-50" />
+    <!-- 7-axis -->
+    <line x1="0" y1="-2000" x2="0" y2="2000" />
+    <polygon points="0,-2000 50,-1950 -50,-1950" />
+
+    <!-- origin -->
+    <circle cx="0" cy="0" r="30" />
+  </g>
+  <g font-size="6.0rem" font-weight="bold" text-anchor="start">
+    <text x="75" y="-75" >(X=0.0, Y=0.0)</text>
+    <text x="1900" y="-75" >X</text>
+    <text x="75" y="-1900" >Y</text>
+  </g>
+</svg>

--- a/docs/tutorials/otio-serialized-schema-only-fields.md
+++ b/docs/tutorials/otio-serialized-schema-only-fields.md
@@ -61,6 +61,7 @@ parameters:
 ### MediaReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
 - *metadata*
 - *name*
@@ -151,6 +152,7 @@ parameters:
 ### ExternalReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
 - *metadata*
 - *name*
@@ -177,6 +179,7 @@ parameters:
 ### GeneratorReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
 - *generator_kind*
 - *metadata*
@@ -186,6 +189,7 @@ parameters:
 ### ImageSequenceReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
 - *frame_step*
 - *frame_zero_padding*
@@ -217,6 +221,7 @@ parameters:
 ### MissingReference.1
 
 parameters:
+- *available_image_bounds*
 - *available_range*
 - *metadata*
 - *name*

--- a/docs/tutorials/otio-serialized-schema.md
+++ b/docs/tutorials/otio-serialized-schema.md
@@ -115,6 +115,7 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
 - *metadata*: 
 - *name*: 
@@ -304,6 +305,7 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
 - *metadata*: 
 - *name*: 
@@ -354,6 +356,7 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
 - *generator_kind*: 
 - *metadata*: 
@@ -431,6 +434,7 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
 - *frame_step*: Step between frame numbers in file names.
 - *frame_zero_padding*: Number of digits to pad zeros out to in frame numbers.
@@ -486,6 +490,7 @@ None
 ```
 
 parameters:
+- *available_image_bounds*: 
 - *available_range*: 
 - *metadata*: 
 - *name*: 

--- a/docs/tutorials/spatial-coordinates.md
+++ b/docs/tutorials/spatial-coordinates.md
@@ -1,0 +1,83 @@
+# OTIO Spatial Coordinate System
+This document describes a proposed coordinate system for OpenTimelineIO. It focuses mainly on the Bounds object, which is a rectangular area represented through a 2D box within that coordinate system.  
+
+## Coordinate System
+The proposed spatial coordinate system is unit-less.  
+It allows decoupling clip layouts from pixel density.  
+It has a single origin (X=0.0, Y=0.0) and is used as a unique canvas across the whole Timeline.  
+Y-Axis-Up convention is used.  
+
+We propose in the OTIO spatial coordinate system that we use planes that are unique in the continuous domain in order to make it analogous to the existing temporal implementation.  Currently in a Composition of Items a RationalTime's value (usually a frame) index is seen as belonging to the Item that appears later in time.  For example, if we have two Items ranging from value 1 to value 2 and from value 2 to value 3, value 2 will belong to the second Item.  Or in other words, we are using exclusive temporal bounds such that the temporal spans are [1,2) and [2,3).
+
+In order to preserve the same logic in the spatial domain we require a plane that is unique in the continuous domain.  To use a similar example given a 2 dimensional bound from (0, 1), and another from (1, 2), we require that a sample at the value 1 falls strictly into one bound or the other, in particular, it should fall into the higher value bound (1,2) and not into (0, 1).
+
+![Coordinate System](../_static/spatial_coords_system.svg)
+## Bounds
+
+A Bounds object is a 2D box that defines a spatial area in the unit-less coordinate system.  
+Here is an example of Bounds defining a first-quadrant-snapped rectangle with a width of 16 and a height of 9.  
+Note that, since Bounds are serializable object, they have a metadata member.  
+```
+"available_image_bounds": {
+  "OTIO_SCHEMA": "Box2d.1",
+  "min": {
+    "OTIO_SCHEMA":"V2d.1",
+    "x": 0.0,
+    "y": 0.0
+  },
+  "max": {
+    "OTIO_SCHEMA":"V2d.1",
+    "x": 16.0,
+    "y": 9.0
+  }
+}
+```
+
+![Example 1](../_static/spatial_coords_example1.svg)  
+
+Here is another example of Bounds defining an origin-centered rectangle with a width of 16 and a height of 9.  
+```
+"available_image_bounds": {
+  "OTIO_SCHEMA": "Box2d.1",
+  "min": {
+    "OTIO_SCHEMA":"V2d.1",
+    "x": -8.0,
+    "y": -4.5
+  },
+  "max": {
+    "OTIO_SCHEMA":"V2d.1",
+    "x": 8.0,
+    "y": 4.5
+  }
+}
+```
+
+![Example 2](../_static/spatial_coords_example2.svg)
+
+When multiple clips are being rendered, either through a transition or through the presence of a multi-tracks timeline, all clips share the same coordinate system.  
+
+For instance, if we add an origin-centered square clip on top of the previous one, here is what we get.  
+
+![Example 3](../_static/spatial_coords_example3.svg)  
+
+Since each clip has its own bounds properties, clips can be arranged into complex layouts.  
+
+This can be used in several contexts, for instance:  
+
+-   Side-by-side comparison
+-   Picture-In-Picture
+-   Complex spatial layouts for notes (collage)
+
+Example of a Picture-In-Picture layout added on top of the previous 2-clips layout:  
+![Example 4](../_static/spatial_coords_example4.svg)  
+## Bounds and Clips
+Currently, we use the Bounds object at the ***Clip.media_reference.bounds*** level. This allows support for different bounds when changing the media-representation of a given Clip. For instance, a Clip could have 2 media-representations (a set of High-Res 16:9 OpenEXR files and a Low-Res 4:3 MP4 file). Those 2 media-representations might not cover the same spatial area, therefore it makes sense for them to have their individual Bounds region.  
+## Non-Bounds representations
+The coordinate system can also be used to describe non-rectangular coordinates. For instance, effects that have spatial-based parameters that need to be expressed in a resolution-independent way could use the same system.  
+
+Examples of potential usage for this coordinate system:  
+
+-   Blur amount
+-   Annotation position
+-   Wipe bar position (angular mask)
+

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # detect if the submodules haven't been updated
-set(DEPS_SUBMODULES any optional-lite pybind11 rapidjson)
+set(DEPS_SUBMODULES any optional-lite pybind11 rapidjson Imath)
 foreach(submodule IN LISTS DEPS_SUBMODULES)
     file(GLOB SUBMOD_CONTENTS ${submodule})
     list(LENGTH SUBMOD_CONTENTS SUBMOD_CONTENT_LEN)
@@ -22,3 +22,15 @@ if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
     install(FILES optional-lite/include/nonstd/optional.hpp
     	    DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio/deps/nonstd")
 endif()
+
+# preserve BUILD_SHARED_LIBS options for this project, but set it off for Imath
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+set(BUILD_SHARED_LIBS OFF)
+
+# If we do not want Imath to install headers and CMake files use the EXCLUDE_FROM_ALL option
+if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
+  add_subdirectory(Imath)
+else()
+  add_subdirectory(Imath EXCLUDE_FROM_ALL)
+endif()
+

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -82,7 +82,7 @@ target_include_directories(opentimelineio PRIVATE
                            "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
                            "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
 
-target_link_libraries(opentimelineio PUBLIC opentime)
+target_link_libraries(opentimelineio PUBLIC opentime Imath::Imath)
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
     LIBRARY_OUTPUT_NAME "opentimelineio"

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -72,17 +72,24 @@ Clip::available_range(ErrorStatus* error_status) const
     return _media_reference->available_range().value();
 }
 
-optional<Imath::Box2d> 
-Clip::available_image_bounds(ErrorStatus* error_status) const {
-    if (!_media_reference) {
-        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
-                                    "No image bounds set on clip", this);
+optional<Imath::Box2d>
+Clip::available_image_bounds(ErrorStatus* error_status) const
+{
+    if (!_media_reference)
+    {
+        *error_status = ErrorStatus(
+            ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+            "No image bounds set on clip",
+            this);
         return optional<Imath::Box2d>();
     }
 
-    if (!_media_reference.value->available_image_bounds()) {
-        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
-                                    "No image bounds set on media reference on clip", this);
+    if (!_media_reference.value->available_image_bounds())
+    {
+        *error_status = ErrorStatus(
+            ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+            "No image bounds set on media reference on clip",
+            this);
         return optional<Imath::Box2d>();
     }
 

--- a/src/opentimelineio/clip.cpp
+++ b/src/opentimelineio/clip.cpp
@@ -72,4 +72,21 @@ Clip::available_range(ErrorStatus* error_status) const
     return _media_reference->available_range().value();
 }
 
+optional<Imath::Box2d> 
+Clip::available_image_bounds(ErrorStatus* error_status) const {
+    if (!_media_reference) {
+        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+                                    "No image bounds set on clip", this);
+        return optional<Imath::Box2d>();
+    }
+
+    if (!_media_reference.value->available_image_bounds()) {
+        *error_status = ErrorStatus(ErrorStatus::CANNOT_COMPUTE_BOUNDS,
+                                    "No image bounds set on media reference on clip", this);
+        return optional<Imath::Box2d>();
+    }
+
+    return _media_reference.value->available_image_bounds();
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -30,6 +30,8 @@ public:
     virtual TimeRange
     available_range(ErrorStatus* error_status = nullptr) const;
 
+    virtual optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+
 protected:
     virtual ~Clip();
 

--- a/src/opentimelineio/clip.h
+++ b/src/opentimelineio/clip.h
@@ -30,7 +30,8 @@ public:
     virtual TimeRange
     available_range(ErrorStatus* error_status = nullptr) const;
 
-    virtual optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+    virtual optional<Imath::Box2d>
+    available_image_bounds(ErrorStatus* error_status) const;
 
 protected:
     virtual ~Clip();

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -68,8 +68,9 @@ Composable::duration(ErrorStatus* error_status) const
     return RationalTime();
 }
 
-optional<Imath::Box2d> 
-Composable::available_image_bounds(ErrorStatus* error_status) const {
+optional<Imath::Box2d>
+Composable::available_image_bounds(ErrorStatus* error_status) const
+{
     *error_status = ErrorStatus::NOT_IMPLEMENTED;
     return optional<Imath::Box2d>();
 }

--- a/src/opentimelineio/composable.cpp
+++ b/src/opentimelineio/composable.cpp
@@ -68,4 +68,10 @@ Composable::duration(ErrorStatus* error_status) const
     return RationalTime();
 }
 
+optional<Imath::Box2d> 
+Composable::available_image_bounds(ErrorStatus* error_status) const {
+    *error_status = ErrorStatus::NOT_IMPLEMENTED;
+    return optional<Imath::Box2d>();
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -3,8 +3,10 @@
 #include "opentimelineio/serializableObjectWithMetadata.h"
 #include "opentimelineio/version.h"
 
-namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+#include <ImathBox.h>
 
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
+    
 class Composition;
 
 class Composable : public SerializableObjectWithMetadata
@@ -28,6 +30,8 @@ public:
     Composition* parent() const { return _parent; }
 
     virtual RationalTime duration(ErrorStatus* error_status = nullptr) const;
+
+    virtual optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
 
 protected:
     bool        _set_parent(Composition*) noexcept;

--- a/src/opentimelineio/composable.h
+++ b/src/opentimelineio/composable.h
@@ -5,8 +5,8 @@
 
 #include <ImathBox.h>
 
-namespace opentimelineio { namespace OPENTIMELINEIO_VERSION  {
-    
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
 class Composition;
 
 class Composable : public SerializableObjectWithMetadata
@@ -31,7 +31,8 @@ public:
 
     virtual RationalTime duration(ErrorStatus* error_status = nullptr) const;
 
-    virtual optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+    virtual optional<Imath::Box2d>
+    available_image_bounds(ErrorStatus* error_status) const;
 
 protected:
     bool        _set_parent(Composition*) noexcept;

--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -1,5 +1,6 @@
 #include "opentimelineio/composition.h"
 #include "opentimelineio/vectorIndexing.h"
+#include "opentimelineio/clip.h"
 
 #include <assert.h>
 #include <set>
@@ -668,6 +669,20 @@ Composition::_bisect_left(
     }
 
     return *lower_search_bound;
+}
+
+bool Composition::has_clips() const {
+    for (auto child: children()) {
+        if (dynamic_cast<Clip*>(child.value)) {
+            return true;
+        }
+        else if (auto child_comp = dynamic_cast<Composition*>(child.value)) {
+            if( child_comp->has_clips() ) {
+               return true;
+            }
+        }
+    }
+    return false;
 }
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/composition.cpp
+++ b/src/opentimelineio/composition.cpp
@@ -1,6 +1,6 @@
 #include "opentimelineio/composition.h"
-#include "opentimelineio/vectorIndexing.h"
 #include "opentimelineio/clip.h"
+#include "opentimelineio/vectorIndexing.h"
 
 #include <assert.h>
 #include <set>
@@ -671,14 +671,20 @@ Composition::_bisect_left(
     return *lower_search_bound;
 }
 
-bool Composition::has_clips() const {
-    for (auto child: children()) {
-        if (dynamic_cast<Clip*>(child.value)) {
+bool
+Composition::has_clips() const
+{
+    for (auto child: children())
+    {
+        if (dynamic_cast<Clip*>(child.value))
+        {
             return true;
         }
-        else if (auto child_comp = dynamic_cast<Composition*>(child.value)) {
-            if( child_comp->has_clips() ) {
-               return true;
+        else if (auto child_comp = dynamic_cast<Composition*>(child.value))
+        {
+            if (child_comp->has_clips())
+            {
+                return true;
             }
         }
     }

--- a/src/opentimelineio/composition.h
+++ b/src/opentimelineio/composition.h
@@ -71,6 +71,8 @@ public:
 
     bool has_child(Composable* child) const;
 
+    bool has_clips() const;
+
     virtual std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const;
 

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -591,7 +591,17 @@ SerializableObject::Reader::_decode(_Resolver& resolver)
 
         return any(SerializableObject::ReferenceId{ ref_id });
     }
-    else
+    else if (schema_name_and_version == "V2d.1") {
+        double x,y;
+        return _fetch("x", &x) && _fetch("y", &y) ? 
+            any(Imath::V2d(x,y)) : any();
+    }
+    else if (schema_name_and_version == "Box2d.1") {
+        Imath::V2d min, max; 
+        return _fetch("min", &min) && _fetch("max", &max) ? 
+            any(Imath::Box2d(std::move(min), std::move(max))) : any();
+    }
+    else 
     {
         std::string ref_id;
         if (_dict.find("OTIO_REF_ID") != _dict.end())
@@ -711,6 +721,14 @@ SerializableObject::Reader::read(std::string const& key, AnyVector* value)
     return _fetch(key, value);
 }
 
+bool SerializableObject::Reader::read(std::string const& key, Imath::V2d* value) {
+    return _fetch(key, value);
+}
+
+bool SerializableObject::Reader::read(std::string const& key, Imath::Box2d* value) {
+    return _fetch(key, value);
+}
+
 template <typename T>
 bool
 SerializableObject::Reader::_read_optional(
@@ -766,8 +784,13 @@ SerializableObject::Reader::read(
     return _read_optional(key, value);
 }
 
-bool
-SerializableObject::Reader::read(std::string const& key, any* value)
+bool 
+SerializableObject::Reader::read(std::string const& key, optional<Imath::Box2d>* value) {
+    return _read_optional(key, value);
+}
+
+bool 
+SerializableObject::Reader::read(std::string const& key, any* value) 
 {
     auto e = _dict.find(key);
     if (e == _dict.end())

--- a/src/opentimelineio/deserialization.cpp
+++ b/src/opentimelineio/deserialization.cpp
@@ -591,17 +591,20 @@ SerializableObject::Reader::_decode(_Resolver& resolver)
 
         return any(SerializableObject::ReferenceId{ ref_id });
     }
-    else if (schema_name_and_version == "V2d.1") {
-        double x,y;
-        return _fetch("x", &x) && _fetch("y", &y) ? 
-            any(Imath::V2d(x,y)) : any();
+    else if (schema_name_and_version == "V2d.1")
+    {
+        double x, y;
+        return _fetch("x", &x) && _fetch("y", &y) ? any(Imath::V2d(x, y))
+                                                  : any();
     }
-    else if (schema_name_and_version == "Box2d.1") {
-        Imath::V2d min, max; 
-        return _fetch("min", &min) && _fetch("max", &max) ? 
-            any(Imath::Box2d(std::move(min), std::move(max))) : any();
+    else if (schema_name_and_version == "Box2d.1")
+    {
+        Imath::V2d min, max;
+        return _fetch("min", &min) && _fetch("max", &max)
+                   ? any(Imath::Box2d(std::move(min), std::move(max)))
+                   : any();
     }
-    else 
+    else
     {
         std::string ref_id;
         if (_dict.find("OTIO_REF_ID") != _dict.end())
@@ -721,11 +724,15 @@ SerializableObject::Reader::read(std::string const& key, AnyVector* value)
     return _fetch(key, value);
 }
 
-bool SerializableObject::Reader::read(std::string const& key, Imath::V2d* value) {
+bool
+SerializableObject::Reader::read(std::string const& key, Imath::V2d* value)
+{
     return _fetch(key, value);
 }
 
-bool SerializableObject::Reader::read(std::string const& key, Imath::Box2d* value) {
+bool
+SerializableObject::Reader::read(std::string const& key, Imath::Box2d* value)
+{
     return _fetch(key, value);
 }
 
@@ -784,13 +791,15 @@ SerializableObject::Reader::read(
     return _read_optional(key, value);
 }
 
-bool 
-SerializableObject::Reader::read(std::string const& key, optional<Imath::Box2d>* value) {
+bool
+SerializableObject::Reader::read(
+    std::string const& key, optional<Imath::Box2d>* value)
+{
     return _read_optional(key, value);
 }
 
-bool 
-SerializableObject::Reader::read(std::string const& key, any* value) 
+bool
+SerializableObject::Reader::read(std::string const& key, any* value)
 {
     auto e = _dict.find(key);
     if (e == _dict.end())
@@ -860,7 +869,7 @@ deserialize_json_from_file(
     {
         fp = nullptr;
     }
-#else  // _WINDOWS
+#else // _WINDOWS
     fp = fopen(file_name.c_str(), "r");
 #endif // _WINDOWS
     if (!fp)

--- a/src/opentimelineio/errorStatus.cpp
+++ b/src/opentimelineio/errorStatus.cpp
@@ -55,6 +55,8 @@ ErrorStatus::outcome_to_string(Outcome o)
             return "cannot compute duration on this type of object";
         case CANNOT_TRIM_TRANSITION:
             return "cannot trim transition";
+        case CANNOT_COMPUTE_BOUNDS:
+            return "cannot compute image bounds";
         default:
             return "unknown/illegal ErrorStatus::Outcome code";
     };

--- a/src/opentimelineio/errorStatus.h
+++ b/src/opentimelineio/errorStatus.h
@@ -35,7 +35,8 @@ struct ErrorStatus
         INVALID_TIME_RANGE,
         OBJECT_WITHOUT_DURATION,
         CANNOT_TRIM_TRANSITION,
-        OBJECT_CYCLE
+        OBJECT_CYCLE,
+        CANNOT_COMPUTE_BOUNDS
     };
 
     ErrorStatus()

--- a/src/opentimelineio/externalReference.cpp
+++ b/src/opentimelineio/externalReference.cpp
@@ -3,10 +3,11 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 ExternalReference::ExternalReference(
-    std::string const&         target_url,
-    optional<TimeRange> const& available_range,
-    AnyDictionary const&       metadata)
-    : Parent(std::string(), available_range, metadata)
+    std::string const&            target_url,
+    optional<TimeRange> const&    available_range,
+    AnyDictionary const&          metadata,
+    optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(std::string(), available_range, metadata, available_image_bounds)
     , _target_url(target_url)
 {}
 

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -22,7 +22,6 @@ public:
         AnyDictionary const&          metadata               = AnyDictionary(),
         optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
-
     std::string target_url() const noexcept { return _target_url; }
 
     void set_target_url(std::string const& target_url)

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -20,7 +20,7 @@ public:
         std::string const&            target_url             = std::string(),
         optional<TimeRange> const&    available_range        = nullopt,
         AnyDictionary const&          metadata               = AnyDictionary(),
-        optional<imath::box2d> const& available_image_bounds = nullopt);
+        optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
 
     std::string target_url() const noexcept { return _target_url; }

--- a/src/opentimelineio/externalReference.h
+++ b/src/opentimelineio/externalReference.h
@@ -17,9 +17,11 @@ public:
     using Parent = MediaReference;
 
     ExternalReference(
-        std::string const&         target_url      = std::string(),
-        optional<TimeRange> const& available_range = nullopt,
-        AnyDictionary const&       metadata        = AnyDictionary());
+        std::string const&            target_url             = std::string(),
+        optional<TimeRange> const&    available_range        = nullopt,
+        AnyDictionary const&          metadata               = AnyDictionary(),
+        optional<imath::box2d> const& available_image_bounds = nullopt);
+
 
     std::string target_url() const noexcept { return _target_url; }
 

--- a/src/opentimelineio/generatorReference.cpp
+++ b/src/opentimelineio/generatorReference.cpp
@@ -3,12 +3,13 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 GeneratorReference::GeneratorReference(
-    std::string const&         name,
-    std::string const&         generator_kind,
-    optional<TimeRange> const& available_range,
-    AnyDictionary const&       parameters,
-    AnyDictionary const&       metadata)
-    : Parent(name, available_range, metadata)
+    std::string const&            name,
+    std::string const&            generator_kind,
+    optional<TimeRange> const&    available_range,
+    AnyDictionary const&          parameters,
+    AnyDictionary const&          metadata,
+    optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(name, available_range, metadata, available_image_bounds)
     , _generator_kind(generator_kind)
     , _parameters(parameters)
 {}

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -17,11 +17,12 @@ public:
     using Parent = MediaReference;
 
     GeneratorReference(
-        std::string const&         name            = std::string(),
-        std::string const&         generator_kind  = std::string(),
-        optional<TimeRange> const& available_range = nullopt,
-        AnyDictionary const&       parameters      = AnyDictionary(),
-        AnyDictionary const&       metadata        = AnyDictionary());
+        std::string const&            name                   = std::string(),
+        std::string const&            generator_kind         = std::string(),
+        optional<TimeRange> const&    available_range        = nullopt,
+        AnyDictionary const&          parameters             = AnyDictionary(),
+        AnyDictionary const&          metadata               = AnyDictionary(),
+        optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
     std::string generator_kind() const noexcept { return _generator_kind; }
 

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -12,8 +12,9 @@ ImageSequenceReference::ImageSequenceReference(
     int                        frame_zero_padding,
     MissingFramePolicy const   missing_frame_policy,
     optional<TimeRange> const& available_range,
-    AnyDictionary const&       metadata)
-    : Parent(std::string(), available_range, metadata)
+    AnyDictionary const&       metadata,
+    optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(std::string(), available_range, metadata, available_image_bounds)
     , _target_url_base(target_url_base)
     , _name_prefix(name_prefix)
     , _name_suffix(name_suffix)

--- a/src/opentimelineio/imageSequenceReference.cpp
+++ b/src/opentimelineio/imageSequenceReference.cpp
@@ -3,16 +3,16 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 ImageSequenceReference::ImageSequenceReference(
-    std::string const&         target_url_base,
-    std::string const&         name_prefix,
-    std::string const&         name_suffix,
-    int                        start_frame,
-    int                        frame_step,
-    double                     rate,
-    int                        frame_zero_padding,
-    MissingFramePolicy const   missing_frame_policy,
-    optional<TimeRange> const& available_range,
-    AnyDictionary const&       metadata,
+    std::string const&            target_url_base,
+    std::string const&            name_prefix,
+    std::string const&            name_suffix,
+    int                           start_frame,
+    int                           frame_step,
+    double                        rate,
+    int                           frame_zero_padding,
+    MissingFramePolicy const      missing_frame_policy,
+    optional<TimeRange> const&    available_range,
+    AnyDictionary const&          metadata,
     optional<Imath::Box2d> const& available_image_bounds)
     : Parent(std::string(), available_range, metadata, available_image_bounds)
     , _target_url_base(target_url_base)

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -24,17 +24,18 @@ public:
     using Parent = MediaReference;
 
     ImageSequenceReference(
-        std::string const&       target_url_base    = std::string(),
-        std::string const&       name_prefix        = std::string(),
-        std::string const&       name_suffix        = std::string(),
-        int                      start_frame        = 1,
-        int                      frame_step         = 1,
-        double                   rate               = 1,
-        int                      frame_zero_padding = 0,
+        std::string const&            target_url_base        = std::string(),
+        std::string const&            name_prefix            = std::string(),
+        std::string const&            name_suffix            = std::string(),
+        int                           start_frame            = 1,
+        int                           frame_step             = 1,
+        double                        rate                   = 1,
+        int                           frame_zero_padding     = 0,
         MissingFramePolicy const missing_frame_policy =
             MissingFramePolicy::error,
-        optional<TimeRange> const& available_range = nullopt,
-        AnyDictionary const&       metadata        = AnyDictionary());
+        optional<TimeRange> const&    available_range        = nullopt,
+        AnyDictionary const&          metadata               = AnyDictionary(),
+        optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
     std::string target_url_base() const noexcept { return _target_url_base; }
 

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -24,13 +24,13 @@ public:
     using Parent = MediaReference;
 
     ImageSequenceReference(
-        std::string const&            target_url_base        = std::string(),
-        std::string const&            name_prefix            = std::string(),
-        std::string const&            name_suffix            = std::string(),
-        int                           start_frame            = 1,
-        int                           frame_step             = 1,
-        double                        rate                   = 1,
-        int                           frame_zero_padding     = 0,
+        std::string const&       target_url_base    = std::string(),
+        std::string const&       name_prefix        = std::string(),
+        std::string const&       name_suffix        = std::string(),
+        int                      start_frame        = 1,
+        int                      frame_step         = 1,
+        double                   rate               = 1,
+        int                      frame_zero_padding = 0,
         MissingFramePolicy const missing_frame_policy =
             MissingFramePolicy::error,
         optional<TimeRange> const&    available_range        = nullopt,

--- a/src/opentimelineio/item.h
+++ b/src/opentimelineio/item.h
@@ -32,13 +32,10 @@ public:
 
     virtual bool visible() const;
     virtual bool overlapping() const;
-    
+
     bool enabled() const { return _enabled; };
 
-    void set_enabled(bool enabled)
-    {
-        _enabled = enabled;
-    }
+    void set_enabled(bool enabled) { _enabled = enabled; }
 
     optional<TimeRange> source_range() const noexcept { return _source_range; }
 

--- a/src/opentimelineio/mediaReference.cpp
+++ b/src/opentimelineio/mediaReference.cpp
@@ -3,11 +3,13 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 MediaReference::MediaReference(
-    std::string const&         name,
-    optional<TimeRange> const& available_range,
-    AnyDictionary const&       metadata)
+    std::string const&            name,
+    optional<TimeRange> const&    available_range,
+    AnyDictionary const&          metadata,
+    optional<Imath::Box2d> const& available_image_bounds)
     : Parent(name, metadata)
     , _available_range(available_range)
+    , _available_image_bounds(available_image_bounds)
 {}
 
 MediaReference::~MediaReference()
@@ -23,6 +25,7 @@ bool
 MediaReference::read_from(Reader& reader)
 {
     return reader.read_if_present("available_range", &_available_range) &&
+           reader.read_if_present("available_image_bounds", &_available_image_bounds) &&
            Parent::read_from(reader);
 }
 
@@ -31,6 +34,7 @@ MediaReference::write_to(Writer& writer) const
 {
     Parent::write_to(writer);
     writer.write("available_range", _available_range);
+    writer.write("available_image_bounds", _available_image_bounds);
 }
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/mediaReference.cpp
+++ b/src/opentimelineio/mediaReference.cpp
@@ -25,7 +25,8 @@ bool
 MediaReference::read_from(Reader& reader)
 {
     return reader.read_if_present("available_range", &_available_range) &&
-           reader.read_if_present("available_image_bounds", &_available_image_bounds) &&
+           reader.read_if_present(
+               "available_image_bounds", &_available_image_bounds) &&
            Parent::read_from(reader);
 }
 

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -3,6 +3,8 @@
 #include "opentimelineio/serializableObjectWithMetadata.h"
 #include "opentimelineio/version.h"
 
+#include <ImathBox.h>
+
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 using namespace opentime;
@@ -19,9 +21,10 @@ public:
     using Parent = SerializableObjectWithMetadata;
 
     MediaReference(
-        std::string const&         name            = std::string(),
-        optional<TimeRange> const& available_range = nullopt,
-        AnyDictionary const&       metadata        = AnyDictionary());
+        std::string const&            name                   = std::string(),
+        optional<TimeRange> const&    available_range        = nullopt,
+        AnyDictionary const&          metadata               = AnyDictionary(),
+        optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
     optional<TimeRange> available_range() const noexcept
     {
@@ -34,6 +37,14 @@ public:
     }
 
     virtual bool is_missing_reference() const;
+   
+    optional<Imath::Box2d> available_image_bounds() const {
+        return _available_image_bounds;
+    }
+
+    void set_available_image_bounds(optional<Imath::Box2d> const& available_image_bounds) {
+        _available_image_bounds = available_image_bounds;
+    } 
 
 protected:
     virtual ~MediaReference();
@@ -43,6 +54,7 @@ protected:
 
 private:
     optional<TimeRange> _available_range;
+    optional<Imath::Box2d> _available_image_bounds;
 };
 
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/mediaReference.h
+++ b/src/opentimelineio/mediaReference.h
@@ -37,14 +37,17 @@ public:
     }
 
     virtual bool is_missing_reference() const;
-   
-    optional<Imath::Box2d> available_image_bounds() const {
+
+    optional<Imath::Box2d> available_image_bounds() const
+    {
         return _available_image_bounds;
     }
 
-    void set_available_image_bounds(optional<Imath::Box2d> const& available_image_bounds) {
+    void set_available_image_bounds(
+        optional<Imath::Box2d> const& available_image_bounds)
+    {
         _available_image_bounds = available_image_bounds;
-    } 
+    }
 
 protected:
     virtual ~MediaReference();
@@ -53,7 +56,7 @@ protected:
     virtual void write_to(Writer&) const;
 
 private:
-    optional<TimeRange> _available_range;
+    optional<TimeRange>    _available_range;
     optional<Imath::Box2d> _available_image_bounds;
 };
 

--- a/src/opentimelineio/missingReference.cpp
+++ b/src/opentimelineio/missingReference.cpp
@@ -3,10 +3,11 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 MissingReference::MissingReference(
-    std::string const&         name,
-    optional<TimeRange> const& available_range,
-    AnyDictionary const&       metadata)
-    : Parent(name, available_range, metadata)
+    std::string const&            name,
+    optional<TimeRange> const&    available_range,
+    AnyDictionary const&          metadata,
+    optional<Imath::Box2d> const& available_image_bounds)
+    : Parent(name, available_range, metadata, available_image_bounds)
 {}
 
 MissingReference::~MissingReference()

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -17,9 +17,10 @@ public:
     using Parent = MediaReference;
 
     MissingReference(
-        std::string const&         name            = std::string(),
-        optional<TimeRange> const& available_range = nullopt,
-        AnyDictionary const&       metadata        = AnyDictionary());
+        std::string const&            name                   = std::string(),
+        optional<TimeRange> const&    available_range        = nullopt,
+        AnyDictionary const&          metadata               = AnyDictionary(),
+        optional<Imath::Box2d> const& available_image_bounds = nullopt);
 
     virtual bool is_missing_reference() const;
 

--- a/src/opentimelineio/multiMediaReference.cpp
+++ b/src/opentimelineio/multiMediaReference.cpp
@@ -3,8 +3,7 @@
 namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 
 MultiMediaReference::MultiMediaReference(
-    std::string const&         name,
-    AnyDictionary const&       metadata)
+    std::string const& name, AnyDictionary const& metadata)
     : Parent(name, metadata)
     , _available_range(available_range)
 {}
@@ -12,14 +11,14 @@ MultiMediaReference::MultiMediaReference(
 MultiMediaReference::~MultiMediaReference()
 {}
 
-optional<TimeRange> MultiMediaReference::available_range() const noexcept final{
+optional<TimeRange>
+MultiMediaReference::available_range() const noexcept final
+{}
 
-}
-
-void MultiMediaReference::set_available_range(optional<TimeRange> const& available_range) final
-{
-
-}
+void
+MultiMediaReference::set_available_range(
+    optional<TimeRange> const& available_range) final
+{}
 
 bool
 MultiMediaReference::read_from(Reader& reader)

--- a/src/opentimelineio/multiMediaReference.cpp
+++ b/src/opentimelineio/multiMediaReference.cpp
@@ -1,0 +1,38 @@
+#include "opentimelineio/mediaReference.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+MultiMediaReference::MultiMediaReference(
+    std::string const&         name,
+    AnyDictionary const&       metadata)
+    : Parent(name, metadata)
+    , _available_range(available_range)
+{}
+
+MultiMediaReference::~MultiMediaReference()
+{}
+
+optional<TimeRange> MultiMediaReference::available_range() const noexcept final{
+
+}
+
+void MultiMediaReference::set_available_range(optional<TimeRange> const& available_range) final
+{
+
+}
+
+bool
+MultiMediaReference::read_from(Reader& reader)
+{
+    return reader.read_if_present("available_range", &_available_range) &&
+           Parent::read_from(reader);
+}
+
+void
+MultiMediaReference::write_to(Writer& writer) const
+{
+    Parent::write_to(writer);
+    writer.write("available_range", _available_range);
+}
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/multiMediaReference.h
+++ b/src/opentimelineio/multiMediaReference.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "opentimelineio/mediaReference.h"
+#include "opentimelineio/version.h"
+
+namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
+
+class MultiMediaReference final : public MediaReference
+{
+    using References = std::vector<Retainer<MediaReference>>;
+public:
+    struct Schema
+    {
+        static auto constexpr name   = "MultiMediaReference";
+        static int constexpr version = 1;
+    };
+
+    using Parent = MediaReference;
+
+    MultiMediaReference(
+        std::string const&         name            = std::string(),
+        AnyDictionary const&       metadata        = AnyDictionary());
+
+    optional<TimeRange> available_range() const noexcept final;
+
+    void set_available_range(optional<TimeRange> const& available_range) final;
+
+protected:
+    virtual ~MultiMediaReference();
+
+    virtual bool read_from(Reader&);
+    virtual void write_to(Writer&) const;
+
+private:
+    References _references;
+};
+
+}} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/multiMediaReference.h
+++ b/src/opentimelineio/multiMediaReference.h
@@ -8,6 +8,7 @@ namespace opentimelineio { namespace OPENTIMELINEIO_VERSION {
 class MultiMediaReference final : public MediaReference
 {
     using References = std::vector<Retainer<MediaReference>>;
+
 public:
     struct Schema
     {
@@ -18,8 +19,8 @@ public:
     using Parent = MediaReference;
 
     MultiMediaReference(
-        std::string const&         name            = std::string(),
-        AnyDictionary const&       metadata        = AnyDictionary());
+        std::string const&   name     = std::string(),
+        AnyDictionary const& metadata = AnyDictionary());
 
     optional<TimeRange> available_range() const noexcept final;
 

--- a/src/opentimelineio/safely_typed_any.cpp
+++ b/src/opentimelineio/safely_typed_any.cpp
@@ -56,18 +56,21 @@ create_safely_typed_any(TimeTransform&& value)
     return any(value);
 }
 
-any 
-create_safely_typed_any(Imath::V2d&& value) {
+any
+create_safely_typed_any(Imath::V2d&& value)
+{
     return any(value);
 }
 
-any 
-create_safely_typed_any(Imath::Box2d&& value) {
+any
+create_safely_typed_any(Imath::Box2d&& value)
+{
     return any(value);
 }
 
-any 
-create_safely_typed_any(AnyVector&& value) {
+any
+create_safely_typed_any(AnyVector&& value)
+{
     return any(std::move(value));
 }
 
@@ -137,18 +140,21 @@ safely_cast_time_transform_any(any const& a)
     return any_cast<TimeTransform>(a);
 }
 
-Imath::V2d 
-safely_cast_point_any(any const& a) {
+Imath::V2d
+safely_cast_point_any(any const& a)
+{
     return any_cast<Imath::V2d>(a);
 }
 
-Imath::Box2d 
-safely_cast_box_any(any const& a) {
+Imath::Box2d
+safely_cast_box_any(any const& a)
+{
     return any_cast<Imath::Box2d>(a);
 }
 
-AnyDictionary 
-safely_cast_any_dictionary_any(any const& a) {
+AnyDictionary
+safely_cast_any_dictionary_any(any const& a)
+{
     return any_cast<AnyDictionary>(a);
 }
 

--- a/src/opentimelineio/safely_typed_any.cpp
+++ b/src/opentimelineio/safely_typed_any.cpp
@@ -56,9 +56,18 @@ create_safely_typed_any(TimeTransform&& value)
     return any(value);
 }
 
-any
-create_safely_typed_any(AnyVector&& value)
-{
+any 
+create_safely_typed_any(Imath::V2d&& value) {
+    return any(value);
+}
+
+any 
+create_safely_typed_any(Imath::Box2d&& value) {
+    return any(value);
+}
+
+any 
+create_safely_typed_any(AnyVector&& value) {
     return any(std::move(value));
 }
 
@@ -128,9 +137,18 @@ safely_cast_time_transform_any(any const& a)
     return any_cast<TimeTransform>(a);
 }
 
-AnyDictionary
-safely_cast_any_dictionary_any(any const& a)
-{
+Imath::V2d 
+safely_cast_point_any(any const& a) {
+    return any_cast<Imath::V2d>(a);
+}
+
+Imath::Box2d 
+safely_cast_box_any(any const& a) {
+    return any_cast<Imath::Box2d>(a);
+}
+
+AnyDictionary 
+safely_cast_any_dictionary_any(any const& a) {
     return any_cast<AnyDictionary>(a);
 }
 

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -39,17 +39,17 @@ any create_safely_typed_any(AnyVector&&);
 any create_safely_typed_any(AnyDictionary&&);
 any create_safely_typed_any(SerializableObject*);
 
-bool                safely_cast_bool_any(any const& a);
-int                 safely_cast_int_any(any const& a);
-int64_t             safely_cast_int64_any(any const& a);
-uint64_t            safely_cast_uint64_any(any const& a);
-double              safely_cast_double_any(any const& a);
-std::string         safely_cast_string_any(any const& a);
-RationalTime        safely_cast_rational_time_any(any const& a);
-TimeRange           safely_cast_time_range_any(any const& a);
-TimeTransform       safely_cast_time_transform_any(any const& a);
-Imath::V2d          safely_cast_point_any(any const& a);
-Imath::Box2d        safely_cast_box_any(any const& a);
+bool          safely_cast_bool_any(any const& a);
+int           safely_cast_int_any(any const& a);
+int64_t       safely_cast_int64_any(any const& a);
+uint64_t      safely_cast_uint64_any(any const& a);
+double        safely_cast_double_any(any const& a);
+std::string   safely_cast_string_any(any const& a);
+RationalTime  safely_cast_rational_time_any(any const& a);
+TimeRange     safely_cast_time_range_any(any const& a);
+TimeTransform safely_cast_time_transform_any(any const& a);
+Imath::V2d    safely_cast_point_any(any const& a);
+Imath::Box2d  safely_cast_box_any(any const& a);
 
 SerializableObject* safely_cast_retainer_any(any const& a);
 

--- a/src/opentimelineio/safely_typed_any.h
+++ b/src/opentimelineio/safely_typed_any.h
@@ -33,6 +33,8 @@ any create_safely_typed_any(std::string&&);
 any create_safely_typed_any(RationalTime&&);
 any create_safely_typed_any(TimeRange&&);
 any create_safely_typed_any(TimeTransform&&);
+any create_safely_typed_any(Imath::V2d&&);
+any create_safely_typed_any(Imath::Box2d&&);
 any create_safely_typed_any(AnyVector&&);
 any create_safely_typed_any(AnyDictionary&&);
 any create_safely_typed_any(SerializableObject*);
@@ -46,6 +48,9 @@ std::string         safely_cast_string_any(any const& a);
 RationalTime        safely_cast_rational_time_any(any const& a);
 TimeRange           safely_cast_time_range_any(any const& a);
 TimeTransform       safely_cast_time_transform_any(any const& a);
+Imath::V2d          safely_cast_point_any(any const& a);
+Imath::Box2d        safely_cast_box_any(any const& a);
+
 SerializableObject* safely_cast_retainer_any(any const& a);
 
 AnyDictionary safely_cast_any_dictionary_any(any const& a);

--- a/src/opentimelineio/serializableObject.h
+++ b/src/opentimelineio/serializableObject.h
@@ -10,6 +10,8 @@
 #include "opentimelineio/typeRegistry.h"
 #include "opentimelineio/version.h"
 
+#include <ImathBox.h>
+
 #include <list>
 #include <type_traits>
 
@@ -83,6 +85,8 @@ public:
         bool read(std::string const& key, RationalTime* dest);
         bool read(std::string const& key, TimeRange* dest);
         bool read(std::string const& key, class TimeTransform* dest);
+        bool read(std::string const& key, Imath::V2d* value);
+        bool read(std::string const& key, Imath::Box2d* value);
         bool read(std::string const& key, AnyVector* dest);
         bool read(std::string const& key, AnyDictionary* dest);
         bool read(std::string const& key, any* dest);
@@ -93,6 +97,8 @@ public:
         bool read(std::string const& key, optional<RationalTime>* dest);
         bool read(std::string const& key, optional<TimeRange>* dest);
         bool read(std::string const& key, optional<TimeTransform>* dest);
+        bool read(std::string const& key, optional<Imath::Box2d>* value);
+
         // skipping std::string because we translate null into the empty
         // string, so the conversion is somewhat ambiguous
 
@@ -393,8 +399,11 @@ public:
         void write(std::string const& key, std::string const& value);
         void write(std::string const& key, RationalTime value);
         void write(std::string const& key, TimeRange value);
+        void write(std::string const& key, Imath::V2d value);
+        void write(std::string const& key, Imath::Box2d value);
         void write(std::string const& key, optional<RationalTime> value);
         void write(std::string const& key, optional<TimeRange> value);
+        void write(std::string const& key, optional<Imath::Box2d> value);
         void write(std::string const& key, class TimeTransform value);
         void write(std::string const& key, SerializableObject const* value);
         void write(std::string const& key, SerializableObject* value)

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -66,7 +66,7 @@ public:
     virtual void write_value(class TimeRange const& value)           = 0;
     virtual void write_value(class TimeTransform const& value)       = 0;
     virtual void write_value(struct SerializableObject::ReferenceId) = 0;
-    virtual void write_value(Imath::Box2d const&) = 0;
+    virtual void write_value(Imath::Box2d const&)                    = 0;
 
 protected:
     void _error(ErrorStatus const& error_status)
@@ -167,9 +167,9 @@ public:
 
     void write_value(Imath::Box2d const& value) { _store(any(value)); }
 
-    void start_array(size_t /* n */) 
+    void start_array(size_t /* n */)
     {
-        if (has_errored()) 
+        if (has_errored())
         {
             return;
         }
@@ -377,7 +377,7 @@ public:
         _writer.EndObject();
     }
 
-    void write_value(Imath::V2d const& value) 
+    void write_value(Imath::V2d const& value)
     {
         _writer.StartObject();
 
@@ -393,7 +393,7 @@ public:
         _writer.EndObject();
     }
 
-    void write_value(Imath::Box2d const& value) 
+    void write_value(Imath::Box2d const& value)
     {
         _writer.StartObject();
 
@@ -410,7 +410,7 @@ public:
     }
 
     void start_array(size_t) { _writer.StartArray(); }
-    
+
     void start_object() { _writer.StartObject(); }
 
     void end_array() { _writer.EndArray(); }
@@ -477,11 +477,11 @@ SerializableObject::Writer::_build_dispatch_tables()
     wt[&typeid(TimeTransform)] = [this](any const& value) {
         _encoder.write_value(any_cast<TimeTransform const&>(value));
     };
-    wt[&typeid(Imath::V2d)] = [this](any const& value) { 
-        _encoder.write_value(any_cast<Imath::V2d const&>(value)); 
+    wt[&typeid(Imath::V2d)] = [this](any const& value) {
+        _encoder.write_value(any_cast<Imath::V2d const&>(value));
     };
-    wt[&typeid(Imath::Box2d)] = [this](any const& value) { 
-        _encoder.write_value(any_cast<Imath::Box2d const&>(value)); 
+    wt[&typeid(Imath::Box2d)] = [this](any const& value) {
+        _encoder.write_value(any_cast<Imath::Box2d const&>(value));
     };
 
     /*
@@ -520,8 +520,8 @@ SerializableObject::Writer::_build_dispatch_tables()
     et[&typeid(TimeTransform)] = &_simple_any_comparison<TimeTransform>;
     et[&typeid(SerializableObject::ReferenceId)] =
         &_simple_any_comparison<SerializableObject::ReferenceId>;
-    et[&typeid(Imath::V2d)]    = &_simple_any_comparison<Imath::V2d>;
-    et[&typeid(Imath::Box2d)]  = &_simple_any_comparison<Imath::Box2d>;
+    et[&typeid(Imath::V2d)]   = &_simple_any_comparison<Imath::V2d>;
+    et[&typeid(Imath::Box2d)] = &_simple_any_comparison<Imath::Box2d>;
 
     /*
      * These next recurse back through the Writer itself:
@@ -676,15 +676,16 @@ SerializableObject::Writer::write(
     value ? _encoder.write_value(*value) : _encoder.write_null_value();
 }
 
-void 
-SerializableObject::Writer::write(std::string const& key, optional<Imath::Box2d> value) 
+void
+SerializableObject::Writer::write(
+    std::string const& key, optional<Imath::Box2d> value)
 {
     _encoder_write_key(key);
     value ? _encoder.write_value(*value) : _encoder.write_null_value();
 }
 
-void 
-SerializableObject::Writer::write(std::string const& key, TimeTransform value) 
+void
+SerializableObject::Writer::write(std::string const& key, TimeTransform value)
 {
     _encoder_write_key(key);
     _encoder.write_value(value);
@@ -768,23 +769,23 @@ SerializableObject::Writer::write(
 #endif
 }
 
-void SerializableObject::Writer::write(
-    std::string const& key, Imath::V2d value) 
+void
+SerializableObject::Writer::write(std::string const& key, Imath::V2d value)
 {
     _encoder_write_key(key);
     _encoder.write_value(value);
 }
 
-void SerializableObject::Writer::write(
-    std::string const& key, Imath::Box2d value) 
+void
+SerializableObject::Writer::write(std::string const& key, Imath::Box2d value)
 {
     _encoder_write_key(key);
     _encoder.write_value(value);
 }
 
-void 
+void
 SerializableObject::Writer::write(
-    std::string const& key, AnyDictionary const& value) 
+    std::string const& key, AnyDictionary const& value)
 {
     _encoder_write_key(key);
 
@@ -979,7 +980,7 @@ serialize_json_to_file(
     std::vector<wchar_t> wchars(wlen);
     MultiByteToWideChar(CP_UTF8, 0, file_name.c_str(), -1, wchars.data(), wlen);
     std::ofstream os(wchars.data());
-#else  // _WINDOWS
+#else // _WINDOWS
     std::ofstream os(file_name);
 #endif // _WINDOWS
     if (!os.is_open())

--- a/src/opentimelineio/serialization.cpp
+++ b/src/opentimelineio/serialization.cpp
@@ -66,6 +66,7 @@ public:
     virtual void write_value(class TimeRange const& value)           = 0;
     virtual void write_value(class TimeTransform const& value)       = 0;
     virtual void write_value(struct SerializableObject::ReferenceId) = 0;
+    virtual void write_value(Imath::Box2d const&) = 0;
 
 protected:
     void _error(ErrorStatus const& error_status)
@@ -162,9 +163,13 @@ public:
         _store(any(value));
     }
 
-    void start_array(size_t /* n */)
+    void write_value(Imath::V2d const& value) { _store(any(value)); }
+
+    void write_value(Imath::Box2d const& value) { _store(any(value)); }
+
+    void start_array(size_t /* n */) 
     {
-        if (has_errored())
+        if (has_errored()) 
         {
             return;
         }
@@ -372,8 +377,40 @@ public:
         _writer.EndObject();
     }
 
-    void start_array(size_t) { _writer.StartArray(); }
+    void write_value(Imath::V2d const& value) 
+    {
+        _writer.StartObject();
 
+        _writer.Key("OTIO_SCHEMA");
+        _writer.String("V2d.1");
+
+        _writer.Key("x");
+        _writer.Double(value.x);
+
+        _writer.Key("y");
+        _writer.Double(value.y);
+
+        _writer.EndObject();
+    }
+
+    void write_value(Imath::Box2d const& value) 
+    {
+        _writer.StartObject();
+
+        _writer.Key("OTIO_SCHEMA");
+        _writer.String("Box2d.1");
+
+        _writer.Key("min");
+        write_value(value.min);
+
+        _writer.Key("max");
+        write_value(value.max);
+
+        _writer.EndObject();
+    }
+
+    void start_array(size_t) { _writer.StartArray(); }
+    
     void start_object() { _writer.StartObject(); }
 
     void end_array() { _writer.EndArray(); }
@@ -440,6 +477,12 @@ SerializableObject::Writer::_build_dispatch_tables()
     wt[&typeid(TimeTransform)] = [this](any const& value) {
         _encoder.write_value(any_cast<TimeTransform const&>(value));
     };
+    wt[&typeid(Imath::V2d)] = [this](any const& value) { 
+        _encoder.write_value(any_cast<Imath::V2d const&>(value)); 
+    };
+    wt[&typeid(Imath::Box2d)] = [this](any const& value) { 
+        _encoder.write_value(any_cast<Imath::Box2d const&>(value)); 
+    };
 
     /*
      * These next recurse back through the Writer itself:
@@ -477,6 +520,8 @@ SerializableObject::Writer::_build_dispatch_tables()
     et[&typeid(TimeTransform)] = &_simple_any_comparison<TimeTransform>;
     et[&typeid(SerializableObject::ReferenceId)] =
         &_simple_any_comparison<SerializableObject::ReferenceId>;
+    et[&typeid(Imath::V2d)]    = &_simple_any_comparison<Imath::V2d>;
+    et[&typeid(Imath::Box2d)]  = &_simple_any_comparison<Imath::Box2d>;
 
     /*
      * These next recurse back through the Writer itself:
@@ -631,8 +676,15 @@ SerializableObject::Writer::write(
     value ? _encoder.write_value(*value) : _encoder.write_null_value();
 }
 
-void
-SerializableObject::Writer::write(std::string const& key, TimeTransform value)
+void 
+SerializableObject::Writer::write(std::string const& key, optional<Imath::Box2d> value) 
+{
+    _encoder_write_key(key);
+    value ? _encoder.write_value(*value) : _encoder.write_null_value();
+}
+
+void 
+SerializableObject::Writer::write(std::string const& key, TimeTransform value) 
 {
     _encoder_write_key(key);
     _encoder.write_value(value);
@@ -716,9 +768,23 @@ SerializableObject::Writer::write(
 #endif
 }
 
-void
+void SerializableObject::Writer::write(
+    std::string const& key, Imath::V2d value) 
+{
+    _encoder_write_key(key);
+    _encoder.write_value(value);
+}
+
+void SerializableObject::Writer::write(
+    std::string const& key, Imath::Box2d value) 
+{
+    _encoder_write_key(key);
+    _encoder.write_value(value);
+}
+
+void 
 SerializableObject::Writer::write(
-    std::string const& key, AnyDictionary const& value)
+    std::string const& key, AnyDictionary const& value) 
 {
     _encoder_write_key(key);
 

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -118,4 +118,31 @@ Stack::clip_if(
     return children_if<Clip>(error_status, search_range, shallow_search);
 }
 
+optional<Imath::Box2d> 
+Stack::available_image_bounds(ErrorStatus* error_status) const 
+{
+    optional<Imath::Box2d> box;
+    bool found_first_child = false;
+    for (auto clip : children_if<Clip>(error_status))
+    {
+        optional<Imath::Box2d> child_box;
+        if (auto clip_box = clip->available_image_bounds(error_status)) {
+            child_box = clip_box;
+        }
+        if (*error_status) {
+            return optional<Imath::Box2d>();
+        }
+        if (child_box) {
+            if (found_first_child) {
+                box->extendBy(*child_box);
+            }
+            else {
+                box = child_box;
+                found_first_child = true;
+            }          
+        }
+    }
+    return box;
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -118,28 +118,33 @@ Stack::clip_if(
     return children_if<Clip>(error_status, search_range, shallow_search);
 }
 
-optional<Imath::Box2d> 
-Stack::available_image_bounds(ErrorStatus* error_status) const 
+optional<Imath::Box2d>
+Stack::available_image_bounds(ErrorStatus* error_status) const
 {
     optional<Imath::Box2d> box;
-    bool found_first_child = false;
-    for (auto clip : children_if<Clip>(error_status))
+    bool                   found_first_child = false;
+    for (auto clip: children_if<Clip>(error_status))
     {
         optional<Imath::Box2d> child_box;
-        if (auto clip_box = clip->available_image_bounds(error_status)) {
+        if (auto clip_box = clip->available_image_bounds(error_status))
+        {
             child_box = clip_box;
         }
-        if (is_error(error_status)) {
+        if (is_error(error_status))
+        {
             return optional<Imath::Box2d>();
         }
-        if (child_box) {
-            if (found_first_child) {
+        if (child_box)
+        {
+            if (found_first_child)
+            {
                 box->extendBy(*child_box);
             }
-            else {
-                box = child_box;
+            else
+            {
+                box               = child_box;
                 found_first_child = true;
-            }          
+            }
         }
     }
     return box;

--- a/src/opentimelineio/stack.cpp
+++ b/src/opentimelineio/stack.cpp
@@ -129,7 +129,7 @@ Stack::available_image_bounds(ErrorStatus* error_status) const
         if (auto clip_box = clip->available_image_bounds(error_status)) {
             child_box = clip_box;
         }
-        if (*error_status) {
+        if (is_error(error_status)) {
             return optional<Imath::Box2d>();
         }
         if (child_box) {

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -35,7 +35,8 @@ public:
     virtual std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const;
 
-    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+    optional<Imath::Box2d>
+    available_image_bounds(ErrorStatus* error_status) const;
 
     // Return a vector of clips.
     //

--- a/src/opentimelineio/stack.h
+++ b/src/opentimelineio/stack.h
@@ -35,6 +35,8 @@ public:
     virtual std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const;
 
+    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+
     // Return a vector of clips.
     //
     // An optional search_range may be provided to limit the search.

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -76,6 +76,12 @@ public:
         ErrorStatus*        error_status   = nullptr,
         optional<TimeRange> search_range   = nullopt,
         bool                shallow_search = false) const;
+   
+    optional<Imath::Box2d> available_image_bounds(
+        ErrorStatus* error_status) const 
+    {
+        return _tracks.value->available_image_bounds(error_status);
+    }
 
 protected:
     virtual ~Timeline();

--- a/src/opentimelineio/timeline.h
+++ b/src/opentimelineio/timeline.h
@@ -76,9 +76,9 @@ public:
         ErrorStatus*        error_status   = nullptr,
         optional<TimeRange> search_range   = nullopt,
         bool                shallow_search = false) const;
-   
-    optional<Imath::Box2d> available_image_bounds(
-        ErrorStatus* error_status) const 
+
+    optional<Imath::Box2d>
+    available_image_bounds(ErrorStatus* error_status) const
     {
         return _tracks.value->available_image_bounds(error_status);
     }

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -292,4 +292,30 @@ Track::clip_if(
     return children_if<Clip>(error_status, search_range, shallow_search);
 }
 
+optional<Imath::Box2d> 
+Track::available_image_bounds(ErrorStatus* error_status) const 
+{
+    optional<Imath::Box2d> box;
+    bool found_first_clip = false;
+    for (auto child: children()) {
+        if (auto clip = dynamic_cast<Clip*>(child.value)) {
+            if (auto clip_box = clip->available_image_bounds(error_status)) {
+                if (clip_box) {
+                    if (found_first_clip) {
+                        box->extendBy(*clip_box);
+                    }
+                    else {
+                        box = clip_box;
+                        found_first_clip = true;
+                    }
+                }
+            }
+            if (*error_status) {
+                return optional<Imath::Box2d>();
+            }
+        }
+    }
+    return box;
+}
+
 }} // namespace opentimelineio::OPENTIMELINEIO_VERSION

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -292,25 +292,32 @@ Track::clip_if(
     return children_if<Clip>(error_status, search_range, shallow_search);
 }
 
-optional<Imath::Box2d> 
-Track::available_image_bounds(ErrorStatus* error_status) const 
+optional<Imath::Box2d>
+Track::available_image_bounds(ErrorStatus* error_status) const
 {
     optional<Imath::Box2d> box;
-    bool found_first_clip = false;
-    for (auto child: children()) {
-        if (auto clip = dynamic_cast<Clip*>(child.value)) {
-            if (auto clip_box = clip->available_image_bounds(error_status)) {
-                if (clip_box) {
-                    if (found_first_clip) {
+    bool                   found_first_clip = false;
+    for (auto child: children())
+    {
+        if (auto clip = dynamic_cast<Clip*>(child.value))
+        {
+            if (auto clip_box = clip->available_image_bounds(error_status))
+            {
+                if (clip_box)
+                {
+                    if (found_first_clip)
+                    {
                         box->extendBy(*clip_box);
                     }
-                    else {
-                        box = clip_box;
+                    else
+                    {
+                        box              = clip_box;
                         found_first_clip = true;
                     }
                 }
             }
-            if (is_error(error_status)) {
+            if (is_error(error_status))
+            {
                 return optional<Imath::Box2d>();
             }
         }

--- a/src/opentimelineio/track.cpp
+++ b/src/opentimelineio/track.cpp
@@ -310,7 +310,7 @@ Track::available_image_bounds(ErrorStatus* error_status) const
                     }
                 }
             }
-            if (*error_status) {
+            if (is_error(error_status)) {
                 return optional<Imath::Box2d>();
             }
         }

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -59,6 +59,8 @@ public:
     virtual std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const;
 
+    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+
     // Return a vector of clips.
     //
     // An optional search_range may be provided to limit the search.

--- a/src/opentimelineio/track.h
+++ b/src/opentimelineio/track.h
@@ -59,7 +59,8 @@ public:
     virtual std::map<Composable*, TimeRange>
     range_of_all_children(ErrorStatus* error_status = nullptr) const;
 
-    optional<Imath::Box2d> available_image_bounds(ErrorStatus* error_status) const;
+    optional<Imath::Box2d>
+    available_image_bounds(ErrorStatus* error_status) const;
 
     // Return a vector of clips.
     //

--- a/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
+++ b/src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
@@ -12,6 +12,7 @@ pybind11_add_module(_otio
                     otio_anyDictionary.cpp
                     otio_anyVector.cpp
                     otio_bindings.cpp
+                    otio_imath.cpp
                     otio_tests.cpp
                     otio_serializableObjects.cpp
                     otio_utils.cpp 
@@ -21,7 +22,8 @@ target_include_directories(_otio
     PRIVATE pybind11/include
     PRIVATE "${PROJECT_SOURCE_DIR}/src"
     PRIVATE "${PROJECT_SOURCE_DIR}/src/deps"
-    PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include")
+    PRIVATE "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
+)
 
 target_link_libraries(_otio PUBLIC opentimelineio opentime)
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
@@ -69,6 +69,7 @@ PYBIND11_MODULE(_otio, m) {
     otio_exception_bindings(m);
     otio_any_dictionary_bindings(m);
     otio_any_vector_bindings(m);
+    otio_imath_bindings(m);
     otio_serializable_object_bindings(m);
     otio_tests_bindings(m);
 

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.h
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_bindings.h
@@ -5,5 +5,6 @@
 void otio_exception_bindings(pybind11::module);
 void otio_any_dictionary_bindings(pybind11::module);
 void otio_any_vector_bindings(pybind11::module);
+void otio_imath_bindings(pybind11::module);
 void otio_serializable_object_bindings(pybind11::module);
 void otio_tests_bindings(pybind11::module);

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
@@ -1,0 +1,127 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+
+#include "otio_utils.h"
+
+#include "ImathBox.h"
+#include "ImathVec.h"
+
+namespace py = pybind11;
+
+template <typename CLASS>
+CLASS _type_checked(py::object const& rhs, char const* op) {
+    try {
+        return py::cast<CLASS>(rhs);
+    }
+    catch (...) {
+        std::string rhs_type = py::cast<std::string>(rhs.get_type().attr("__name__"));
+        throw py::type_error(string_printf("unsupported operand type(s) for %s: "
+                                           "%s and %s", typeid(CLASS).name(), op, rhs_type.c_str()));
+    }
+}
+
+static void define_imath_2d(py::module m) {
+    py::class_<Imath::V2d>(m, "V2d")
+        .def(py::init<>())
+        .def(py::init<double>())
+        .def(py::init<double, double>())
+        .def_readwrite("x", &Imath::V2d::x)
+        .def_readwrite("y", &Imath::V2d::y)
+        .def("__getitem__", [](Imath::V2d const &v, size_t i) {
+                return v[i];
+            })
+        .def("__eq__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs == _type_checked<Imath::V2d>(rhs, "==");
+            })
+        .def("__ne__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs != _type_checked<Imath::V2d>(rhs, "!=");
+            })
+        .def("__xor__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs ^ _type_checked<Imath::V2d>(rhs, "^");
+            })
+        .def("__mod__", [](Imath::V2d lhs, py::object const& rhs) {
+                return lhs % _type_checked<Imath::V2d>(rhs, "%");
+            })
+        .def("__iadd__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs += rhs;
+            })
+        .def("__isub__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs -= rhs;
+            })
+        .def("__imul__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs *= rhs;
+            })
+        .def("__idiv__", [](Imath::V2d lhs, Imath::V2d rhs) {
+                return lhs /= rhs;
+            })
+        .def(py::self - py::self)
+        .def(py::self + py::self)
+        .def(py::self * py::self)
+        .def(py::self / py::self)
+        .def("equalWithAbsError", [](Imath::V2d* v, Imath::V2d const & v2, double e) {
+                return v->equalWithAbsError(v2, e);
+            })
+        .def("equalWithRelError", [](Imath::V2d* v, Imath::V2d const & v2, double e) {
+                return v->equalWithRelError(v2, e);
+            })
+        .def("dot", [](Imath::V2d* v, Imath::V2d const & v2) {
+                return v->dot(v2);
+            })
+        .def("cross", [](Imath::V2d* v, Imath::V2d const & v2) {
+                return v->cross(v2);
+            })
+        .def("length", &Imath::V2d::length)
+        .def("length2", &Imath::V2d::length2)
+        .def("normalize", &Imath::V2d::normalize)
+        .def("normalizeExc", &Imath::V2d::normalizeExc)
+        .def("normalizeNonNull", &Imath::V2d::normalizeNonNull)
+        .def("normalized", &Imath::V2d::normalized)
+        .def("normalizedExc", &Imath::V2d::normalizedExc)
+        .def("normalizedNonNull", &Imath::V2d::normalizedNonNull)
+        .def_static("baseTypeLowest", []() {
+                return Imath::V2d::baseTypeLowest();
+            })
+        .def_static("baseTypeMax", []() {
+                return Imath::V2d::baseTypeMax();
+            })
+        .def_static("baseTypeSmallest", []() {
+                return Imath::V2d::baseTypeSmallest();
+            })
+        .def_static("baseTypeEpsilon", []() {
+                return Imath::V2d::baseTypeEpsilon();
+            })
+        .def_static("dimensions", []() {
+                return Imath::V2d::dimensions();
+            });
+
+    py::class_<Imath::Box2d>(m, "Box2d")
+        .def(py::init<>())
+        .def(py::init<Imath::V2d>())
+        .def(py::init<Imath::V2d, Imath::V2d>())
+        .def_readwrite("min", &Imath::Box2d::min)
+        .def_readwrite("max", &Imath::Box2d::max)
+        .def("__eq__", [](Imath::Box2d lhs, py::object const& rhs) {
+            return lhs == _type_checked<Imath::Box2d>(rhs, "==");
+        })
+        .def("__ne__", [](Imath::Box2d lhs, py::object const& rhs) {
+            return lhs != _type_checked<Imath::Box2d>(rhs, "!=");
+        })
+        .def("center", &Imath::Box2d::center)
+        .def("extendBy", [](Imath::Box2d* box, Imath::V2d const& point ) {
+            return box->extendBy(point); 
+        })
+        .def("extendBy", [](Imath::Box2d* box, Imath::Box2d const& rhs ) {
+            return box->extendBy(rhs); 
+        })
+        .def("intersects", [](Imath::Box2d* box, Imath::V2d const& point ) {
+            return box->intersects(point); 
+        })
+        .def("intersects", [](Imath::Box2d* box, Imath::Box2d const& rhs ) {
+            return box->intersects(rhs); 
+        });
+}
+
+void otio_imath_bindings(py::module m) {
+    define_imath_2d(m);
+}
+

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -671,13 +671,13 @@ static void define_media_references(py::module m) {
                           return new GeneratorReference(name, generator_kind,
                                                         available_range,
                                                         py_to_any_dictionary(parameters),
-                                                        py_to_any_dictionary(metadata)
+                                                        py_to_any_dictionary(metadata),
                                                         available_image_bounds); }),
              py::arg_v("name"_a = std::string()),
              "generator_kind"_a = std::string(),
              "available_range"_a = nullopt,
              "parameters"_a = py::none(),
-             py::arg_v("metadata"_a = py::none())
+             py::arg_v("metadata"_a = py::none()),
              "available_image_bounds"_a = nullopt)
         .def_property("generator_kind", &GeneratorReference::generator_kind, &GeneratorReference::set_generator_kind)
         .def_property_readonly("parameters", [](GeneratorReference* g) {

--- a/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
+++ b/src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
@@ -29,6 +29,8 @@
 #include "otio_utils.h"
 #include "otio_anyDictionary.h"
 
+#include "ImathBox.h"
+
 namespace py = pybind11;
 using namespace pybind11::literals;
 
@@ -290,6 +292,7 @@ static void define_bases2(py::module m) {
         .def("children_if", [](SerializableCollection* t, py::object descended_from_type, optional<TimeRange> const& search_range) {
                 return children_if(t, descended_from_type, search_range);
             }, "descended_from_type"_a = py::none(), "search_range"_a = nullopt);
+
 }
 
 static void define_items_and_compositions(py::module m) {
@@ -338,7 +341,10 @@ static void define_items_and_compositions(py::module m) {
             }, "time"_a, "to_item"_a)
         .def("transformed_time_range", [](Item* item, TimeRange time_range, Item* to_item) {
             return item->transformed_time_range(time_range, to_item, ErrorStatusHandler());
-            }, "time_range"_a, "to_item"_a);
+            }, "time_range"_a, "to_item"_a)
+        .def_property_readonly("available_image_bounds", [](Item* item) {
+            return item->available_image_bounds(ErrorStatusHandler());
+            });
 
     auto transition_class =
         py::class_<Transition, Composable, managing_ptr<Transition>>(m, "Transition", py::dynamic_attr())
@@ -468,6 +474,7 @@ static void define_items_and_compositions(py::module m) {
                 auto result = c->handles_of_child(child, ErrorStatusHandler());
                 return py::make_tuple(py::cast(result.first), py::cast(result.second));
             }, "child_a")
+        .def("has_clips", &Composition::has_clips)
         .def("__internal_getitem__", [](Composition* c, int index) {
                 index = adjusted_vector_index(index, c->children());
                 if (index < 0 || index >= int(c->children().size())) {
@@ -643,28 +650,35 @@ static void define_media_references(py::module m) {
                managing_ptr<MediaReference>>(m, "MediaReference", py::dynamic_attr())
         .def(py::init([](std::string name,
                          optional<TimeRange> available_range,
-                         py::object metadata) {
-                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata)); }),
+                         py::object metadata,
+                         optional<Imath::Box2d> const& available_image_bounds) {
+                          return new MediaReference(name, available_range, py_to_any_dictionary(metadata), available_image_bounds); }),
              py::arg_v("name"_a = std::string()),
              "available_range"_a = nullopt,
-             py::arg_v("metadata"_a = py::none()))
+             py::arg_v("metadata"_a = py::none()),
+             "available_image_bounds"_a = nullopt)
+
         .def_property("available_range", &MediaReference::available_range, &MediaReference::set_available_range)
+        .def_property("available_image_bounds", &MediaReference::available_image_bounds, &MediaReference::set_available_image_bounds) 
         .def_property_readonly("is_missing_reference", &MediaReference::is_missing_reference);
 
     py::class_<GeneratorReference, MediaReference,
                managing_ptr<GeneratorReference>>(m, "GeneratorReference", py::dynamic_attr())
         .def(py::init([](std::string name, std::string generator_kind,
                          optional<TimeRange> const& available_range,
-                         py::object parameters, py::object metadata) {
+                         py::object parameters, py::object metadata,
+                         optional<Imath::Box2d> const& available_image_bounds) {
                           return new GeneratorReference(name, generator_kind,
                                                         available_range,
                                                         py_to_any_dictionary(parameters),
-                                                        py_to_any_dictionary(metadata)); }),
+                                                        py_to_any_dictionary(metadata)
+                                                        available_image_bounds); }),
              py::arg_v("name"_a = std::string()),
              "generator_kind"_a = std::string(),
              "available_range"_a = nullopt,
              "parameters"_a = py::none(),
-             py::arg_v("metadata"_a = py::none()))
+             py::arg_v("metadata"_a = py::none())
+             "available_image_bounds"_a = nullopt)
         .def_property("generator_kind", &GeneratorReference::generator_kind, &GeneratorReference::set_generator_kind)
         .def_property_readonly("parameters", [](GeneratorReference* g) {
                 auto ptr = g->parameters().get_or_create_mutation_stamp();
@@ -676,28 +690,34 @@ static void define_media_references(py::module m) {
         .def(py::init([](
                         py::object name,
                         optional<TimeRange> available_range,
-                        py::object metadata) {
+                        py::object metadata,
+                        optional<Imath::Box2d> const& available_image_bounds) {
                     return new MissingReference(
                                   string_or_none_converter(name),
                                   available_range,
-                                  py_to_any_dictionary(metadata)); 
+                                  py_to_any_dictionary(metadata),
+                                  available_image_bounds); 
                     }),
              py::arg_v("name"_a = std::string()),
              "available_range"_a = nullopt,
-             py::arg_v("metadata"_a = py::none()));
+             py::arg_v("metadata"_a = py::none()),
+             "available_image_bounds"_a = nullopt);
 
 
     py::class_<ExternalReference, MediaReference,
                managing_ptr<ExternalReference>>(m, "ExternalReference", py::dynamic_attr())
         .def(py::init([](std::string target_url,
                          optional<TimeRange> const& available_range,
-                         py::object metadata) {
+                         py::object metadata,
+                         optional<Imath::Box2d> const& available_image_bounds) {
                           return new ExternalReference(target_url,
                                                         available_range,
-                                                        py_to_any_dictionary(metadata)); }),
+                                                        py_to_any_dictionary(metadata),
+                                                        available_image_bounds); }),
              "target_url"_a = std::string(),
              "available_range"_a = nullopt,
-             py::arg_v("metadata"_a = py::none()))
+             py::arg_v("metadata"_a = py::none()),
+             "available_image_bounds"_a = nullopt)
         .def_property("target_url", &ExternalReference::target_url, &ExternalReference::set_target_url);
 
     auto imagesequencereference_class = py:: class_<ImageSequenceReference, MediaReference,
@@ -778,7 +798,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                          int frame_zero_padding,
                          ImageSequenceReference::MissingFramePolicy const missing_frame_policy,
                          optional<TimeRange> const& available_range,
-                         py::object metadata) {
+                         py::object metadata,
+                         optional<Imath::Box2d> const& available_image_bounds) {
                           return new ImageSequenceReference(target_url_base,
                                                             name_prefix,
                                                             name_suffix,
@@ -788,7 +809,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                                                             frame_zero_padding,
                                                             missing_frame_policy,
                                                             available_range,
-                                                            py_to_any_dictionary(metadata)); }),
+                                                            py_to_any_dictionary(metadata),
+                                                            available_image_bounds); }),
                         "target_url_base"_a = std::string(),
                         "name_prefix"_a = std::string(),
                         "name_suffix"_a = std::string(),
@@ -798,7 +820,8 @@ Negative ``start_frame`` is also handled. The above example with a ``start_frame
                         "frame_zero_padding"_a = 0,
                         "missing_frame_policy"_a = ImageSequenceReference::MissingFramePolicy::error,
                         "available_range"_a = nullopt,
-                        py::arg_v("metadata"_a = py::none()))
+                        py::arg_v("metadata"_a = py::none()),
+                        "available_image_bounds"_a = nullopt)
         .def_property("target_url_base", &ImageSequenceReference::target_url_base, &ImageSequenceReference::set_target_url_base, "Everything leading up to the file name in the ``target_url``.")
         .def_property("name_prefix", &ImageSequenceReference::name_prefix, &ImageSequenceReference::set_name_prefix, "Everything in the file name leading up to the frame number.")
         .def_property("name_suffix", &ImageSequenceReference::name_suffix, &ImageSequenceReference::set_name_suffix, "Everything after the frame number in the file name.")

--- a/src/py-opentimelineio/opentimelineio/core/mediaReference.py
+++ b/src/py-opentimelineio/opentimelineio/core/mediaReference.py
@@ -4,10 +4,11 @@ from .. import _otio
 
 @add_method(_otio.MediaReference)
 def __str__(self):
-    return "{}({}, {}, {})".format(
+    return "{}({}, {}, {}, {})".format(
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
+        repr(self.available_image_bounds),
         repr(self.metadata)
     )
 
@@ -18,6 +19,7 @@ def __repr__(self):
         "otio.{}.{}("
         "name={},"
         " available_range={},"
+        " available_image_bounds={},"
         " metadata={}"
         ")"
     ).format(
@@ -25,5 +27,6 @@ def __repr__(self):
         self.__class__.__name__,
         repr(self.name),
         repr(self.available_range),
+        repr(self.available_image_bounds),
         repr(self.metadata)
     )

--- a/src/py-opentimelineio/opentimelineio/schema/__init__.py
+++ b/src/py-opentimelineio/opentimelineio/schema/__init__.py
@@ -27,6 +27,7 @@
 """User facing classes."""
 
 from .. _otio import (
+    Box2d,
     Clip,
     Effect,
     TimeEffect,
@@ -42,7 +43,8 @@ from .. _otio import (
     Stack,
     Timeline,
     Track,
-    Transition
+    Transition,
+    V2d,
 )
 
 MarkerColor = Marker.Color
@@ -55,6 +57,7 @@ from . schemadef import (
 )
 
 from . import (
+    box2d,
     clip,
     effect,
     external_reference,
@@ -66,6 +69,7 @@ from . import (
     timeline,
     track,
     transition,
+    v2d,
 )
 
 track.TrackKind = TrackKind

--- a/src/py-opentimelineio/opentimelineio/schema/box2d.py
+++ b/src/py-opentimelineio/opentimelineio/schema/box2d.py
@@ -1,0 +1,23 @@
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.Box2d)
+def __str__(self):
+    return 'Box2d({}, {})'.format(
+        self.min,
+        self.max
+    )
+
+
+@add_method(_otio.Box2d)
+def __repr__(self):
+    return (
+        'otio.schema.Box2d('
+        'min={}, '
+        'max={}'
+        ')'.format(
+            repr(self.min),
+            repr(self.max),
+        )
+    )

--- a/src/py-opentimelineio/opentimelineio/schema/generator_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/generator_reference.py
@@ -4,10 +4,11 @@ from .. import _otio
 
 @add_method(_otio.GeneratorReference)
 def __str__(self):
-    return 'GeneratorReference("{}", "{}", {}, {})'.format(
+    return 'GeneratorReference("{}", "{}", {}, {}, {})'.format(
         self.name,
         self.generator_kind,
         self.parameters,
+        self.available_image_bounds,
         self.metadata
     )
 
@@ -19,11 +20,13 @@ def __repr__(self):
         'name={}, '
         'generator_kind={}, '
         'parameters={}, '
+        'available_image_bounds={}, '
         'metadata={}'
         ')'.format(
             repr(self.name),
             repr(self.generator_kind),
             repr(self.parameters),
+            repr(self.available_image_bounds),
             repr(self.metadata),
         )
     )

--- a/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
+++ b/src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
@@ -6,7 +6,7 @@ from .. import _otio
 def __str__(self):
     return (
         'ImageSequenceReference('
-        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {})' .format(
+        '"{}", "{}", "{}", {}, {}, {}, {}, {}, {}, {}, {})' .format(
             self.target_url_base,
             self.name_prefix,
             self.name_suffix,
@@ -16,6 +16,7 @@ def __str__(self):
             self.frame_zero_padding,
             self.missing_frame_policy,
             self.available_range,
+            self.available_image_bounds,
             self.metadata,
         )
     )
@@ -34,6 +35,7 @@ def __repr__(self):
         'frame_zero_padding={}, '
         'missing_frame_policy={}, '
         'available_range={}, '
+        'available_image_bounds={}, '
         'metadata={}'
         ')' .format(
             repr(self.target_url_base),
@@ -45,6 +47,7 @@ def __repr__(self):
             repr(self.frame_zero_padding),
             repr(self.missing_frame_policy),
             repr(self.available_range),
+            repr(self.available_image_bounds),
             repr(self.metadata),
         )
     )

--- a/src/py-opentimelineio/opentimelineio/schema/v2d.py
+++ b/src/py-opentimelineio/opentimelineio/schema/v2d.py
@@ -1,0 +1,23 @@
+from .. core._core_utils import add_method
+from .. import _otio
+
+
+@add_method(_otio.V2d)
+def __str__(self):
+    return 'V2d({}, {})'.format(
+        self.x,
+        self.y
+    )
+
+
+@add_method(_otio.V2d)
+def __repr__(self):
+    return (
+        'otio.schema.V2d('
+        'x={}, '
+        'y={}'
+        ')'.format(
+            repr(self.x),
+            repr(self.y),
+        )
+    )

--- a/tests/baselines/empty_external_reference.json
+++ b/tests/baselines/empty_external_reference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "ExternalReference.1",
     "available_range" : null,
+    "available_image_bounds" : null,
     "metadata" : {},
     "name" : "",
     "target_url" : "foo.bar"

--- a/tests/baselines/empty_generator_reference.json
+++ b/tests/baselines/empty_generator_reference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "GeneratorReference.1",
     "available_range" : null,
+    "available_image_bounds" : null,
     "generator_kind" : "",
     "metadata" : {},
     "parameters" : {},

--- a/tests/baselines/empty_missingreference.json
+++ b/tests/baselines/empty_missingreference.json
@@ -1,6 +1,7 @@
 {
     "OTIO_SCHEMA" : "MissingReference.1",
     "available_range" : null,
+    "available_image_bounds" : null,
     "metadata" : {},
     "name" : ""
 }

--- a/tests/sample_data/clip_example.otio
+++ b/tests/sample_data/clip_example.otio
@@ -50,6 +50,19 @@
                 }
               },
               "metadata": {},
+              "available_image_bounds": {
+                "OTIO_SCHEMA": "Box2d.1",
+                "min": {
+                  "OTIO_SCHEMA":"V2d.1",
+                  "x": 0.0,
+                  "y": 0.0
+                },
+                "max": {
+                  "OTIO_SCHEMA":"V2d.1",
+                  "x": 16.0,
+                  "y": 9.0
+                }
+              },
               "name": null
             },
             "metadata": {},

--- a/tests/test_box2d.py
+++ b/tests/test_box2d.py
@@ -1,0 +1,114 @@
+#
+# Copyright Contributors to the OpenTimelineIO project
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+import unittest
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+
+class Box2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_cons(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box = otio.schema.Box2d(v1, v2)
+
+        self.assertEqual(box.min, v1)
+        self.assertEqual(box.max, v2)
+
+    def test_str(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box = otio.schema.Box2d(v1, v2)
+
+        self.assertMultiLineEqual(
+            str(box),
+            'Box2d(V2d(1.0, 2.0), V2d(3.0, 4.0))'
+        )
+
+        self.assertMultiLineEqual(
+            repr(box),
+            'otio.schema.Box2d('
+            'min=otio.schema.V2d(x=1.0, y=2.0), '
+            'max=otio.schema.V2d(x=3.0, y=4.0)'
+            ')'
+        )
+
+    def test_center(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box1 = otio.schema.Box2d(v1, v2)
+
+        self.assertEqual(box1.center(),
+                         otio.schema.V2d(2.0, 3.0)
+                         )
+
+    def test_extend(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box1 = otio.schema.Box2d(v1, v2)
+
+        box1.extendBy(otio.schema.V2d(5.0, 5.0))
+        self.assertEqual(box1,
+                         otio.schema.Box2d(
+                             otio.schema.V2d(1.0, 2.0),
+                             otio.schema.V2d(5.0, 5.0)
+                         )
+                         )
+
+        v3 = otio.schema.V2d(2.0, 3.0)
+        v4 = otio.schema.V2d(6.0, 6.0)
+        box2 = otio.schema.Box2d(v3, v4)
+
+        box1.extendBy(box2)
+        self.assertEqual(box1,
+                         otio.schema.Box2d(
+                             otio.schema.V2d(1.0, 2.0),
+                             otio.schema.V2d(6.0, 6.0)
+                         )
+                         )
+
+    def test_intersects(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+        box1 = otio.schema.Box2d(v1, v2)
+
+        self.assertTrue(box1.intersects(otio.schema.V2d(2.0, 3.0)))
+
+        self.assertFalse(box1.intersects(otio.schema.V2d(0.0, 3.0)))
+
+        v3 = otio.schema.V2d(1.1, 1.9)
+        v4 = otio.schema.V2d(3.1, 3.9)
+        box2 = otio.schema.Box2d(v3, v4)
+
+        self.assertTrue(box1.intersects(box2))
+
+        v5 = otio.schema.V2d(3.1, 4.1)
+        v6 = otio.schema.V2d(4.1, 5.1)
+        box3 = otio.schema.Box2d(v5, v6)
+
+        self.assertFalse(box1.intersects(box3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -62,7 +62,7 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertMultiLineEqual(
             str(cl),
-            'Clip("test_clip", MissingReference(\'\', None, {}), None, {})'
+            'Clip("test_clip", MissingReference(\'\', None, None, {}), None, {})'
         )
         self.assertMultiLineEqual(
             repr(cl),
@@ -134,6 +134,33 @@ class ClipTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         self.assertEqual(cl.trimmed_range(), cl.source_range)
         self.assertIsNot(cl.trimmed_range(), cl.source_range)
+
+    def test_available_image_bounds(self):
+        available_image_bounds = otio.schema.Box2d(
+            otio.schema.V2d(0.0, 0.0),
+            otio.schema.V2d(16.0, 9.0)
+        )
+
+        media_reference = otio.schema.ExternalReference(
+            "/var/tmp/foo.mov",
+            available_image_bounds=available_image_bounds
+        )
+
+        cl = otio.schema.Clip(
+            name="test_available_image_bounds",
+            media_reference=media_reference
+        )
+
+        self.assertEqual(available_image_bounds, cl.available_image_bounds)
+        self.assertEqual(
+            cl.available_image_bounds,
+            media_reference.available_image_bounds
+        )
+
+        self.assertEqual(0.0, cl.available_image_bounds.min.x)
+        self.assertEqual(0.0, cl.available_image_bounds.min.y)
+        self.assertEqual(16.0, cl.available_image_bounds.max.x)
+        self.assertEqual(9.0, cl.available_image_bounds.max.y)
 
     def test_ref_default(self):
         cl = otio.schema.Clip()

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -377,6 +377,42 @@ class CompositionTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertNotIn(cl, st)
         self.assertIn(cl2, st)
 
+    def test_has_clip(self):
+        st = otio.schema.Stack(name="ST")
+
+        tr1 = otio.schema.Track(name="tr1")
+        st.append(tr1)
+
+        self.assertFalse(st.has_clips())
+        self.assertFalse(tr1.has_clips())
+
+        c1 = otio.schema.Clip(name="c1")
+        tr1.append(c1)
+
+        self.assertTrue(st.has_clips())
+        self.assertTrue(tr1.has_clips())
+
+        tr2 = otio.schema.Track(name="tr2")
+        st.append(tr2)
+
+        self.assertTrue(st.has_clips())
+        self.assertTrue(tr1.has_clips())
+        self.assertFalse(tr2.has_clips())
+
+        g1 = otio.schema.Gap(name="g1")
+        tr2.append(g1)
+
+        self.assertTrue(st.has_clips())
+        self.assertTrue(tr1.has_clips())
+        self.assertFalse(tr2.has_clips())
+
+        c2 = otio.schema.Clip(name="c2")
+        tr2.append(c2)
+
+        self.assertTrue(st.has_clips())
+        self.assertTrue(tr1.has_clips())
+        self.assertTrue(tr2.has_clips())
+
 
 class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
@@ -763,6 +799,139 @@ class StackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):
             clip3.transformed_time(otio.opentime.RationalTime(152, 24), st),
             otio.opentime.RationalTime(50, 24)
         )
+
+    def test_available_image_bounds_single_clip(self):
+        st = otio.schema.Stack(name="foo", children=[
+            otio.schema.Gap(name="GAP1")
+        ])
+
+        # There's noting valid, we should have no available_image_bounds
+        self.assertEqual(st.available_image_bounds, None)
+
+        clip = otio.schema.Clip(
+            media_reference=otio.schema.ExternalReference(
+                available_image_bounds=otio.schema.Box2d(
+                    otio.schema.V2d(1, 1),
+                    otio.schema.V2d(2, 2)
+                ),
+                target_url="/var/tmp/test.mov"
+            ),
+            name="clip1"
+        )
+
+        # The Stack available_image_bounds should be equal to
+        # the single clip that's in it
+        st.append(clip)
+        self.assertEqual(st.available_image_bounds, clip.available_image_bounds)
+
+    def test_available_image_bounds_multi_clip(self):
+        st = otio.schema.Stack(name="foo", children=[
+            otio.schema.Gap(name="GAP1"),
+            otio.schema.Clip(
+                media_reference=otio.schema.ExternalReference(
+                    available_image_bounds=otio.schema.Box2d(
+                        otio.schema.V2d(1, 1),
+                        otio.schema.V2d(2, 2)
+                    ),
+                    target_url="/var/tmp/test.mov"
+                ),
+                name="clip1"
+            ),
+            otio.schema.Gap(name="GAP2"),
+            otio.schema.Clip(
+                media_reference=otio.schema.ExternalReference(
+                    available_image_bounds=otio.schema.Box2d(
+                        otio.schema.V2d(2, 2),
+                        otio.schema.V2d(3, 3)
+                    ),
+                    target_url="/var/tmp/test.mov"
+                ),
+                name="clip2"
+            ),
+            otio.schema.Gap(name="GAP3"),
+            otio.schema.Clip(
+                media_reference=otio.schema.ExternalReference(
+                    available_image_bounds=otio.schema.Box2d(
+                        otio.schema.V2d(3, 3),
+                        otio.schema.V2d(4, 4)
+                    ),
+                    target_url="/var/tmp/test.mov"
+                ),
+                name="clip3"
+            ),
+            otio.schema.Gap(name="GAP4")
+        ])
+
+        # The Stack available_image_bounds should cover the overlapping boxes,
+        # the gaps should be ignored
+        self.assertEqual(st.available_image_bounds,
+                         otio.schema.Box2d(
+                             otio.schema.V2d(1, 1),
+                             otio.schema.V2d(4, 4)
+                         )
+                         )
+
+    def test_available_image_bounds_multi_layer(self):
+        tr1 = otio.schema.Track(name="tr1", children=[
+            otio.schema.Gap(name="GAP1")
+        ])
+        st = otio.schema.Stack(name="foo", children=[tr1])
+
+        self.assertEqual(st.available_image_bounds, tr1.available_image_bounds)
+        self.assertEqual(st.available_image_bounds, None)
+
+        cl1 = otio.schema.Clip(
+            media_reference=otio.schema.ExternalReference(
+                available_image_bounds=otio.schema.Box2d(
+                    otio.schema.V2d(0, 0),
+                    otio.schema.V2d(2, 2)
+                ),
+                target_url="/var/tmp/test.mov"
+            ),
+            name="clip1"
+        )
+        tr1.append(cl1)
+
+        self.assertEqual(st.available_image_bounds, cl1.available_image_bounds)
+        self.assertEqual(st.available_image_bounds, tr1.available_image_bounds)
+
+        tr2 = otio.schema.Track(name="tr2", children=[
+            otio.schema.Gap(name="GAP2")
+        ])
+        st.append(tr2)
+
+        self.assertEqual(st.available_image_bounds, cl1.available_image_bounds)
+        self.assertEqual(st.available_image_bounds, tr1.available_image_bounds)
+
+        cl2 = otio.schema.Clip(
+            media_reference=otio.schema.ExternalReference(
+                available_image_bounds=otio.schema.Box2d(
+                    otio.schema.V2d(1, 1),
+                    otio.schema.V2d(3, 3)
+                ),
+                target_url="/var/tmp/test.mov"
+            ),
+            name="clip2"
+        )
+        tr2.append(cl2)
+
+        # Each track should have available_image_bounds equal to its single clip,
+        # but the stack available_image_bounds should use both tracks
+        self.assertEqual(tr1.available_image_bounds, cl1.available_image_bounds)
+        self.assertEqual(tr2.available_image_bounds, cl2.available_image_bounds)
+
+        union = st.available_image_bounds
+        self.assertEqual(union,
+                         otio.schema.Box2d(
+                             otio.schema.V2d(0, 0),
+                             otio.schema.V2d(3, 3)
+                         )
+                         )
+
+        # Appending a track with no available_image_bounds should do nothing
+        st.append(otio.schema.Track())
+        union2 = st.available_image_bounds
+        self.assertEqual(union, union2)
 
 
 class TrackTest(unittest.TestCase, otio_test_utils.OTIOAssertions):

--- a/tests/test_generator_reference.py
+++ b/tests/test_generator_reference.py
@@ -24,7 +24,11 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             },
             metadata={
                 "foo": "bar"
-            }
+            },
+            available_image_bounds=otio.schema.Box2d(
+                otio.schema.V2d(0.0, 0.0),
+                otio.schema.V2d(16.0, 9.0)
+            )
         )
 
     def test_constructor(self):
@@ -37,6 +41,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             otio.opentime.TimeRange(
                 otio.opentime.RationalTime(0, 24),
                 otio.opentime.RationalTime(100, 24),
+            )
+        )
+        self.assertEqual(
+            self.gen.available_image_bounds,
+            otio.schema.Box2d(
+                otio.schema.V2d(0.0, 0.0),
+                otio.schema.V2d(16.0, 9.0)
             )
         )
 
@@ -59,11 +70,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             '"{}", '
             '"{}", '
             '{}, '
+            '{}, '
             "{}"
             ")".format(
                 str(self.gen.name),
                 str(self.gen.generator_kind),
                 str(self.gen.parameters),
+                str(self.gen.available_image_bounds),
                 str(self.gen.metadata),
             )
         )
@@ -74,11 +87,13 @@ class GeneratorRefTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             "name={}, "
             "generator_kind={}, "
             "parameters={}, "
+            "available_image_bounds={}, "
             "metadata={}"
             ")".format(
                 repr(self.gen.name),
                 repr(self.gen.generator_kind),
                 repr(self.gen.parameters),
+                repr(self.gen.available_image_bounds),
                 repr(self.gen.metadata),
             )
         )

--- a/tests/test_image_sequence_reference.py
+++ b/tests/test_image_sequence_reference.py
@@ -64,6 +64,10 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(60, 30),
             ),
             metadata={"custom": {"foo": "bar"}},
+            available_image_bounds=otio.schema.Box2d(
+                otio.schema.V2d(0.0, 0.0),
+                otio.schema.V2d(16.0, 9.0)
+            ),
         )
         self.assertEqual(
             str(ref),
@@ -77,6 +81,7 @@ class ImageSequenceReferenceTests(
             '5, '
             'MissingFramePolicy.error, '
             'TimeRange(RationalTime(0, 30), RationalTime(60, 30)), '
+            'Box2d(V2d(0.0, 0.0), V2d(16.0, 9.0)), '
             "{'custom': {'foo': 'bar'}}"
             ')'
         )
@@ -95,6 +100,10 @@ class ImageSequenceReferenceTests(
                 otio.opentime.RationalTime(0, 30),
                 otio.opentime.RationalTime(60, 30),
             ),
+            available_image_bounds=otio.schema.Box2d(
+                otio.schema.V2d(0.0, 0.0),
+                otio.schema.V2d(16.0, 9.0)
+            ),
             metadata={"custom": {"foo": "bar"}},
         )
         ref_value = (
@@ -108,6 +117,9 @@ class ImageSequenceReferenceTests(
             'frame_zero_padding=5, '
             'missing_frame_policy=<MissingFramePolicy.error: 0>, '
             'available_range={}, '
+            'available_image_bounds=otio.schema.Box2d('
+            'min=otio.schema.V2d(x=0.0, y=0.0), '
+            'max=otio.schema.V2d(x=16.0, y=9.0)), '
             "metadata={{'custom': {{'foo': 'bar'}}}}"
             ')'.format(repr(ref.available_range))
         )
@@ -527,7 +539,7 @@ class ImageSequenceReferenceTests(
 
         self.assertEqual(ref.frame_range_for_time_range(time_range), (13, 29))
 
-    def test_frame_range_for_time_range_out_of_bounds(self):
+    def test_frame_range_for_time_range_out_of_available_image_bounds(self):
         ref = otio.schema.ImageSequenceReference(
             "file:///show/seq/shot/rndr/",
             "show_shot.",

--- a/tests/test_media_reference.py
+++ b/tests/test_media_reference.py
@@ -51,12 +51,12 @@ class MediaReferenceTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         missing = otio.schema.MissingReference()
         self.assertMultiLineEqual(
             str(missing),
-            "MissingReference(\'\', None, {})"
+            "MissingReference(\'\', None, None, {})"
         )
         self.assertMultiLineEqual(
             repr(missing),
             "otio.schema.MissingReference("
-            "name='', available_range=None, metadata={}"
+            "name='', available_range=None, available_image_bounds=None, metadata={}"
             ")"
         )
 

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -343,6 +343,54 @@ class TimelineTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
             tl.tracks[0].range_of_child_at_index(0)
         )
 
+    def test_available_image_bounds(self):
+        track = otio.schema.Track(name="test_track")
+        tl = otio.schema.Timeline("test_timeline", tracks=[track])
+
+        # three clips, each successive clip partially overlaps the previous
+        cl = otio.schema.Clip(
+            name="test clip1",
+            media_reference=otio.schema.ExternalReference(
+                available_image_bounds=otio.schema.Box2d(
+                    otio.schema.V2d(0.0, 0.0),
+                    otio.schema.V2d(1.0, 1.0)
+                ),
+                target_url="/var/tmp/test.mov"
+            )
+        )
+        cl2 = otio.schema.Clip(
+            name="test clip2",
+            media_reference=otio.schema.ExternalReference(
+                available_image_bounds=otio.schema.Box2d(
+                    otio.schema.V2d(1.0, 1.0),
+                    otio.schema.V2d(2.0, 2.0)
+                ),
+                target_url="/var/tmp/test.mov"
+            )
+        )
+        cl3 = otio.schema.Clip(
+            name="test clip3",
+            media_reference=otio.schema.ExternalReference(
+                available_image_bounds=otio.schema.Box2d(
+                    otio.schema.V2d(2.0, 2.0),
+                    otio.schema.V2d(3.0, 3.0)
+                ),
+                target_url="/var/tmp/test.mov"
+            )
+        )
+        gap = otio.schema.Gap(name="gap")
+
+        tl.tracks[0].append(cl)
+        tl.tracks[0].extend([cl2, cl3, gap])
+
+        union = otio.schema.Box2d(
+            otio.schema.V2d(0.0, 0.0),
+            otio.schema.V2d(3.0, 3.0)
+        )
+
+        # union should be overlapping area, gap should be ignored
+        self.assertEqual(tl.tracks[0].available_image_bounds, union)
+
     def test_iterators(self):
         self.maxDiff = None
         track = otio.schema.Track(name="test_track")

--- a/tests/test_v2d.py
+++ b/tests/test_v2d.py
@@ -1,0 +1,130 @@
+#
+# Copyright Contributors to the OpenTimelineIO project
+#
+# Licensed under the Apache License, Version 2.0 (the "Apache License")
+# with the following modification; you may not use this file except in
+# compliance with the Apache License and the following modification to it:
+# Section 6. Trademarks. is deleted and replaced with:
+#
+# 6. Trademarks. This License does not grant permission to use the trade
+#    names, trademarks, service marks, or product names of the Licensor
+#    and its affiliates, except as required to comply with Section 4(c) of
+#    the License and to reproduce the content of the NOTICE file.
+#
+# You may obtain a copy of the Apache License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the Apache License with the above modification is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the Apache License for the specific
+# language governing permissions and limitations under the Apache License.
+#
+
+import unittest
+import sys
+
+import opentimelineio as otio
+import opentimelineio.test_utils as otio_test_utils
+
+
+class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
+    def test_cons(self):
+        v = otio.schema.V2d(1.0, 2.0)
+
+        self.assertEqual(v.x, 1.0)
+        self.assertEqual(v.y, 2.0)
+
+        self.assertEqual(v[0], 1.0)
+        self.assertEqual(v[1], 2.0)
+
+    def test_str(self):
+        v = otio.schema.V2d(1.0, 2.0)
+
+        self.assertMultiLineEqual(
+            str(v),
+            'V2d(1.0, 2.0)'
+        )
+
+        self.assertMultiLineEqual(
+            repr(v),
+            'otio.schema.V2d(x=1.0, y=2.0)'
+        )
+
+    def test_equality(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+
+        self.assertFalse(v1 == v2)
+        self.assertTrue(v1 != v2)
+
+        v3 = otio.schema.V2d(1.0, 2.0)
+        self.assertTrue(v1 == v3)
+        self.assertFalse(v1 != v3)
+
+        self.assertTrue(v1.equalWithAbsError(v3, 0.0))
+        self.assertTrue(v1.equalWithRelError(v3, 0.0))
+
+    def test_math_ops(self):
+        v1 = otio.schema.V2d(1.0, 2.0)
+        v2 = otio.schema.V2d(3.0, 4.0)
+
+        self.assertEqual(v1 ^ v2, 11.0)
+        self.assertEqual(v1.dot(v2), 11.0)
+
+        self.assertEqual(v1 % v2, -2.0)
+        self.assertEqual(v1.cross(v2), -2.0)
+
+        self.assertEqual(v1 + v2, otio.schema.V2d(4.0, 6.0))
+        self.assertEqual(v1 - v2, otio.schema.V2d(-2.0, -2.0))
+        self.assertEqual(v1 * v2, otio.schema.V2d(3.0, 8.0))
+        self.assertEqual(v1 / v2, otio.schema.V2d(1.0 / 3.0, 0.5))
+
+        v1 += v2
+        self.assertEqual(v1, otio.schema.V2d(4.0, 6.0))
+
+        v1 -= v2
+        self.assertEqual(v1, otio.schema.V2d(1.0, 2.0))
+
+        v1 *= v2
+        self.assertEqual(v1, otio.schema.V2d(3.0, 8.0))
+
+        v1 /= v2
+        self.assertEqual(v1, otio.schema.V2d(1.0, 2.0))
+
+    def test_geometry(self):
+        v = otio.schema.V2d(3.0, 4.0)
+
+        self.assertEqual(v.length(), 5.0)
+        self.assertEqual(v.length2(), 25.0)
+
+    def test_normalize(self):
+        v = otio.schema.V2d(3.0, 4.0)
+
+        self.assertEqual(v.normalized(), otio.schema.V2d(0.6, 0.8))
+        self.assertEqual(v.normalizedNonNull(), otio.schema.V2d(0.6, 0.8))
+
+        v2 = v
+        v.normalize()
+        v2.normalizeNonNull()
+        self.assertEqual(v, otio.schema.V2d(0.6, 0.8))
+        self.assertEqual(v2, otio.schema.V2d(0.6, 0.8))
+
+        nv = otio.schema.V2d(0.0, 0.0)
+
+        with self.assertRaises(ValueError):
+            nv.normalizeExc()
+
+        with self.assertRaises(ValueError):
+            nv.normalizedExc()
+
+    def test_limits(self):
+        self.assertEqual(otio.schema.V2d.baseTypeLowest(), -1 * sys.float_info.max)
+        self.assertEqual(otio.schema.V2d.baseTypeMax(), sys.float_info.max)
+        self.assertEqual(otio.schema.V2d.baseTypeSmallest(), sys.float_info.min)
+        self.assertEqual(otio.schema.V2d.baseTypeEpsilon(), sys.float_info.epsilon)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #771

This is a merge of the spatial_coordinates branch to main.  The code remains unchanged from the branch besides resolving conflicts (mostly whitespace related) related to a clang-format that was run after the initial fork. I also ran clang-format on code coming from the spatial_coordinates branch to conform it to the new style.

I'll copy-paste the comments from the original merge in the spatial_coordinates that contained the bulk of the work below for convenience.  Here's a [link](https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/1022) to it.

**Summary**

This change addresses the need to have spatial bounds expressed in the MediaReference. These are used to define a measurement-agnostic coordinate system representing the viewing area of the clip(s), which can be used by media players to determine how to display or scale/resize/center (if necessary) the media referenced by the Clips.

The Imath library is used to implement the spatial bounding box, specifically the Box class and its dependency Vec. Imath was selected since its already used by OpenExr, another ASWF project, and this helps establish a common standard between the two projects. Since the 2d template specializations (ie Box2d, a box using 2 dimensional doubles) made the most sense in this context, I only implemented support for it, and its V2d (a 2d vector) dependency. This, however, does not close the door to implementing support for more dimensions or other vector types if needed in the future. The Imath types are contained within a Bounds class which derives from SerializableObject. This encapsulation allows not only the serialization of bounds, but also for the concept to be extended in the future -- for example, support for additional Imath types or for a Transformation type to allow transformations between different coordinate systems.

For a more in-depth explanation of the idea and motivations please see the issue linked here:
https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/771

I have flagged as many potential discussion points that I think might arise with Note below.

**Files changed**

.gitmodules
Add Imath as a submodule

*.md files
Lists the additions to the schemas (automatically generated by Makefiles).

src/deps/CMakeLists.txt
Include Imath submodule and set the option to build it statically (without overriding the option for the base OTIO project). We want to build statically to keep the libraries self-contained so they can be made easily into Python wheels. Also use the EXCLUDE_FROM_ALL option if we are not installing dependencies so Imath doesn't write its header files into the installation directory.

src/opentime/CMakeLists.txt
Add new bounds class to compilation, link with static Imath library and remove OpenTimelineIOConfig export. Remove export of build tree (this is the same issue seen here: https://github.com/PixarAnimationStudios/OpenTimelineIO/pull/911).

src/opentimelineio/bounds.cpp
Implement the Bounds class. For the time being it contains only an optional Imath::Box2d. The box is optional to avoid selecting default values for the Box. Since its optional we can simply have no box as the default.

src/opentimelineio/bounds.h
Add mutators and accessors to the public interface.
Python Bindings: Also added

src/opentimelineio/clip.cpp
Implement the bounds method. Simply returns the Bounds if it has been set on the clip or an error otherwise (conforming to the standard of the available_range method).

src/opentimelineio/clip.h
Adds the bounds method to the public interface.
Python Bindings: Also added

src/opentimelineio/composable.cpp
Implements the bounds method to return an error so that any derived classes that do not explicitly override the virtual method return the error (it is overriden by Clip, Stack and Track).

src/opentimelineio/composable.h
Adds the bounds method to the public interface
Python Bindings: Also added

src/opentimelineio/composition.cpp
Implements the has_clips method for composition, which returns true if the Composition contains at least one clip. This function is used by bounds method of the derived Stack class to exclude any tracks that do not contain any clips when it calculates the union of the bounds. Since the bounds default to width, height and center of {0, 0, (0, 0)} we want to prevent the default values from affecting the result and thus use the has_clips method to skip over any tracks that do not contain clips.

src/opentimelineio/composition.h
Adds the has_clips method to the public interface.
Python Bindings: Also added
Note: Even though this method is only needed by Stack, I thought it could be useful elsewhere so I made it public. If you would prefer I could make it protected so only Stack could access it. Or if you do not want it in the interface at all, I can also implement it as a lambda function (or in the anonymous namespace) inside of Stack::bounds.

src/opentimelineio/deserialization.cpp
Implements the de/serialization of Imath::Box2d Imath::V2d and Bounds, including optional support for Imath::Box2d. The code for serializing the Imath types follows the existing standard provided by Time and TimeRange.

src/opentimelineio/errorStatus.cpp
Adds a new error value for when the bounds cannot be determined. This occurs when the user asks for bounds on a Clip that does not contain bounds or asks for bounds on a Composition that has a Clip that does not contain bounds.

src/opentimelineio/externalReference.cpp, src/opentimelineio/generatorReference.cpp, src/opentimelineio/imageSequenceReference.cpp, src/opentimelineio/missingReference.h
Pass bounds constructor argument to MediaReference parent constructor

src/opentimelineio/externalReference.h, src/opentimelineio/generatorReference.h, src/opentimelineio/imageSequenceReference.h, src/opentimelineio/missingReference.h
Adds optional constructor argument for bounds.

src/opentimelineio/mediaReference.cpp
Initializes bounds member and add it to the read/write method for serialization. A Retainer is used to store Bounds so the memory can be managed in the Python bindings similar to the Effect class.

src/opentimelineio/mediaReference.h
Add bounds member and constructor argument as well as a mutator and accessor method.
Python Bindings: Also added (includes derived classes)

src/opentimelineio/safely_typed_any.cpp
Adds casting support for Box2d and V2d (required by serialization code).

src/opentimelineio/safely_typed_any.h
Adds casting methods for Box2d and V2d to public interface.

src/opentimelineio/serializableObject.h
Adds de/serialization support for Box2d and V2d found within the Bounds schema.

src/opentimelineio/serialization.cpp
Adds de/serialization code for Box2d and V2d.

src/opentimelineio/stack.cpp
Implements bounds method for a stack. We begin by finding the first bounding box, defined as the Box of the first Clip or of the first Composition that contains at least one Clip. After this is found, we then extend the box to contain each subsequent Clip or Composition containing at least one Clip. If no Clips are found or no Boxes are found, we return nullptr. If an error is found, we return the error (as a parameter). This follows the standard defined by the available_range method.

src/opentimelineio/stack.h
Adds bounds method to the public interface.
Python Bindings: Also added

src/opentimelineio/timeline.h
Adds bounds to the public interface and implements it by redirecting the call to it's Stack.
Python Bindings: Also added

src/opentimelineio/track.cpp
Implements bounds method for a track. Similarly to Stack, we begin by finding the first bounding box, however in this case we don't need to consider Compositions, only Clips. Once we have the bounding Box of the first clip, we extend it with the Box of each subsequent Clip. If no Clips or Boxes are found, we return nullptr. If an error is found, we return the error (as a parameter) and the default Box. This follows the standard defined by the available_range method.

src/opentimelineio/track.h
Adds bounds method to the public interface.
Python Bindings: Also added

src/opentimelineio/typeRegistry.cpp
Register Bounds as a SerializableObject.

src/py-opentimelineio/opentimelineio-bindings/CMakeLists.txt
Adds compilation of Python bindings for Imath types.

src/py-opentimelineio/opentimelineio-bindings/otio_bindings.cpp
Initialize Imath bindings

src/py-opentimelineio/opentimelineio-bindings/otio_bindings.h
Imath bindings function prototype

src/py-opentimelineio/opentimelineio-bindings/otio_imath.cpp
Create pybind bindings for Imath types.
Note: I did not use the existing Python bindings for Imath here because they are done using boost. Using them would create a dependency on boost that we want to avoid. We don't want to break the self-contained nature of the Python binding libraries by depending on a dynamic system library. Because of this if we want to use the Imath types in the Python OTIO library with the Imath Python library, we would need to create some kind bridge code.

src/py-opentimelineio/opentimelineio-bindings/otio_serializableObjects.cpp
Adds all added opentimelineio public c++ interface methods to the Python bindings
Note: These are denoted by Python Bindings in descriptions above.

src/py-opentimelineio/opentimelineio/core/mediaReference.py
Adds bounds to the repr and str method for MediaReference.

src/py-opentimelineio/opentimelineio/schema/init.py
Import schemas for Bounds, Box2d and V2d.

src/py-opentimelineio/opentimelineio/schema/bounds.py
Create a Bounds schema

src/py-opentimelineio/opentimelineio/schema/box2d.py
Create a Box schema

src/py-opentimelineio/opentimelineio/schema/image_sequence_reference.py
Adds bounds to the repr and str method for ImageSequence.

src/py-opentimelineio/opentimelineio/schema/v2d.py
Create a Vector schema

Tests

tests/baselines/*.json
Adds empty bounds to the json representations
Note: This is necessary even if the bounds don't exist in the metadata since the serialization code will add a null bounds member in this case. If you'd prefer I could make it exclude the bounds member entirely if it is not defined.

tests/sample_data/clip_example.otio
Added bounds to the example clip and associated test (test_documentation.py).

tests/test_bounds.py
Test all the public bounds methods. This is essentially just the schemas and getting and setting the box.

tests/test_box2d.py
Test all public Box2d methods.
Note: I did test each method but only on a basic level to ensure it was bound to the correct underlying C++ method. Imath has its own more rigorous unit testing to make sure the methods are working correctly.

tests/test_clip.py
Updated the str test to include the bounds. Also adds a bounding box to a clip and tests that they were set correctly using the contains methods to find the edges of the Box.

tests/test_composition.py
Tests the added has_clips method on empty stacks and tracks and ones containing no Clips (only Gaps). Also tests that the bounds are correctly applied to empty Stacks, single clip Stacks, multi-clip Stacks, Stacks with gaps, and Stacks containing Tracks containing Clips. Tracks are also tested for empty Tracks, gap-only Tracks, single Clip Tracks and multi-Clip Tracks.

tests/test_media_reference.py
Tests for new bounds in schema

tests/test_v2d.py
Test all public V2d methods.
Note: I did test each method but only on a basic level to ensure it was bound to the correct underlying C++ method. Imath has its own more rigorous unit testing to make sure the methods are working correctly.

tests/test_generator_reference.py, tests/test_image_sequence_reference.py, tests/test_media_reference.py
Ensures the bounds can be passed to the constructor and the same bounds are returned from the accessor.
ImageSequenceReference and MediaRefererence also test the str and repr methods return the expected string.

tests/test_timeline.py
Timeline bounds are tested to ensure a single track timeline has equal bounds between the Track and the Timeline.