### PR TITLE
Install full OTIO Python env with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,11 @@ project(OpenTimelineIO VERSION ${OTIO_VERSION} LANGUAGES C CXX)
 # maintenance and troubleshooting
 
 # Installation options
-option(OTIO_CXX_INSTALL          "Install the C++ bindings" ON)
-option(OTIO_PYTHON_INSTALL       "Install the Python bindings" OFF)
-option(OTIO_DEPENDENCIES_INSTALL "Install OTIO's C++ header dependencies (any and nonstd)" ON)
+option(OTIO_CXX_INSTALL               "Install the C++ bindings" ON)
+option(OTIO_PYTHON_INSTALL            "Install the Python bindings" OFF)
+option(OTIO_DEPENDENCIES_INSTALL      "Install OTIO's C++ header dependencies (any and nonstd)" ON)
 option(OTIO_INSTALL_COMMANDLINE_TOOLS "Install the OTIO command line tools" ON)
+option(OTIO_INSTALL_CONTRIB           "Install the opentimelineio_contrib Python package" ON)
 set(OTIO_PYTHON_INSTALL_DIR "" CACHE STRING "Python installation dir (such as the site-packages dir)")
 
 # Build options

--- a/src/py-opentimelineio/CMakeLists.txt
+++ b/src/py-opentimelineio/CMakeLists.txt
@@ -1,2 +1,21 @@
+#------------------------------------------------------------------------------
+# py-opentimelineio/CMakeLists.txt
+
 add_subdirectory(opentime-bindings)
 add_subdirectory(opentimelineio-bindings)
+
+# Install pure-python OTIO packages to match PyPI wheel structure
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/py-opentimelineio/opentimelineio/"
+    DESTINATION "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}/opentimelineio")
+
+if(OTIO_INSTALL_COMMANDLINE_TOOLS)
+    install(DIRECTORY "${PROJECT_SOURCE_DIR}/src/opentimelineview"
+        DESTINATION "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}")
+endif()
+
+if(OTIO_INSTALL_CONTRIB)
+    install(DIRECTORY "${PROJECT_SOURCE_DIR}/contrib/opentimelineio_contrib"
+        DESTINATION "${OTIO_RESOLVED_PYTHON_INSTALL_DIR}"
+        PATTERN "tests" EXCLUDE
+        PATTERN "Makefile" EXCLUDE)
+endif()


### PR DESCRIPTION
Currently when setting `OTIO_PYTHON_INSTALL=ON` in CMake, only the compiled Python bindings are installed, which can't be used on their own. This update expands this to match the OTIO PyPI package in the CMake install location, including the three pure-python libs: `opentimelineio`, `opentimelineview`, and `opentielineio_contrib`. The result is that the CMake install is production-ready in a Python env.

While on by default when building the Python bindings, `opentimelineview` is also gated behind the existing (and currently unused) `OTIO_INSTALL_COMMANDLINE_TOOLS`, and `opentielineio_contrib` behind a new `OTIO_INSTALL_CONTRIB` option, so both can be turned off if only the core lib is needed.
