### PR TITLE
Update codecov action to v5

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,7 +5,7 @@ name: OpenTimelineIO
 
 # for configuring which build will be a C++ coverage build / coverage report
 env:
-  GH_COV_PY: "3.10"
+  GH_COV_PY: "3.13"
   GH_COV_OS: ubuntu-latest
   GH_DEPENDABOT: dependabot
 
@@ -162,9 +162,8 @@ jobs:
           flags: py-unittests
           name: py-opentimelineio-codecov
           fail_ci_if_error: false
-        env:
-          # based on: https://github.com/codecov/codecov-action?tab=readme-ov-file#usage
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   package_wheels:
     needs: py_build_test


### PR DESCRIPTION
OTIO's code coverage reports have been stuck in a stale state for a while now. Pull requests report coverage based on a commit from Apr 14, 2024 instead of the current main. For example:

> ✅ All modified and coverable lines are covered by tests.
✅ Project coverage is 85.10%. Comparing base ([c0e97b0](https://app.codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/commit/c0e97b0c195881bec166c0a581dbae2999217265?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=AcademySoftwareFoundation)) to head ([646eaec](https://app.codecov.io/gh/AcademySoftwareFoundation/OpenTimelineIO/commit/646eaec9c81d1e76ac0640788029bafe0a4e936d?dropdown=coverage&el=desc&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=AcademySoftwareFoundation)).
⚠️ Report is 80 commits behind head on main.
> ❌ Your changes status has failed because you have indirect coverage changes. Learn more about [Unexpected Coverage Changes](https://docs.codecov.com/docs/unexpected-coverage-changes) and [reasons for indirect coverage changes](https://docs.codecov.com/docs/unexpected-coverage-changes#reasons-for-indirect-changes).
> The "base" commit that codecov compares against seems to be this one: https://github.com/AcademySoftwareFoundation/OpenTimelineIO/commit/c0e97b0c195881bec166c0a581dbae2999217265 for reasons that are unclear.

In an attempt to get this fixed I have just re-read the instructions https://github.com/codecov/codecov-action, re-entered the repo's CODECOV token in the "secrets" settings area, and in this PR, updated the codecov action to v5.

Let's see if that helps...