### PR TITLE
Detect & use Imath from vfxplatform CY2019-2022

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,6 @@ set (OTIO_IMATH_TARGETS
     # For OpenEXR <= 2.3:
     ${ILMBASE_LIBRARIES})
 
-get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
-message(XXX4 "${IMATH_INCLUDES}")
 message(XXX5 "${OTIO_IMATH_TARGETS}")
 
 add_subdirectory(src/opentime)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,8 +239,6 @@ if (NOT Imath_FOUND)
         set(USE_DEPS_IMATH ON)
     else()
         message(STATUS "Using IlmBase::Imath specifed by ${IlmBase_CONFIG}")
-        get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
-        message(XXX1 "${IMATH_INCLUDES} ... ${IlmBase_INCLUDE_DIRS}")
     endif()
 else()
     message(STATUS "Using Imath::Imath specified by ${Imath_CONFIG}")
@@ -259,8 +257,6 @@ set (OTIO_IMATH_TARGETS
     $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
     # For OpenEXR <= 2.3:
     ${ILMBASE_LIBRARIES})
-
-message(XXX5 "${OTIO_IMATH_TARGETS}")
 
 add_subdirectory(src/opentime)
 add_subdirectory(src/opentimelineio)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(OTIO_PYTHON_INSTALL            "Install the Python bindings" OFF)
 option(OTIO_DEPENDENCIES_INSTALL      "Install OTIO's C++ header dependencies (any and nonstd)" ON)
 option(OTIO_INSTALL_COMMANDLINE_TOOLS "Install the OTIO command line tools" ON)
 option(OTIO_INSTALL_CONTRIB           "Install the opentimelineio_contrib Python package" ON)
+option(OTIO_FIND_IMATH                "Find Imath in the environment" OFF)
 set(OTIO_PYTHON_INSTALL_DIR "" CACHE STRING "Python installation dir (such as the site-packages dir)")
 
 # Build options
@@ -230,18 +231,23 @@ set(CTEST_OUTPUT_ON_FAILURE ON)
 
 #----- Imath
 # prefer an installed Imath 3.
-find_package(Imath QUIET)
-if (NOT Imath_FOUND)
-    # check if there is an installed IlmBase
-    find_package(IlmBase QUIET)
-    if (NOT IlmBase_FOUND)
-        message(STATUS "Using Imath in OpenTimelineIO/src/deps")
-        set(USE_DEPS_IMATH ON)
+if (OTIO_FIND_IMATH)
+    find_package(Imath QUIET)
+    if (NOT Imath_FOUND)
+        # check if there is an installed IlmBase
+        find_package(IlmBase QUIET)
+        if (NOT IlmBase_FOUND)
+            message(STATUS "Using Imath in OpenTimelineIO/src/deps")
+            set(USE_DEPS_IMATH ON)
+        else()
+            message(STATUS "Using IlmBase::Imath specifed by ${IlmBase_CONFIG}")
+        endif()
     else()
-        message(STATUS "Using IlmBase::Imath specifed by ${IlmBase_CONFIG}")
+        message(STATUS "Using Imath::Imath specified by ${Imath_CONFIG}")
     endif()
 else()
-    message(STATUS "Using Imath::Imath specified by ${Imath_CONFIG}")
+    message(STATUS "Using Imath in OpenTimelineIO/src/deps")
+    set(USE_DEPS_IMATH ON)
 endif()
 
 # set up the internally hosted dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,42 @@ set(CTEST_OUTPUT_ON_FAILURE ON)
 #------------------------------------------------------------------------------
 # Build the dependencies and components
 
+#----- Imath
+# prefer an installed Imath 3.
+find_package(Imath QUIET)
+if (NOT Imath_FOUND)
+    # check if there is an installed IlmBase
+    find_package(IlmBase QUIET)
+    if (NOT IlmBase_FOUND)
+        message(STATUS "Using Imath in OpenTimelineIO/src/deps")
+        set(USE_DEPS_IMATH ON)
+    else()
+        message(STATUS "Using IlmBase::Imath specifed by ${IlmBase_CONFIG}")
+        get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+        message(XXX1 "${IMATH_INCLUDES} ... ${IlmBase_INCLUDE_DIRS}")
+    endif()
+else()
+    message(STATUS "Using Imath::Imath specified by ${Imath_CONFIG}")
+endif()
+
+# set up the internally hosted dependencies
 add_subdirectory(src/deps)
