### PR TITLE
Port to PySide6

### DIFF
--- a/docs/tutorials/quickstart.md
+++ b/docs/tutorials/quickstart.md
@@ -8,10 +8,10 @@ This is for users who wish to get started using the "OTIOView" application to in
 
 OTIOView has an additional prerequisite to OTIO:
 
-- Try `python -m pip install PySide2`
-- If that doesn't work, try downloading PySide2 here: <a href="https://wiki.qt.io/Qt_for_Python" target="_blank">https://wiki.qt.io/Qt_for_Python</a>
+- Try `python -m pip install PySide2` or `python -m pip install PySide6`
+- If that doesn't work, try downloading PySide here: <a href="https://wiki.qt.io/Qt_for_Python" target="_blank">https://wiki.qt.io/Qt_for_Python</a>
 
-You probably want the prebuilt binary for your platform.  PySide2 generally includes a link to the appropriate version of Qt as well.
+You probably want the prebuilt binary for your platform.  PySide generally includes a link to the appropriate version of Qt as well.
 
 ## Install OTIO
 

--- a/setup.py
+++ b/setup.py
@@ -356,7 +356,8 @@ setup(
             'urllib3>=1.24.3'
         ],
         'view': [
-            'PySide2~=5.11'
+            'PySide2~=5.11; platform.machine=="x86_64"',
+            'PySide6~=6.2; platform.machine=="aarch64"'
         ]
     },
 

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -28,7 +28,12 @@
 import os
 import sys
 import argparse
-from PySide6 import QtWidgets, QtGui
+try:
+    from PySide6 import QtWidgets, QtGui
+    from PySide6.QtGui import QAction
+except ImportError:
+    from PySide2 import QtWidgets, QtGui
+    from PySide2.QtWidgets import QAction
 
 import opentimelineio as otio
 import opentimelineio.console as otio_console
@@ -148,11 +153,11 @@ class Main(QtWidgets.QMainWindow):
         # menu
         menubar = self.menuBar()
 
-        file_load = QtGui.QAction('Open...', menubar)
+        file_load = QAction('Open...', menubar)
         file_load.setShortcut(QtGui.QKeySequence.Open)
         file_load.triggered.connect(self._file_load)
 
-        exit_action = QtGui.QAction('Exit', menubar)
+        exit_action = QAction('Exit', menubar)
         exit_action.setShortcut(QtGui.QKeySequence.Quit)
         exit_action.triggered.connect(self.close)
 
@@ -234,7 +239,7 @@ class Main(QtWidgets.QMainWindow):
 
         def __callback():
             self._navigation_filter_callback(actions)
-        navigation_menu.triggered[[QtGui.QAction]].connect(__callback)
+        navigation_menu.triggered[[QAction]].connect(__callback)
 
     def _navigation_filter_callback(self, filters):
         nav_filter = 0

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -28,7 +28,7 @@
 import os
 import sys
 import argparse
-from PySide2 import QtWidgets, QtGui
+from PySide6 import QtWidgets, QtGui
 
 import opentimelineio as otio
 import opentimelineio.console as otio_console
@@ -148,11 +148,11 @@ class Main(QtWidgets.QMainWindow):
         # menu
         menubar = self.menuBar()
 
-        file_load = QtWidgets.QAction('Open...', menubar)
+        file_load = QtGui.QAction('Open...', menubar)
         file_load.setShortcut(QtGui.QKeySequence.Open)
         file_load.triggered.connect(self._file_load)
 
-        exit_action = QtWidgets.QAction('Exit', menubar)
+        exit_action = QtGui.QAction('Exit', menubar)
         exit_action.setShortcut(QtGui.QKeySequence.Quit)
         exit_action.triggered.connect(self.close)
 
@@ -234,7 +234,7 @@ class Main(QtWidgets.QMainWindow):
 
         def __callback():
             self._navigation_filter_callback(actions)
-        navigation_menu.triggered[[QtWidgets.QAction]].connect(__callback)
+        navigation_menu.triggered[[QtGui.QAction]].connect(__callback)
 
     def _navigation_filter_callback(self, filters):
         nav_filter = 0
@@ -247,11 +247,7 @@ class Main(QtWidgets.QMainWindow):
 
     def center(self):
         frame = self.frameGeometry()
-        desktop = QtWidgets.QApplication.desktop()
-        screen = desktop.screenNumber(
-            desktop.cursor().pos()
-        )
-        centerPoint = desktop.screenGeometry(screen).center()
+        centerPoint = QtGui.QScreen().availableGeometry().center()
         frame.moveCenter(centerPoint)
         self.move(frame.topLeft())
 

