### PR TITLE
Add missing export markers (OTIO_API) for constructors

### DIFF
--- a/src/opentimelineio/effect.h
+++ b/src/opentimelineio/effect.h
@@ -27,7 +27,7 @@ public:
     /// @param name The name of the effect.
     /// @param metadata The metadata for the clip.
     /// @param enabled Whether the effect is enabled.
-    Effect(
+    OTIO_API Effect(
         std::string const&   name        = std::string(),
         std::string const&   effect_name = std::string(),
         AnyDictionary const& metadata    = AnyDictionary(),

--- a/src/opentimelineio/freezeFrame.h
+++ b/src/opentimelineio/freezeFrame.h
@@ -25,7 +25,7 @@ public:
     ///
     /// @param name The name of the time effect.
     /// @param metadata The metadata for the time effect.
-    FreezeFrame(
+    OTIO_API FreezeFrame(
         std::string const&   name     = std::string(),
         AnyDictionary const& metadata = AnyDictionary());
 

--- a/src/opentimelineio/gap.h
+++ b/src/opentimelineio/gap.h
@@ -47,6 +47,7 @@ public:
     /// @param markers The list of markers for the gap. Note that the
     /// the gap keeps a retainer to each marker.
     /// @param metadata The metadata for the gap.
+    OTIO_API
     Gap(RationalTime                duration,
         std::string const&          name     = std::string(),
         std::vector<Effect*> const& effects  = std::vector<Effect*>(),

--- a/src/opentimelineio/generatorReference.h
+++ b/src/opentimelineio/generatorReference.h
@@ -29,7 +29,7 @@ public:
     /// @param parameters The parameters used to configure the generator.
     /// @param metadata The metadata for the generator.
     /// @param available_image_bounds The spatial bounds of the generator.
-    GeneratorReference(
+    OTIO_API GeneratorReference(
         std::string const&              name            = std::string(),
         std::string const&              generator_kind  = std::string(),
         std::optional<TimeRange> const& available_range = std::nullopt,

--- a/src/opentimelineio/imageSequenceReference.h
+++ b/src/opentimelineio/imageSequenceReference.h
@@ -50,7 +50,7 @@ public:
     /// @param available_range The available range of the image sequence.
     /// @param metadata The metadata for the image sequence.
     /// @param available_image_bounds The spatial bounds of the image sequence.
-    ImageSequenceReference(
+    OTIO_API ImageSequenceReference(
         std::string const&       target_url_base    = std::string(),
         std::string const&       name_prefix        = std::string(),
         std::string const&       name_suffix        = std::string(),

--- a/src/opentimelineio/missingReference.h
+++ b/src/opentimelineio/missingReference.h
@@ -30,7 +30,7 @@ public:
     /// @param available_range The available range of the missing reference.
     /// @param metadata The metadata for the missing reference.
     /// @param available_image_bounds The spatial bounds for the missing reference.
-    MissingReference(
+    OTIO_API MissingReference(
         std::string const&              name            = std::string(),
         std::optional<TimeRange> const& available_range = std::nullopt,
         AnyDictionary const&            metadata        = AnyDictionary(),

--- a/src/opentimelineio/timeEffect.h
+++ b/src/opentimelineio/timeEffect.h
@@ -26,7 +26,7 @@ public:
     /// @param name The name of the object.
     /// @param effect_name The time effect name.
     /// @param metadata The metadata for the time effect.
-    TimeEffect(
+    OTIO_API TimeEffect(
         std::string const&   name        = std::string(),
         std::string const&   effect_name = std::string(),
         AnyDictionary const& metadata    = AnyDictionary());


### PR DESCRIPTION
This is a follow up to #1953
I am working on MSVC support for Kdenlive (currently MinGW is used for Windows) and hit

```
kdenliveLib.lib(otioexport.cpp.obj) : error LNK2019: unresolved external symbol "public: __cdecl opentimelineio::v0_18_1::GeneratorReference::GeneratorReference(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> > const &,class std::optional<class opentime::v0_18_1::TimeRange> const &,class opentimelineio::v0_18_1::AnyDictionary const &,class opentimelineio::v0_18_1::AnyDictionary const &,class std::optional<class Imath_3_1::Box<class Imath_3_1::Vec2<double> > > const &)" (??0GeneratorReference@v0_18_1@opentimelineio@@QEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@0AEBV?$optional@VTimeRange@v0_18_1@opentime@@@4@AEBVAnyDictionary@12@2AEBV?$optional@V?$Box@V?$Vec2@N@Imath_3_1@@@Imath_3_1@@@4@@Z) referenced in function "private: void __cdecl OtioExport::exportClip(class std::shared_ptr<class TimelineItemModel> const &,struct OtioExport::ClipData const &,struct opentimelineio::v0_18_1::SerializableObject::Retainer<class opentimelineio::v0_18_1::Track> &)" (?exportClip@OtioExport@@AEAAXAEBV?$shared_ptr@VTimelineItemModel@@@std@@AEBUClipData@1@AEAU?$Retainer@VTrack@v0_18_1@opentimelineio@@@SerializableObject@v0_18_1@opentimelineio@@@Z)
bin\cachetest.exe : fatal error LNK1120: 1 unresolved externals 
```

this brought to my attention that only some classes have `OTIO_API` on their constructors, while others, such as `GeneratorReference`, have not causing the above failure. As far as I understand all of these classes and ctors are public API however (please check and confirm) and hence should have `OTIO_API`.

@darbyjohnston Was #1953 just in complete or did you only add it to certain classes on purpose? This does probably not only affect the ctors, but also other class members. Should I add `OTIO_API` to all of them (either here or in a seperate PR)? Is it safe to assume that everything in the `public:` section of `src/opentimelineio/*.h` files is public api and hence should have `OTIO_API`?