+
+set (OTIO_IMATH_TARGETS
+    # For OpenEXR/Imath 3.x:
+    $<TARGET_NAME_IF_EXISTS:Imath::Imath>
+    $<TARGET_NAME_IF_EXISTS:Imath::Half>
+    # For OpenEXR >= 2.4/2.5 with reliable exported targets
+    $<TARGET_NAME_IF_EXISTS:IlmBase::Imath>
+    $<TARGET_NAME_IF_EXISTS:IlmBase::Half>
+    $<TARGET_NAME_IF_EXISTS:IlmBase::Iex>
+    # For OpenEXR <= 2.3:
+    ${ILMBASE_LIBRARIES})
+
+get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+message(XXX4 "${IMATH_INCLUDES}")
+message(XXX5 "${OTIO_IMATH_TARGETS}")
+
 add_subdirectory(src/opentime)
 add_subdirectory(src/opentimelineio)
 

--- a/src/deps/CMakeLists.txt
+++ b/src/deps/CMakeLists.txt
@@ -1,6 +1,10 @@
 
+
+
+#----- Other dependencies
+
 # detect if the submodules haven't been updated
-set(DEPS_SUBMODULES any optional-lite pybind11 rapidjson Imath)
+set(DEPS_SUBMODULES any optional-lite pybind11 rapidjson)
 foreach(submodule IN LISTS DEPS_SUBMODULES)
     file(GLOB SUBMOD_CONTENTS ${submodule})
     list(LENGTH SUBMOD_CONTENTS SUBMOD_CONTENT_LEN)
@@ -23,14 +27,16 @@ if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
     	    DESTINATION "${OTIO_RESOLVED_CXX_INSTALL_DIR}/include/opentimelineio/deps/nonstd")
 endif()
 
-# preserve BUILD_SHARED_LIBS options for this project, but set it off for Imath
-option(BUILD_SHARED_LIBS "Build shared libraries" ON)
-set(BUILD_SHARED_LIBS OFF)
+if (USE_DEPS_IMATH)
+    # preserve BUILD_SHARED_LIBS options for this project, but set it off for Imath
+    option(BUILD_SHARED_LIBS "Build shared libraries" ON)
+    set(BUILD_SHARED_LIBS OFF)
 
-# If we do not want Imath to install headers and CMake files use the EXCLUDE_FROM_ALL option
-if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
-  add_subdirectory(Imath)
-else()
-  add_subdirectory(Imath EXCLUDE_FROM_ALL)
+    # If we do not want Imath to install headers and CMake files use the EXCLUDE_FROM_ALL option
+    if(OTIO_CXX_INSTALL AND OTIO_DEPENDENCIES_INSTALL)
+        add_subdirectory(Imath)
+    else()
+        add_subdirectory(Imath EXCLUDE_FROM_ALL)
+    endif()
 endif()
 

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -76,10 +76,6 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
 
 add_library(OTIO::opentimelineio ALIAS opentimelineio)
 
-get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
-message(XXX "${IMATH_INCLUDES} ... ${ILMBASE_INCLUDE_DIRS}")
-
-
 target_include_directories(opentimelineio PRIVATE
                            "${IMATH_INCLUDES}"
                            "${PROJECT_SOURCE_DIR}/src"

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -76,13 +76,19 @@ add_library(opentimelineio ${OTIO_SHARED_OR_STATIC_LIB}
 
 add_library(OTIO::opentimelineio ALIAS opentimelineio)
 
+get_target_property(IMATH_INCLUDES IlmBase::IlmBaseConfig INTERFACE_INCLUDE_DIRECTORIES)
+message(XXX "${IMATH_INCLUDES} ... ${ILMBASE_INCLUDE_DIRS}")
+
+
 target_include_directories(opentimelineio PRIVATE
+                           "${IMATH_INCLUDES}"
                            "${PROJECT_SOURCE_DIR}/src"
                            "${PROJECT_SOURCE_DIR}/src/deps"
                            "${PROJECT_SOURCE_DIR}/src/deps/optional-lite/include"
                            "${PROJECT_SOURCE_DIR}/src/deps/rapidjson/include")
 
-target_link_libraries(opentimelineio PUBLIC opentime Imath::Imath)
+target_link_libraries(opentimelineio PUBLIC opentime ${OTIO_IMATH_TARGETS})
+
 set_target_properties(opentimelineio PROPERTIES
     DEBUG_POSTFIX "${OTIO_DEBUG_POSTFIX}"
     LIBRARY_OUTPUT_NAME "opentimelineio"


### PR DESCRIPTION
With this change, OpenTimelineIO will (1) detect VFX platform 2022, attempt to fall back to 2021 or earlier, then fall back to a locally cloned copy of Imath in src/deps.

The reason for this change is that OpenTimelineIO should use an Imath in the system already so that it is API compatible when both OpenEXR and OpenTImelineIO are used in the same project.

There is no extra logic to override install vfxplatform variants, as this can be accomplished in the usual manner by passing variables through the command line for cmake's find_package library to consume.

Fixes #1254 