### PR TITLE
clang notices that constexpr can't be used on a mutating function

### DIFF
--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -153,7 +153,7 @@ public:
 
     std::string to_time_string() const;
 
-    inline RationalTime const& operator+=(RationalTime other) noexcept
+   RationalTime const& operator+=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -167,7 +167,7 @@ public:
         return *this;
     }
 
-    inline RationalTime const& operator-=(RationalTime other) noexcept
+   RationalTime const& operator-=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {

--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -153,7 +153,7 @@ public:
 
     std::string to_time_string() const;
 
-    constexpr RationalTime const& operator+=(RationalTime other) noexcept
+    inline RationalTime const& operator+=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {
@@ -167,7 +167,7 @@ public:
         return *this;
     }
 
-    constexpr RationalTime const& operator-=(RationalTime other) noexcept
+    inline RationalTime const& operator-=(RationalTime other) noexcept
     {
         if (_rate < other._rate)
         {


### PR DESCRIPTION
This PR fixes an issue raised by the version of Clang bundled with XCode 13.x, see below. Clang correctly notices that constexpr can't be used on a mutating function.

````
Users/nporcino/build/local/include/opentime/rationalTime.h:160:20: error: cannot assign to non-static data member within const member function 'operator+='
            _value = other._value + value_rescaled_to(other._rate);
            ~~~~~~ ^
/Users/nporcino/build/local/include/opentime/rationalTime.h:156:35: note: member function 'opentime::v1_0::RationalTime::operator+=' is declared const here
    constexpr RationalTime const& operator+=(RationalTime other) noexcept
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nporcino/build/local/include/opentime/rationalTime.h:161:20: error: cannot assign to non-static data member within const member function 'operator+='
            _rate  = other._rate;
            ~~~~~  ^
/Users/nporcino/build/local/include/opentime/rationalTime.h:156:35: note: member function 'opentime::v1_0::RationalTime::operator+=' is declared const here
    constexpr RationalTime const& operator+=(RationalTime other) noexcept
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nporcino/build/local/include/opentime/rationalTime.h:165:20: error: cannot assign to non-static data member within const member function 'operator+='
            _value += other.value_rescaled_to(_rate);
            ~~~~~~ ^
/Users/nporcino/build/local/include/opentime/rationalTime.h:156:35: note: member function 'opentime::v1_0::RationalTime::operator+=' is declared const here
    constexpr RationalTime const& operator+=(RationalTime other) noexcept
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nporcino/build/local/include/opentime/rationalTime.h:174:20: error: cannot assign to non-static data member within const member function 'operator-='
            _value = value_rescaled_to(other._rate) - other._value;
            ~~~~~~ ^
/Users/nporcino/build/local/include/opentime/rationalTime.h:170:35: note: member function 'opentime::v1_0::RationalTime::operator-=' is declared const here
    constexpr RationalTime const& operator-=(RationalTime other) noexcept
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nporcino/build/local/include/opentime/rationalTime.h:175:20: error: cannot assign to non-static data member within const member function 'operator-='
            _rate  = other._rate;
            ~~~~~  ^
/Users/nporcino/build/local/include/opentime/rationalTime.h:170:35: note: member function 'opentime::v1_0::RationalTime::operator-=' is declared const here
    constexpr RationalTime const& operator-=(RationalTime other) noexcept
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/nporcino/build/local/include/opentime/rationalTime.h:179:20: error: cannot assign to non-static data member within const member function 'operator-='
            _value -= other.value_rescaled_to(_rate);
            ~~~~~~ ^
/Users/nporcino/build/local/include/opentime/rationalTime.h:170:35: note: member function 'opentime::v1_0::RationalTime::operator-=' is declared const here
    constexpr RationalTime const& operator-=(RationalTime other) noexcept
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
6 errors generated.
````
