### PR TITLE
Don't skip asserts in unit test release builds

### DIFF
--- a/tests/utils.h
+++ b/tests/utils.h
@@ -1,4 +1,5 @@
 #pragma once
+#undef NDEBUG
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
Fixes #1235

**Summarize your change.**

This branch undefines NDEBUG when using unit tests.  This is to ensure the asserts used in assertEqual and assertNotEqual, etc fail the test even in release builds.  Since this file is only included by the unit tests it won't have any impact outside of that scope.

**Reference associated tests.**

test_clip.cpp and test_opentime.cpp
