### PR TITLE
otioview track and window fit improvements

### DIFF
--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -270,6 +270,8 @@ class Main(QtWidgets.QMainWindow):
             if new_frame_w != frame_w or new_frame_h != frame_h:
                 self.resize(new_frame_w, new_frame_h)
                 frame_geo = self.frameGeometry()
+                frame_w = frame_geo.width()
+                frame_h = frame_geo.height()
 
             center_point = screen_geo.center()
             center_point.setY(center_point.y() - title_bar_height // 2)

--- a/src/opentimelineview/console.py
+++ b/src/opentimelineview/console.py
@@ -251,10 +251,30 @@ class Main(QtWidgets.QMainWindow):
         self.timeline_widget.navigationfilter_changed.emit(nav_filter)
 
     def center(self):
-        frame = self.frameGeometry()
-        centerPoint = QtGui.QScreen().availableGeometry().center()
-        frame.moveCenter(centerPoint)
-        self.move(frame.topLeft())
+        screens = QtWidgets.QApplication.screens()
+        if screens:
+            style = QtWidgets.QApplication.style()
+            title_bar_height = style.pixelMetric(QtWidgets.QStyle.PM_TitleBarHeight)
+
+            screen = screens[0]
+            screen_geo = screen.availableGeometry()
+            screen_w = screen_geo.width()
+            screen_h = screen_geo.height() - title_bar_height
+
+            frame_geo = self.frameGeometry()
+            frame_w = frame_geo.width()
+            frame_h = frame_geo.height()
+
+            new_frame_w = screen_w if frame_w > screen_w else frame_w
+            new_frame_h = screen_h if frame_h > screen_h else frame_h
+            if new_frame_w != frame_w or new_frame_h != frame_h:
+                self.resize(new_frame_w, new_frame_h)
+                frame_geo = self.frameGeometry()
+
+            center_point = screen_geo.center()
+            center_point.setY(center_point.y() - title_bar_height // 2)
+            frame_geo.moveCenter(center_point)
+            self.move(frame_geo.topLeft())
 
     def show(self):
         super(Main, self).show()

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -197,7 +197,7 @@ class CompositionWidget(QtWidgets.QGraphicsScene):
         self.setSceneRect(
             start_time * track_widgets.TIME_MULTIPLIER,
             0,
-            duration * track_widgets.TIME_MULTIPLIER + 
+            duration * track_widgets.TIME_MULTIPLIER +
             self.track_name_width() * zoom_level,
             height
         )

--- a/src/opentimelineview/timeline_widget.py
+++ b/src/opentimelineview/timeline_widget.py
@@ -80,7 +80,7 @@ def get_nav_menu_data():
 
 def get_filters(filter_dict, bitmask):
     filters = list()
-    for item in filter_dict.itervalues():
+    for item in filter_dict.values():
         if bitmask & item.bitmask:
             filters.append(item)
     return filters

--- a/src/opentimelineview/track_widgets.py
+++ b/src/opentimelineview/track_widgets.py
@@ -279,7 +279,6 @@ class TrackNameItem(BaseItem):
                 self.track_name + '\n({})'.format(self.track.kind))
             for widget in self.track_widget.widget_items:
                 widget.current_x_offset = self.short_width
-                widget.counteract_zoom(CURRENT_ZOOM_LEVEL)
             self.name_toggle = False
         else:
             track_name_rect = QtCore.QRectF(
@@ -293,8 +292,16 @@ class TrackNameItem(BaseItem):
                 self.full_track_name + '\n({})'.format(self.track.kind))
             for widget in self.track_widget.widget_items:
                 widget.current_x_offset = self.full_width
-                widget.counteract_zoom(CURRENT_ZOOM_LEVEL)
             self.name_toggle = True
+
+        scene = self.scene()
+        if scene and hasattr(scene, "counteract_zoom"):
+            # If scene is CompositionWidget, trigger counteract zoom through
+            # it to also update the scene rect.
+            scene.counteract_zoom(CURRENT_ZOOM_LEVEL)
+        else:
+            for widget in self.track_widget.widget_items:
+                widget.counteract_zoom(CURRENT_ZOOM_LEVEL)
 
     def itemChange(self, change, value):
         return super(BaseItem, self).itemChange(change, value)


### PR DESCRIPTION
Fixes #1207 

This resolves an issue where `otioview` didn't take into account `TrackNameItem` width when framing the timeline within the current graphics scene. This resulted in track ends going offscreen without the ability to scroll to them until the window was expanded. It will now factor in the largest name item width to adapt to normal and expanded item states.

This PR also resolves a related issue with the initial size and position of the `otioview` window. Previously the window was centered to a default constructed `QScreen`, which in my debugging on Windows could contain garbage size data and put the otioview window far off screen. It also didn't take into account small screens (like the laptop I am contributing from), window title bars, and OS-used portions of the screen for things like a taskbar. I've updated the method to get the screen from the QApplication, to resize the window to fit the screen if necessary, and to make sure it is centered in the available space provided by the OS. This reduces the need for users to move or resize the window to work in `otioview`, preserving the initial track fit results.

Lastly, there is a one line change that fixes a Python 3 incompatibility. I've been testing this in Python 3.7 and 3.9 on Windows and have not run into issues. It would be good to verify the results of these fixes on Linux and macOS prior to merging this.