### PR TITLE
Updated verify_license.py to support more languages

### DIFF
--- a/maintainers/verify_license.py
+++ b/maintainers/verify_license.py
@@ -16,7 +16,16 @@ licenses = {
     ".cpp": """// SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 """,
+    ".c": """// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+""",
     ".h": """// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+""",
+    ".swift": """// SPDX-License-Identifier: Apache-2.0
+// Copyright Contributors to the OpenTimelineIO project
+""",
+    ".mm": """// SPDX-License-Identifier: Apache-2.0
 // Copyright Contributors to the OpenTimelineIO project
 """
 }


### PR DESCRIPTION
This PR updates the maintainers/verify_license.py script to support Swift, C and Objective-C++ source files so that it can be used on the OTIO language binding repos.
