### PR TITLE
Add Python 3.10 to CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['2.7', '3.7', '3.8', '3.9']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10']
 
     env:
       OTIO_CXX_COVERAGE_BUILD: ON
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-build: [cp27*, cp37*, cp38*, cp39*]
+        python-build: ['cp27*', 'cp37*', 'cp38*', 'cp39*', 'cp310*']
     steps:
       - uses: actions/checkout@v3
 
@@ -153,12 +153,25 @@ jobs:
           echo "DISTUTILS_USE_SDK=1" >> $GITHUB_ENV
           echo "MSSdk=1" >> $GITHUB_ENV
 
-      - name: Build wheels
+      - name: Build wheels (Python 2.7)
+        if: matrix.python-build == 'cp27*'
+        # cibuildwheel 1.12.0 is the last release that supported Python 2.7.
         uses: pypa/cibuildwheel@v1.12.0
         with:
           output-dir: wheelhouse
         env:
           CIBW_BUILD: ${{ matrix.python-build }}
+
+      - name: Build wheels (Python 3)
+        uses: pypa/cibuildwheel@v2.3.1
+        if: matrix.python-build != 'cp27*'
+        with:
+          output-dir: wheelhouse
+        env:
+          CIBW_BUILD: ${{ matrix.python-build }}
+          CIBW_SKIP: '*musllinux*'
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2010
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2010
 
       - uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ OpenTimelineIO
 ==============
 
 [![Supported VFX Platform Versions](https://img.shields.io/badge/vfx%20platform-2018--2021-lightgrey.svg)](http://www.vfxplatform.com/)
-![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.7%2C%203.8%2C%203.9-blue)
+![Supported Versions](https://img.shields.io/badge/python-2.7%2C%203.7%2C%203.8%2C%203.9%2C%203.10-blue)
 [![Build Status](https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/workflows/python-package.yml/badge.svg)](https://github.com/PixarAnimationStudios/OpenTimelineIO/actions/workflows/python-package.yml)
 [![codecov](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO/branch/main/graph/badge.svg)](https://codecov.io/gh/PixarAnimationStudios/OpenTimelineIO)
 [![docs](https://readthedocs.org/projects/opentimelineio/badge/?version=latest)](https://opentimelineio.readthedocs.io/en/latest/index.html)
@@ -52,8 +52,7 @@ Supported VFX Platforms
 -----------------
 The current release supports:
 - VFX platform 2021, 2020, 2019, 2018
-- Python 2.7 - 3.9
-- Notice that Python 2.7 is deprecated & we plan to drop it in OTIO release 0.15
+- Python 2.7 - 3.10
 
 For more information on our vfxplatform support policy: [Contribution Guidelines Documentation Page](https://opentimelineio.readthedocs.io/en/latest/tutorials/contributing.html)
 For more information on the vfxplatform: [VFX Platform Homepage](https://vfxplatform.com)

--- a/setup.py
+++ b/setup.py
@@ -290,6 +290,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Operating System :: OS Independent',
         'Natural Language :: English',
     ],


### PR DESCRIPTION
Fixes #1224.

Add official support for Python 3.10.

Note that I had to update `cibuildwheel` to the latest because 1.12.0 doesn't support Python 3.10. And while being there, I also made sure to use the latest for all Python versions except Python 2.7. You will also notice that I force `manulinux2010` on Linux. This is because this is the version that was previously used and the latest cibuildwheel defaults to manulinux2014. It's important to stick to manylinux2010 because of the VFX platform. See https://github.com/PixarAnimationStudios/OpenTimelineIO/issues/1094 for more details.

I invite anyone interested to test to download the wheels artifact from the job and test locally on your machine.

If anyone is curious, it's a pretty big feat to be able to support 2.7 and 3.10 at the same time in 2022 :)