### PR TITLE
Bumped cibuildwheel to version 3.2.1

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -187,7 +187,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build wheels (Python 3)
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.2.1
         with:
           output-dir: wheelhouse
         env:


### PR DESCRIPTION
Bumping cibuildwheel version to address incorrect builds for linux.

Fixes #1972