### PR TITLE
Initialize test_v2d.py variables

### DIFF
--- a/tests/test_v2d.py
+++ b/tests/test_v2d.py
@@ -101,12 +101,12 @@ class V2dTests(unittest.TestCase, otio_test_utils.OTIOAssertions):
         self.assertEqual(otio.schema.V2d.baseTypeEpsilon(), sys.float_info.epsilon)
 
     def test_json_serialization(self):
-        serialized = otio.adapters.otio_json.write_to_string(otio.schema.V2d())
+        serialized = otio.adapters.otio_json.write_to_string(otio.schema.V2d(0.1, 0.2))
         json_v2d = json.loads(serialized)
         self.assertEqual(json_v2d["OTIO_SCHEMA"], "V2d.1")
 
     def test_serialization_round_trip(self):
-        v2d = otio.schema.V2d()
+        v2d = otio.schema.V2d(0.3, 0.4)
         serialized = otio.adapters.otio_json.write_to_string(v2d)
         deserialized = otio.adapters.otio_json.read_from_string(serialized)
         self.assertEqual(v2d, deserialized)


### PR DESCRIPTION
I have been seeing occasional CI failures with this error:
```
======================================================================
FAIL: test_serialization_round_trip (test_v2d.V2dTests.test_serialization_round_trip)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:/a/OpenTimelineIO/OpenTimelineIO/tests/test_v2d.py", line 112, in test_serialization_round_trip
    self.assertEqual(v2d, deserialized)
AssertionError: otio.schema.V2d(x=1.2375583497411374e+214, y=3.503154865959304e+151) != otio.schema.V2d(x=1.2375583497411374e+214, y=3.5031548659593044e+151)

----------------------------------------------------------------------
Ran 489 tests in 13.798s

FAILED (failures=1, skipped=2)
make: *** [Makefile:79: coverage-core] Error 1
Error: Process completed with exit code 2.
```

It looks like the variables being used are not initialized, causing them to have random values that can trigger the failure. I'm not sure why the serialization is failing but we should probably initialize the values so the tests are consistent.
