### PR TITLE
Hide our custom fabs() function

### DIFF
--- a/src/opentime/rationalTime.h
+++ b/src/opentime/rationalTime.h
@@ -20,21 +20,6 @@ enum IsDropFrameRate : int
     ForceYes      = 1,
 };
 
-/// @brief Returns the absolute value.
-///
-/// \todo Document why this function is used instead of "std::fabs()".
-constexpr double
-fabs(double val) noexcept
-{
-    union
-    {
-        double   f;
-        uint64_t i;
-    } bits = { val };
-    bits.i &= std::numeric_limits<uint64_t>::max() / 2;
-    return bits.f;
-}
-
 /// @brief This class represents a measure of time defined by a value and rate.
 class RationalTime
 {
@@ -419,6 +404,23 @@ private:
     friend class TimeRange;
 
     double _value, _rate;
+
+    /// @brief Returns the absolute value.
+    ///
+    /// \todo This function is used instead of "std::fabs()" so we can mark it as
+    /// constexpr. We can remove this and replace it with the std version when we
+    /// upgrade to C++23. Note that there are two copies of this function, in both
+    /// RationalTime and TimeRange.
+    static constexpr double fabs(double val) noexcept
+    {
+        union
+        {
+            double   f;
+            uint64_t i;
+        } bits = { val };
+        bits.i &= std::numeric_limits<uint64_t>::max() / 2;
+        return bits.f;
+    }
 };
 
 }} // namespace opentime::OPENTIME_VERSION

--- a/src/opentime/timeRange.h
+++ b/src/opentime/timeRange.h
@@ -441,6 +441,23 @@ private:
     {
         return rhs - lhs >= epsilon;
     }
+
+    /// @brief Returns the absolute value.
+    ///
+    /// \todo This function is used instead of "std::fabs()" so we can mark it as
+    /// constexpr. We can remove this and replace it with the std version when we
+    /// upgrade to C++23. Note that there are two copies of this function, in both
+    /// RationalTime and TimeRange.
+    static constexpr double fabs(double val) noexcept
+    {
+        union
+        {
+            double   f;
+            uint64_t i;
+        } bits = { val };
+        bits.i &= std::numeric_limits<uint64_t>::max() / 2;
+        return bits.f;
+    }
 };
 
 }} // namespace opentime::OPENTIME_VERSION


### PR DESCRIPTION
This PR hides our custom `fabs()` function. We added the function as part of the constexpr work, but it really should not be part of the public API. When we upgrade to C++23 we can remove the function entirely and replace it with the version from the std library.

Note that there are two copies of the `fabs()` function, in both RationalTime and TimeRange. The code is short enough it seemed OK to duplicate, especially since we can remove it eventually.
