### PR TITLE
moved fcpx and hls adapters to the additional section

### DIFF
--- a/docs/tutorials/adapters.md
+++ b/docs/tutorials/adapters.md
@@ -19,8 +19,6 @@ To also install a curated list of additional useful adapters, use the [OpenTimel
 - [burnins](https://github.com/OpenTimelineIO/otio-burnins-adapter)
 - [cmx_3600](https://github.com/OpenTimelineIO/otio-cmx3600-adapter)
 - [fcp_xml](https://github.com/OpenTimelineIO/otio-fcp-adapter)
-- [fcpx_xml](https://github.com/OpenTimelineIO/otio-fcpx-xml-adapter)
-- [hls_playlist](https://github.com/OpenTimelineIO/otio-hls-playlist-adapter)
 - [maya_sequencer](https://github.com/OpenTimelineIO/otio-maya-sequencer-adapter)
 - [svg](https://github.com/OpenTimelineIO/otio-svg-adapter)
 - [xges](https://github.com/OpenTimelineIO/otio-xges-adapter)
@@ -32,8 +30,9 @@ These adapters are supported by the broader OpenTimelineIO community. While the 
 Below are some other adapters that may be useful to some users:
 
 - [kdenlive](https://invent.kde.org/multimedia/kdenlive-opentimelineio)
+- [fcpx_xml](https://github.com/OpenTimelineIO/otio-fcpx-xml-adapter)
+- [hls_playlist](https://github.com/OpenTimelineIO/otio-hls-playlist-adapter)
 
 ## Custom Adapters
 
 Adapters are implemented as plugins for OpenTimelineIO and can either be registered via an [environment variable](./otio-env-variables) or by packaging in a Python module with a particular entrypoint defined. For more detail, see the [Writing an OTIO Adapter](./write-an-adapter) tutorial.
-


### PR DESCRIPTION
**Link the Issue(s) this Pull Request is related to.**

fixes #2000

**Summarize your change.**

As pointed out in this [issue](https://github.com/OpenTimelineIO/OpenTimelineIO-Plugins/issues/20
), the fcpx and hls adapters were still mentioned in the batteries included section of the adapters.
I moved them to the additional section

**Reference associated tests.**

No tests s this a doc change only

<!--
Important: If this is your first contribution to OpenTimelineIO, you will need to submit a Contributor License Agreement. For a step-by-step instructions on the pull request process, see
https://github.com/AcademySoftwareFoundation/OpenTimelineIO/tree/main/CONTRIBUTING.md
-->
