### PR TITLE
Install *VersionConfig.cmake

### DIFF
--- a/src/opentime/CMakeLists.txt
+++ b/src/opentime/CMakeLists.txt
@@ -86,9 +86,15 @@ if(OTIO_CXX_INSTALL)
         NO_CHECK_REQUIRED_COMPONENTS_MACRO
     )
 
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfigVersion.cmake
+        COMPATIBILITY AnyNewerVersion
+    )
+
     install(
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfig.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenTimeConfigVersion.cmake
         DESTINATION
             ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentime
     )

--- a/src/opentimelineio/CMakeLists.txt
+++ b/src/opentimelineio/CMakeLists.txt
@@ -164,9 +164,15 @@ if(OTIO_CXX_INSTALL)
         NO_CHECK_REQUIRED_COMPONENTS_MACRO
     )
 
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfigVersion.cmake
+        COMPATIBILITY AnyNewerVersion
+    )
+
     install(
         FILES
             ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfig.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/OpenTimelineIOConfigVersion.cmake
         DESTINATION
             ${OTIO_RESOLVED_CXX_INSTALL_DIR}/share/opentimelineio
     )


### PR DESCRIPTION
This allows for find_package calls with a version requirement such as

```
find_package(OpenTimelineIO 0.18.0 REQUIRED)
```

without this patch it fails like

```
CMake Error at CMakeLists.txt:171 (find_package):
  Could not find a configuration file for package "OpenTimelineIO" that is
  compatible with requested version "0.18.0".
  The following configuration files were considered but not accepted:
    /usr/local/share/opentimelineio/OpenTimelineIOConfig.cmake, version: unknown
```

See also
- https://cmake.org/cmake/help/latest/command/find_package.html#search-modes
- https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#generating-a-package-version-file

