### PR TITLE
fix #839 - FCP XML outputs not recognized by Resolve

### DIFF
--- a/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
+++ b/src/py-opentimelineio/opentimelineio/adapters/fcp_xml.py
@@ -1956,6 +1956,10 @@ def _add_stack_elements_to_sequence(stack, sequence_e, timeline_range, br_map):
     video_e = _get_or_create_subelement(media_e, 'video')
     audio_e = _get_or_create_subelement(media_e, 'audio')
 
+    # This is a fix for Davinci Resolve. After the "video" tag, it expects
+    # a <format> tag, even if empty. See issue 839
+    _get_or_create_subelement(video_e, "format")
+
     # XXX: Due to the way that backreferences are created later on, the XML
     #      is assumed to have its video tracks serialized before its audio
     #      tracks.  Because the order that they are added to the media is


### PR DESCRIPTION
Fixes #839 

## Summary
- Added in the FCPXML Writer an empty subtag `<format />` after `<media><video>` to satisfy Resolve's requirements.

Tested resulting XML: imports fine in Resolve and Premiere.

Before fix, tested the following files, all would show up as a black clip in Resolve.
```
otioconvert -i tests/sample_data/big_int.otio -o ~/otio_fix/big_int.xml               
otioconvert -i tests/sample_data/cdl.edl -o ~/otio_fix/cdl.xml                   
otioconvert -i tests/sample_data/dissolve_test_2.edl -o ~/otio_fix/dissolve_test_2.xml
otioconvert -i tests/sample_data/enabled.otio -o ~/otio_fix/enabled.xml               
otioconvert -i tests/sample_data/multiple_track.otio -o ~/otio_fix/multiple_track.xml
```

After fix, same files as above provide a valid Resolve timeline and continue to be able to be imported by Premiere.