### PR TITLE
Disable pr-tools.yml due to security vulnerability

### DIFF
--- a/.github/workflows/pr-tools.yml
+++ b/.github/workflows/pr-tools.yml
@@ -1,35 +1,39 @@
-name: Pull Request Tools
+# IMPORTANT: We have disabled this workflow due to a security vulnerability related to `pull_request_target`.
+# See also: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation
+# See also: https://paulserban.eu/blog/post/why-is-pullrequesttarget-so-dangerous-a-security-explainer/
 
-on:
-  workflow_dispatch:
-  pull_request_target:
-    types: [
-        opened, # pr is created
-        reopened, # pr is reopened after being closed
-        synchronize, # pr is updated with new commits
-      ]
+# name: Pull Request Tools
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# on:
+#   workflow_dispatch:
+#   pull_request_target:
+#     types: [
+#         opened, # pr is created
+#         reopened, # pr is reopened after being closed
+#         synchronize, # pr is updated with new commits
+#       ]
 
-jobs:
-  # label PRs based on the files that were changed
-  pr-labeler:
-    name: Label Pull Requests
-    runs-on: ubuntu-latest
-    timeout-minutes: 8
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4 # https://github.com/actions/checkout/tree/main#usage
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: true
 
-      # https://github.com/actions/labeler#usage
-      - uses: actions/labeler@v4
-        with:
-          # https://github.com/actions/labeler#inputs
-          configuration-path: .github/labeler.yml
-          sync-labels: true # remove labels when matching files are reverted or no longer changed by the PR
-          dot: true # auto-include paths starting with dot (e.g.; ~/.github)
+# jobs:
+#   # label PRs based on the files that were changed
+#   pr-labeler:
+#     name: Label Pull Requests
+#     runs-on: ubuntu-latest
+#     timeout-minutes: 8
+#     permissions:
+#       contents: read
+#       pull-requests: write
+#     steps:
+#       - name: Checkout Repo
+#         uses: actions/checkout@v4 # https://github.com/actions/checkout/tree/main#usage
+
+#       # https://github.com/actions/labeler#usage
+#       - uses: actions/labeler@v4
+#         with:
+#           # https://github.com/actions/labeler#inputs
+#           configuration-path: .github/labeler.yml
+#           sync-labels: true # remove labels when matching files are reverted or no longer changed by the PR
+#           dot: true # auto-include paths starting with dot (e.g.; ~/.github)


### PR DESCRIPTION
It has been brought to our attention that use of `pull_request_target` creates an opportunity for bad actors to do damage by posting pull requests that run undesirable code within this project's base repo. This PR disables the one workflow that uses that feature.

I opted to leave that code in place, just commented out, in the hopes that some alternate safer implementation becomes available.

Read more here:
- https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation
- https://paulserban.eu/blog/post/why-is-pullrequesttarget-so-dangerous-a-security-explainer/
