### PR TITLE
Update test_v2d to support multiple exception types

### DIFF
--- a/tests/test_v2d.py
+++ b/tests/test_v2d.py
@@ -113,10 +113,10 @@ class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
 
         nv = otio.schema.V2d(0.0, 0.0)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, RuntimeError)):
             nv.normalizeExc()
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises((ValueError, RuntimeError)):
             nv.normalizedExc()
 
     def test_limits(self):


### PR DESCRIPTION
This is to support both imath 2 and 3

As part of vfxreference platform support and imath 2, we need to check for either `ValueError` or `RuntimeError` as the exception type changes.