--- a/src/opentimelineview/details_widget.py
+++ b/src/opentimelineview/details_widget.py
@@ -95,7 +95,9 @@ class OTIOSyntaxHighlighter(QtGui.QSyntaxHighlighter):
 
         text.replace("\\\"", "  ")
 
-        expression = QtCore.QRegularExpression("\".*\" *\\:", QtCore.QRegularExpression.InvertedGreedinessOption)
+        expression = QtCore.QRegularExpression(
+            "\".*\" *\\:",
+            QtCore.QRegularExpression.InvertedGreedinessOption)
         match = expression.match(text)
         index = match.capturedStart()
         while index >= 0:
@@ -104,7 +106,9 @@ class OTIOSyntaxHighlighter(QtGui.QSyntaxHighlighter):
             match = expression.match(text, index + length)
             index = match.capturedStart()
 
-        expression = QtCore.QRegularExpression("\\: *\".*\"", QtCore.QRegularExpression.InvertedGreedinessOption)
+        expression = QtCore.QRegularExpression(
+            "\\: *\".*\"",
+            QtCore.QRegularExpression.InvertedGreedinessOption)
         match = expression.match(text)
         index = match.capturedStart()
         while index >= 0:

--- a/src/opentimelineview/details_widget.py
+++ b/src/opentimelineview/details_widget.py
@@ -22,7 +22,10 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide6 import QtWidgets, QtGui, QtCore
+try:
+    from PySide6 import QtWidgets, QtGui, QtCore
+except ImportError:
+    from PySide2 import QtWidgets, QtGui, QtCore
 
 import opentimelineio as otio
 

--- a/src/opentimelineview/details_widget.py
+++ b/src/opentimelineview/details_widget.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtWidgets, QtGui, QtCore
+from PySide6 import QtWidgets, QtGui, QtCore
 
 import opentimelineio as otio
 
@@ -84,43 +84,51 @@ class OTIOSyntaxHighlighter(QtGui.QSyntaxHighlighter):
         self.schema_format.setFontWeight(QtGui.QFont.Bold)
 
     def highlightBlock(self, text):
-        expression = QtCore.QRegExp("(\\{|\\}|\\[|\\]|\\:|\\,)")
-        index = expression.indexIn(text)
+        expression = QtCore.QRegularExpression("(\\{|\\}|\\[|\\]|\\:|\\,)")
+        match = expression.match(text)
+        index = match.capturedStart()
         while index >= 0:
-            length = expression.matchedLength()
+            length = match.capturedLength()
             self.setFormat(index, length, self.punctuation_format)
-            index = expression.indexIn(text, index + length)
+            match = expression.match(text, index + length)
+            index = match.capturedStart()
 
         text.replace("\\\"", "  ")
 
-        expression = QtCore.QRegExp("\".*\" *\\:")
-        expression.setMinimal(True)
-        index = expression.indexIn(text)
+        expression = QtCore.QRegularExpression("\".*\" *\\:", QtCore.QRegularExpression.InvertedGreedinessOption)
+        match = expression.match(text)
+        index = match.capturedStart()
         while index >= 0:
-            length = expression.matchedLength()
+            length = match.capturedLength()
             self.setFormat(index, length - 1, self.key_format)
-            index = expression.indexIn(text, index + length)
+            match = expression.match(text, index + length)
+            index = match.capturedStart()
 
-        expression = QtCore.QRegExp("\\: *\".*\"")
-        expression.setMinimal(True)
-        index = expression.indexIn(text)
+        expression = QtCore.QRegularExpression("\\: *\".*\"", QtCore.QRegularExpression.InvertedGreedinessOption)
+        match = expression.match(text)
+        index = match.capturedStart()
         while index >= 0:
-            length = expression.matchedLength()
+            length = match.capturedLength()
             firstQuoteIndex = text.index('"', index)
             valueLength = length - (firstQuoteIndex - index) - 2
             self.setFormat(firstQuoteIndex + 1, valueLength, self.value_format)
-            index = expression.indexIn(text, index + length)
+            match = expression.match(text, index + length)
+            index = match.capturedStart()
 
-        expression = QtCore.QRegExp(r"\\: (null|true|false|[0-9\.]+)")
-        index = expression.indexIn(text)
+        expression = QtCore.QRegularExpression(r"\\: (null|true|false|[0-9\.]+)")
+        match = expression.match(text)
+        index = match.capturedStart()
         while index >= 0:
-            length = expression.matchedLength()
+            length = match.capturedLength()
             self.setFormat(index, length, self.literal_format)
