### PR TITLE
Support OTIO_PLUGIN_MANIFEST_PATH being set to an empty string

### DIFF
--- a/src/py-opentimelineio/opentimelineio/plugins/manifest.py
+++ b/src/py-opentimelineio/opentimelineio/plugins/manifest.py
@@ -232,9 +232,10 @@ def load_manifest():
 
     # Read plugin manifests defined on the $OTIO_PLUGIN_MANIFEST_PATH
     # environment variable.  This variable is an os.pathsep separated list of
-    # file paths to manifest json files.
+    # file paths to manifest json files. Can be set to "" to indicate no
+    # local custom manifest path.
     _local_manifest_path = os.environ.get("OTIO_PLUGIN_MANIFEST_PATH", None)
-    if _local_manifest_path is not None:
+    if _local_manifest_path:
         for src_json_path in _local_manifest_path.split(os.pathsep):
             json_path = os.path.abspath(src_json_path)
             if (

--- a/tests/test_adapter_plugin.py
+++ b/tests/test_adapter_plugin.py
@@ -208,36 +208,38 @@ class TestPluginManifest(unittest.TestCase):
         bak = otio.plugins.manifest._MANIFEST
         bak_env = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
 
-        # Generate a fake manifest in a temp file, and point at it with
-        # the environment variable
-        with tempfile.TemporaryDirectory(
-            prefix='test_find_manifest_by_environment_variable'
-        ) as temp_dir:
-            temp_file = os.path.join(temp_dir, basename)
-            otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
+        try:
+            # Generate a fake manifest in a temp file, and point at it with
+            # the environment variable
+            with tempfile.TemporaryDirectory(
+                prefix='test_find_manifest_by_environment_variable'
+            ) as temp_dir:
+                temp_file = os.path.join(temp_dir, basename)
+                otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
 
-            # clear out existing manifest
-            otio.plugins.manifest._MANIFEST = None
+                # clear out existing manifest
+                otio.plugins.manifest._MANIFEST = None
 
-            # set where to find the new manifest
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = (
-                temp_file
-                # add it twice
-                + os.pathsep + temp_file
-            )
-            result = otio.plugins.manifest.load_manifest()
+                # set where to find the new manifest
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = (
+                    temp_file
+                    # add it twice
+                    + os.pathsep + temp_file
+                )
+                result = otio.plugins.manifest.load_manifest()
 
-            # ... should only appear once in the result
-            self.assertEqual(result.source_files.count(temp_file), 1)
+                # ... should only appear once in the result
+                self.assertEqual(result.source_files.count(temp_file), 1)
 
-            # Rather than try and remove any other setuptools based plugins
-            # that might be installed, this check is made more permissive to
-            # see if the known unit test linker is being loaded by the manifest
-            self.assertTrue(len(result.media_linkers) > 0)
-            self.assertIn("example", (ml.name for ml in result.media_linkers))
+                # Rather than try and remove any other setuptools based plugins
+                # that might be installed, this check is made more permissive to
+                # see if the known unit test linker is being loaded by the manifest
+                self.assertTrue(len(result.media_linkers) > 0)
+                self.assertIn("example", (ml.name for ml in result.media_linkers))
 
+        finally:
             otio.plugins.manifest._MANIFEST = bak
-            if bak_env:
+            if bak_env is not None:
                 os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
             else:
                 del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
@@ -249,31 +251,58 @@ class TestPluginManifest(unittest.TestCase):
         bak = otio.plugins.manifest._MANIFEST
         bak_env = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
 
-        # Generate a fake manifest in a temp file, and point at it with
-        # the environment variable
-        with tempfile.TemporaryDirectory(
-            prefix='test_find_manifest_by_environment_variable'
-        ) as temp_dir:
-            temp_file = os.path.join(temp_dir, basename)
-            otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
+        try:
+            # Generate a fake manifest in a temp file, and point at it with
+            # the environment variable
+            with tempfile.TemporaryDirectory(
+                prefix='test_find_manifest_by_environment_variable'
+            ) as temp_dir:
+                temp_file = os.path.join(temp_dir, basename)
+                otio.adapters.write_to_file(self.man, temp_file, 'otio_json')
 
+                # clear out existing manifest
+                otio.plugins.manifest._MANIFEST = None
+
+                # set where to find the new manifest
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = (
+                    temp_file + os.pathsep + 'foo'
+                )
+                result = otio.plugins.manifest.load_manifest()
+
+                # Rather than try and remove any other setuptools based plugins
+                # that might be installed, this check is made more permissive to
+                # see if the known unit test linker is being loaded by the manifest
+                self.assertTrue(len(result.media_linkers) > 0)
+                self.assertIn("example", (ml.name for ml in result.media_linkers))
+        finally:
+            otio.plugins.manifest._MANIFEST = bak
+            if bak_env is not None:
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
+            else:
+                del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
+
+    def test_load_manifest_empty_environment_variable(self):
+        # back up existing manifest
+        bak = otio.plugins.manifest._MANIFEST
+        bak_env = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
+
+        try:
             # clear out existing manifest
             otio.plugins.manifest._MANIFEST = None
 
-            # set where to find the new manifest
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = (
-                temp_file + os.pathsep + 'foo'
-            )
+            # set manifest to an empty path
+            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = ''
             result = otio.plugins.manifest.load_manifest()
 
-            # Rather than try and remove any other setuptools based plugins
-            # that might be installed, this check is made more permissive to
-            # see if the known unit test linker is being loaded by the manifest
-            self.assertTrue(len(result.media_linkers) > 0)
-            self.assertIn("example", (ml.name for ml in result.media_linkers))
+            # Make sure adapters and linkers landed in the proper place
+            for adapter in result.adapters:
+                self.assertIsInstance(adapter, otio.adapters.Adapter)
 
+            for linker in result.media_linkers:
+                self.assertIsInstance(linker, otio.media_linker.MediaLinker)
+        finally:
             otio.plugins.manifest._MANIFEST = bak
-            if bak_env:
+            if bak_env is not None:
                 os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
             else:
                 del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
@@ -284,50 +313,50 @@ class TestPluginManifest(unittest.TestCase):
         # back up existing manifest
         bak = otio.plugins.manifest._MANIFEST
         bak_env = os.environ.get('OTIO_PLUGIN_MANIFEST_PATH')
+        try:
+            local_manifest = {
+                "OTIO_SCHEMA": "PluginManifest.1",
+                "adapters": [
+                    {
+                        "OTIO_SCHEMA": "Adapter.1",
+                        "name": "local_json",
+                        "execution_scope": "in process",
+                        "filepath": "example.py",
+                        "suffixes": ["example"]
+                    }
+                ],
+            }
 
-        local_manifest = {
-            "OTIO_SCHEMA": "PluginManifest.1",
-            "adapters": [
-                {
-                    "OTIO_SCHEMA": "Adapter.1",
-                    "name": "local_json",
-                    "execution_scope": "in process",
-                    "filepath": "example.py",
-                    "suffixes": ["example"]
-                }
-            ],
-        }
+            with tempfile.TemporaryDirectory() as temp_dir:
+                filename = os.path.join(temp_dir, basename)
 
-        with tempfile.TemporaryDirectory() as temp_dir:
-            filename = os.path.join(temp_dir, basename)
+                otio.adapters.write_to_file(local_manifest, filename, 'otio_json')
 
-            otio.adapters.write_to_file(local_manifest, filename, 'otio_json')
+                result = otio.plugins.manifest.load_manifest()
+                self.assertTrue(len(result.adapters) > 0)
+                self.assertIn("otio_json", (ml.name for ml in result.adapters))
+                self.assertNotIn("local_otio", (ml.name for ml in result.adapters))
 
-            result = otio.plugins.manifest.load_manifest()
-            self.assertTrue(len(result.adapters) > 0)
-            self.assertIn("otio_json", (ml.name for ml in result.adapters))
-            self.assertNotIn("local_otio", (ml.name for ml in result.adapters))
+                # set where to find the new manifest
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = filename
+                result = otio.plugins.manifest.load_manifest()
 
-            # set where to find the new manifest
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = filename
-            result = otio.plugins.manifest.load_manifest()
-
-            # Rather than try and remove any other setuptools based plugins
-            # that might be installed, this check is made more permissive to
-            # see if the known unit test linker is being loaded by the manifest
-            self.assertTrue(len(result.adapters) > 0)
-            self.assertIn("otio_json", (ml.name for ml in result.adapters))
-            self.assertIn("local_json", (ml.name for ml in result.adapters))
-            self.assertLess(
-                [ml.name for ml in result.adapters].index("local_json"),
-                [ml.name for ml in result.adapters].index("otio_json")
-            )
-
-        otio.plugins.manifest._MANIFEST = bak
-        if bak_env:
-            os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
-        else:
-            del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
+                # Rather than try and remove any other setuptools based plugins
+                # that might be installed, this check is made more permissive to
+                # see if the known unit test linker is being loaded by the manifest
+                self.assertTrue(len(result.adapters) > 0)
+                self.assertIn("otio_json", (ml.name for ml in result.adapters))
+                self.assertIn("local_json", (ml.name for ml in result.adapters))
+                self.assertLess(
+                    [ml.name for ml in result.adapters].index("local_json"),
+                    [ml.name for ml in result.adapters].index("otio_json")
+                )
+        finally:
+            otio.plugins.manifest._MANIFEST = bak
+            if bak_env is not None:
+                os.environ['OTIO_PLUGIN_MANIFEST_PATH'] = bak_env
+            else:
+                del os.environ['OTIO_PLUGIN_MANIFEST_PATH']
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This restores the ability to set OTIO_PLUGIN_MANIFEST_PATH to an empty string
to indicate no local custom manifest file.

**Link the Issue(s) this Pull Request is related to.**

Fixes #1252

**Summarize your change.**

This changes a truthy check on the env var OTIO_PLUGIN_MANIFEST_PATH to skip any false value and not explicitly `is None`. This will allow OTIO_PLUGIN_MANIFEST_PATH='' to be equivalent to that env var not being set. 

**Reference associated tests.**

Added a test specifically for this. Also updated all tests in `test_adapter_plugin.py` to always un-set custom env vars or manifests on exceptions due to test failures so as to not pollute subsequent tests. 

