### PR TITLE
Reduce the number of dependabot C++ checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "quarterly"


### PR DESCRIPTION
Fixes #1938

Only have dependabot check our C++ dependencies quarterly.
