### PR TITLE
Fixed "Unknown Distribution Format" in PyPI publish action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,7 +17,7 @@ jobs:
     # happen for this actual commit (the commit that the tag points to).
     # It also restores the files timestamps.
     - name: Download wheels from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@v8
+      uses: dawidd6/action-download-artifact@v11
       with:
         workflow: python-package.yml
         workflow_conclusion: success
@@ -25,9 +25,10 @@ jobs:
         name_is_regexp: true
         name: 'wheel-.*'
         path: dist
+        merge_multiple: true
 
     - name: Download sdist from commit ${{ github.sha }}
-      uses: dawidd6/action-download-artifact@v8
+      uses: dawidd6/action-download-artifact@v11
       with:
         workflow: python-package.yml
         workflow_conclusion: success


### PR DESCRIPTION
Fixed an issue where the PyPI publish would throw this error on release:
```
Checking dist/opentimelineio-0.18.0.tar.gz: PASSED
Checking dist/wheel-macos-14-cp310: ERROR    InvalidDistribution: Unknown distribution format:                      
         'wheel-macos-14-cp310'      
```

It appears that multi-matched artifacts would each extract to their own dir rather than merge flatly - so the wheel was in a subdir with the artifact name instead of directly in the `dist` dir.