-            index = expression.indexIn(text, index + length)
+            match = expression.match(text, index + length)
+            index = match.capturedStart()
 
-        expression = QtCore.QRegExp(r"\"OTIO_SCHEMA\"\s*:\s*\".*\"")
-        index = expression.indexIn(text)
+        expression = QtCore.QRegularExpression(r"\"OTIO_SCHEMA\"\s*:\s*\".*\"")
+        match = expression.match(text)
+        index = match.capturedStart()
         while index >= 0:
-            length = expression.matchedLength()
+            length = match.capturedLength()
             self.setFormat(index, length, self.schema_format)
-            index = expression.indexIn(text, index + length)
+            match = expression.match(text, index + length)
+            index = match.capturedStart()

--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -22,7 +22,10 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide6 import QtGui, QtCore, QtWidgets
+try:
+    from PySide6 import QtGui, QtCore, QtWidgets
+except ImportError:
+    from PySide2 import QtGui, QtCore, QtWidgets
 import collections
 import math
 from . import track_widgets

--- a/src/opentimelineview/ruler_widget.py
+++ b/src/opentimelineview/ruler_widget.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import collections
 import math
 from . import track_widgets

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -22,7 +22,7 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 from collections import OrderedDict, namedtuple
 
 import opentimelineio as otio
@@ -461,7 +461,7 @@ class CompositionView(QtWidgets.QGraphicsView):
     def wheelEvent(self, event):
         scale_by = 1.0 + float(event.delta()) / 1000
         self.scale(scale_by, 1)
-        zoom_level = 1.0 / self.matrix().m11()
+        zoom_level = 1.0 / self.transform().m11()
         track_widgets.CURRENT_ZOOM_LEVEL = zoom_level
 
         # some items we do want to keep the same visual size. So we need to
@@ -707,10 +707,10 @@ class CompositionView(QtWidgets.QGraphicsView):
             self.frame_all()
 
     def frame_all(self):
-        zoom_level = 1.0 / self.matrix().m11()
+        zoom_level = 1.0 / self.transform().m11()
         scaleFactor = self.size().width() / self.sceneRect().width()
         self.scale(scaleFactor * zoom_level, 1)
-        zoom_level = 1.0 / self.matrix().m11()
+        zoom_level = 1.0 / self.transform().m11()
         track_widgets.CURRENT_ZOOM_LEVEL = zoom_level
         items_to_scale = [
             i for i in self.scene().items()

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -22,7 +22,10 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide6 import QtGui, QtCore, QtWidgets
+try:
+    from PySide6 import QtGui, QtCore, QtWidgets
+except ImportError:
+    from PySide2 import QtGui, QtCore, QtWidgets
 from collections import OrderedDict, namedtuple
 
 import opentimelineio as otio

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -22,9 +22,9 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide2 import QtGui, QtCore, QtWidgets
+from PySide6 import QtGui, QtCore, QtWidgets
 import opentimelineio as otio
-from PySide2.QtGui import QFontMetrics
+from PySide6.QtGui import QFontMetrics
 
 TIME_SLIDER_HEIGHT = 20
 MEDIA_TYPE_SEPARATOR_HEIGHT = 5
@@ -258,7 +258,7 @@ class TrackNameItem(BaseItem):
         self.font = self.source_name_label.font()
         self.short_width = TRACK_NAME_WIDGET_WIDTH
         font_metrics = QFontMetrics(self.font)
-        self.full_width = font_metrics.width(self.full_track_name) + 40
+        self.full_width = font_metrics.horizontalAdvance(self.full_track_name) + 40
 
         if not self.track.enabled:
             self.setBrush(

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -22,7 +22,11 @@
 # language governing permissions and limitations under the Apache License.
 #
 
-from PySide6 import QtGui, QtCore, QtWidgets
+try:
+    from PySide6 import QtGui, QtCore, QtWidgets
+except ImportError:
+    from PySide2 import QtGui, QtCore, QtWidgets
+
 import opentimelineio as otio
 from PySide6.QtGui import QFontMetrics
 


### PR DESCRIPTION
Fixes #1215
Fixes #1220

This PR upgrades opentimelineview to work with PySide6. I believe most of these changes are also compatible with PySide2 except for these:
* from PySide6
* QtGui.QAction

I'm not very familiar with Python so I'm not sure if there is a way to support both PySide2 and PySide6?

A screenshot of otioview running with PySide6 on an Apple M1:
<img width="1297" alt="Screen Shot 2022-02-20 at 3 31 07 PM" src="https://user-images.githubusercontent.com/8532558/154869730-b2c1d38e-0af7-413a-9dc2-28ba4ac1c98f.png">

